### PR TITLE
Fix silent ledger death + field gaps (3.9.14)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Second brain for Forward Deployed Engineers. One @fde skill - enter at day one, mid-project, or mid-fire; it routes and does the phase work; engagement memory lands in .fde/ as you confirm judgment.",
-  "version": "3.9.13",
+  "version": "3.9.14",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.9.14 — 2026-07-21
+
+Field validation follow-ups: shout when the memory ledger dies silently; tighten receipts/debrief/garden.
+
+### Fixed
+- **Silent ledger death** — corrupt `.fde/.git` is a loud `fde doctor` issue (UNVERSIONED + repair hint); `fde garden` stops claiming reversibility and refuses `--apply` while broken.
+- **Receipts dirty caveat** — ON RECORD hits in hand-edited files are marked dirty.
+- **Smart debrief** — preview lines capped; `Decided:` routes to decisions.md.
+- **Garden risk dedupe** — proposes and applies consolidating identical open-risk echoes into `## Retired`.
+
 ## 3.9.13 — 2026-07-21
 
 Audit → eval → deploy loop hardened in method + doctor (no schema break).

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -401,6 +401,7 @@ const {
   memoryDirtyManual,
   commitMemory,
   memoryHead,
+  memoryGitHealthy,
 } = createMemoryApi({ fs, path, gitBinOk, writeOwnerIfMissing, atomicWriteFile })
 
 // Pull the body under a "## Heading" up to the next "##" (or EOF).
@@ -1095,6 +1096,10 @@ function smartProposeText(input) {
     let bare = line
       .replace(/^[-*+]\s+/, '')
       .replace(/^\*\*(decision|risk|delivery|contact|next):?\*\*:?\s*/i, '$1: ')
+    if (/^decided:\s+/i.test(bare)) {
+      out.push(`decision: ${bare.replace(/^decided:\s+/i, '')}`)
+      continue
+    }
     if (/^(decision|risk|delivery|contact|next):\s*/i.test(bare)) {
       let routed = bare.replace(/^(decision|risk|delivery|contact|next):\s*/i, (m, t) => `${t.toLowerCase()}: `)
       if (/^contact:/i.test(routed) && !/\[signal:(red|amber|green)\]/i.test(routed)) {
@@ -1110,7 +1115,7 @@ function smartProposeText(input) {
       out.push(`next: ${next}`)
       continue
     }
-    if (/\b(we (decided|agreed)|decision:|descope|agreed to|agreement was|freeze scope)\b/i.test(bare)) {
+    if (/\b(we (decided|agreed)|decided:|decision:|descope|agreed to|agreement was|freeze scope|freeze prompts)\b/i.test(bare)) {
       out.push(`decision: ${bare}`)
     } else if (/\b(open question|who signs|unclear who|unresolved)\b/i.test(bare)) {
       out.push(`risk: ${bare}`)
@@ -1170,6 +1175,12 @@ function readDebriefInput(args) {
   return input
 }
 
+function previewLine(text, max = 240) {
+  const t = String(text || '').replace(/\s+/g, ' ').trim()
+  if (t.length <= max) return t
+  return `${t.slice(0, max)}… (${t.length} chars)`
+}
+
 function routeDebriefInput(eng, input, { dry, force }) {
   const d = new Date()
   const date = d.toISOString().slice(0, 10)
@@ -1191,7 +1202,7 @@ function routeDebriefInput(eng, input, { dry, force }) {
         continue
       }
       if (type === 'next') {
-        if (dry) console.log(`→ context.md ## Next action  - ${body}`)
+        if (dry) console.log(`→ context.md ## Next action  - ${previewLine(body)}`)
         else nextAction = body
         counts.next++
         continue
@@ -1199,7 +1210,7 @@ function routeDebriefInput(eng, input, { dry, force }) {
       const sigInline = (body.match(/\[signal:(red|amber|green)\]/i) || [])[1]
       if (sigInline) body = body.replace(/\[signal:(red|amber|green)\]/i, '').trim()
       const entry = datedEntry(eng, date, body, type === 'contact' && sigInline ? sigInline.toLowerCase() : '')
-      if (dry) console.log(`→ ${LOG_FILES[type]}  ${entry}`)
+      if (dry) console.log(`→ ${LOG_FILES[type]}  ${previewLine(entry)}`)
       else appendLogEntry(eng, type, entry, { skipCommit: true })
       counts[type]++
     } else {
@@ -1213,7 +1224,7 @@ function routeDebriefInput(eng, input, { dry, force }) {
   if (nextAction && !dry) setNextAction(eng, nextAction)
   if (ctxLines.length) {
     const stamp = `${date} ${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`
-    if (dry) ctxLines.forEach(l => console.log(`→ context.md  - ${l}`))
+    if (dry) ctxLines.forEach(l => console.log(`→ context.md  - ${previewLine(l)}`))
     else lockedAppendFile(path.join(eng, 'context.md'), `\n## Debrief - ${stamp}\n${ctxLines.map(l => `- ${l}`).join('\n')}\n`)
   }
   return { counts, ctxLines, date, nextAction }
@@ -1308,9 +1319,22 @@ function cmdReceipts(args) {
   }
   const agreed = collect(AGREEMENTS)
   const claimed = collect(CLAIMS)
+  const dirty = memoryDirtyManual(eng)
+  const dirtySet = new Set(dirty)
+  const dirtyAgreedHits = [...new Set(
+    agreed.map(h => (h.match(/^\s*([^:]+):/) || [])[1]).filter(f => f && dirtySet.has(f))
+  )]
   if (agreed.length) {
     console.log('ON RECORD (dated - defensible):')
-    agreed.forEach(h => console.log(h))
+    agreed.forEach(h => {
+      const file = (h.match(/^\s*([^:]+):/) || [])[1]
+      console.log(h + (file && dirtySet.has(file) ? '  ⚠ dirty file' : ''))
+    })
+    if (dirtyAgreedHits.length) {
+      console.log(
+        `⚠ memory dirty (uncommitted manual edits: ${dirtyAgreedHits.join(', ')}) - dated lines above may not match the tamper-evident ledger until reviewed`
+      )
+    }
   }
   if (claimed.length) {
     if (agreed.length) console.log('')
@@ -1493,7 +1517,18 @@ function collectDoctorIssues(eng) {
   }
   if (s.stale) issues.push(`trust signal is STALE (${s.signalAge}d) - reconfirm with fde log contact ... --signal`)
   if (!readOwner(eng)) issues.push('no .owner - run any write or: fde owner set you@firm.com')
-  if (!fs.existsSync(path.join(eng, '.git'))) issues.push('memory not git-versioned - next write will init, or re-run resume --init')
+  const gitHealth = memoryGitHealthy(eng)
+  if (!gitHealth.ok) {
+    if (gitHealth.reason === 'broken') {
+      issues.push(
+        'memory git is BROKEN (UNVERSIONED) - receipts are not tamper-evident; repair: mv .fde/.git .fde/.git.broken && re-run any fde write (or resume --init) to re-init the ledger'
+      )
+    } else if (gitHealth.reason === 'no-git-bin') {
+      issues.push('git binary missing - engagement memory cannot be versioned (receipts stay dated, not tamper-evident)')
+    } else {
+      issues.push('memory not git-versioned - next write will init, or re-run resume --init')
+    }
+  }
   const success = readClean(eng, 'success.md')
   if (!firstLine(success, 80)) issues.push('success.md has no stated done-definition - fill before plan/build')
   if (!sectionBody(readClean(eng, 'context.md'), 'Next action')) {
@@ -1731,10 +1766,24 @@ function cmdGarden(args) {
   const apply = args.includes('--apply')
   const eng = resolveEngagement({ forWrite: apply })
   if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exit(2) }
+  const gitHealth = memoryGitHealthy(eng)
   // Gardener contract (from Rowboat note_curation): no new facts, no deleted substance,
-  // reversible via git, confirm before apply. Mechanical only - no LLM rewrite.
-  console.log('GARDEN (contract: no new facts · no deleted substance · reversible via memory git)')
+  // reversible via git when healthy, confirm before apply. Mechanical only - no LLM rewrite.
+  if (gitHealth.ok) {
+    console.log('GARDEN (contract: no new facts · no deleted substance · reversible via memory git)')
+  } else if (gitHealth.reason === 'broken') {
+    console.log('GARDEN (contract: no new facts · no deleted substance · ⚠ memory git BROKEN — NOT reversible until ledger is repaired)')
+  } else {
+    console.log('GARDEN (contract: no new facts · no deleted substance · ⚠ memory not git-versioned — NOT reversible)')
+  }
   console.log(resumeTriage(eng))
+  if (!gitHealth.ok) {
+    console.log(
+      gitHealth.reason === 'broken'
+        ? '\n⚠ ledger is UNVERSIONED (corrupt .git). Repair before trusting garden apply: mv .fde/.git .fde/.git.broken && run any fde write to re-init.'
+        : '\n⚠ no memory git — garden apply cannot create a reversible commit until the ledger exists.'
+    )
+  }
   const proposals = []
   const s = computeSignals(eng)
   if (s.stale) {
@@ -1742,6 +1791,16 @@ function cmdGarden(args) {
       id: 'reconfirm-signal',
       kind: 'manual',
       text: `Reconfirm stale ${s.trust} signal (${s.signalAge}d): fde log contact "…" --signal`,
+    })
+  }
+  const dupes = findDuplicateOpenRisks(eng)
+  if (dupes.length) {
+    const sample = (dupes[0][0] || '').replace(/\s+/g, ' ').trim().slice(0, 50)
+    proposals.push({
+      id: 'dedupe-risks',
+      kind: 'apply',
+      text: `Consolidate ${dupes.length} duplicate open-risk cluster(s) (e.g. "${sample}${sample.length >= 50 ? '…' : ''}") — keep first, retire echoes`,
+      clusters: dupes,
     })
   }
   const ctx = readEng(eng, 'context.md')
@@ -1769,12 +1828,26 @@ function cmdGarden(args) {
   proposals.forEach((p, i) => console.log(`  ${i + 1}. [${p.kind}] ${p.text}`))
   if (!apply) {
     console.log('\nApply mechanical items only:  fde garden --apply')
-    console.log('Manual items stay yours. Every apply commits to memory git.')
+    console.log('Manual items stay yours. Every apply commits to memory git when the ledger is healthy.')
     return
+  }
+  if (!gitHealth.ok && gitHealth.reason === 'broken') {
+    console.error('refusing garden --apply while memory git is broken - repair the ledger first')
+    process.exit(1)
   }
   ensureMemoryGit(eng)
   let applied = 0
+  const touched = new Set()
   for (const p of proposals) {
+    if (p.id === 'dedupe-risks') {
+      const n = applyRiskDedupe(eng, p.clusters)
+      if (n > 0) {
+        applied++
+        touched.add('risks.md')
+        console.log(`applied: retired ${n} duplicate open-risk echo(s) → ## Retired`)
+      }
+      continue
+    }
     if (p.id !== 'archive-sessions') continue
     const cutDates = new Set(p.sessionBlocks.map(b => b.date))
     const keep = []
@@ -1808,11 +1881,59 @@ function cmdGarden(args) {
       atomicWriteFile(path.join(eng, 'context.md'), keep.join('\n').replace(/\n*$/, '\n'))
     })
     applied++
+    touched.add('context.md')
+    touched.add('context-archive.md')
     console.log(`applied: archived ${p.sessionBlocks.length} old session-end blocks → context-archive.md`)
   }
-  const hash = commitMemory(eng, 'garden', { files: ['context.md', 'context-archive.md'] })
+  const hash = commitMemory(eng, 'garden', { files: [...touched] })
   if (!applied) console.log('no mechanical proposals applied (manual items remain)')
   else console.log(`garden done${hash ? ` @${hash}` : ''}`)
+}
+
+// Keep the first open-risk bullet per fingerprint; move later echoes under ## Retired.
+function applyRiskDedupe(eng, clusters) {
+  const p = path.join(eng, 'risks.md')
+  let md = readEng(eng, 'risks.md')
+  if (!md) return 0
+  const echoTexts = new Set()
+  for (const group of clusters) {
+    for (let i = 1; i < group.length; i++) echoTexts.add(group[i])
+  }
+  if (!echoTexts.size) return 0
+  const retiredLines = []
+  const kept = []
+  let inRetired = false
+  let moved = 0
+  for (const raw of md.split('\n')) {
+    const t = raw.trim()
+    if (/^#{1,6}\s+Retired\b/i.test(t)) {
+      inRetired = true
+      kept.push(raw)
+      continue
+    }
+    if (!inRetired) {
+      const m = t.match(/^-\s*\[\d{4}-\d{2}-\d{2}\]\s*(?:\[@[^\]]+\]\s*)?(.*)$/)
+      if (m && echoTexts.has(m[1].trim())) {
+        retiredLines.push(raw)
+        moved++
+        continue
+      }
+    }
+    kept.push(raw)
+  }
+  if (!moved) return 0
+  let out = kept.join('\n')
+  if (!/^#{1,6}\s+Retired\b/im.test(out)) {
+    out = out.replace(/\n*$/, '\n\n## Retired\n')
+  }
+  const stamp = new Date().toISOString().slice(0, 10)
+  const block = retiredLines.map(l => {
+    const body = l.trim().replace(/^-\s*/, '')
+    return `- [${stamp}] (garden dedupe) ${body}`
+  }).join('\n')
+  out = appendUnderSection(out, 'Retired', block)
+  withFileLock(p, () => { atomicWriteFile(p, out.endsWith('\n') ? out : out + '\n') })
+  return moved
 }
 
 function engagementSlugFromPath(eng) {

--- a/bin/lib/memory.js
+++ b/bin/lib/memory.js
@@ -151,12 +151,32 @@ function createMemoryApi(deps) {
     } catch (_) { return '' }
   }
 
+  // True only when .git exists AND can resolve HEAD. A corrupt ledger (broken
+  // HEAD / missing objects) still has a .git directory — existsSync alone lied.
+  function memoryGitHealthy(eng) {
+    if (!eng) return { ok: false, reason: 'missing' }
+    if (!fs.existsSync(path.join(eng, '.git'))) return { ok: false, reason: 'missing' }
+    if (!gitBinOk()) return { ok: false, reason: 'no-git-bin' }
+    try {
+      execFileSync('git', ['rev-parse', '--verify', 'HEAD'], {
+        cwd: eng, encoding: 'utf8', timeout: 5000, stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      execFileSync('git', ['status', '--porcelain'], {
+        cwd: eng, encoding: 'utf8', timeout: 10000, stdio: ['ignore', 'pipe', 'ignore'],
+      })
+      return { ok: true, reason: '' }
+    } catch (_) {
+      return { ok: false, reason: 'broken' }
+    }
+  }
+
   return {
     MEMORY_EPHEMERAL,
     memoryPorcelainPaths,
     memoryDirtyManual,
     commitMemory,
     memoryHead,
+    memoryGitHealthy,
     ensureMemoryGit,
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.9.13",
+  "version": "3.9.14",
   "description": "Field kit for engineers embedded in client work - a real CLI (recon, memory, portfolio), one @fde skill with field judgment on top, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -1424,3 +1424,86 @@ test('doctor ship/close: value bucket required; eval only when AI in scope', () 
   const aiOk = runFde(sandbox, ['doctor'])
   assert.equal(aiOk.status, 0, aiOk.stdout + aiOk.stderr)
 })
+
+test('doctor shouts when memory .git is corrupt (silent ledger death)', () => {
+  const sandbox = makeSandbox('broken-git')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'broke']).status, 0)
+  const eng = engagementPath(sandbox, 'broke')
+  assert.equal(runFde(sandbox, ['log', 'decision', 'descope until audit']).status, 0)
+  fs.writeFileSync(
+    path.join(eng, 'context.md'),
+    '# Engagement context\n**Phase:** build\n\n## Next action\n- fix ledger\n'
+  )
+  fs.writeFileSync(path.join(eng, 'success.md'), '# Success\nDone when: pilot signed.\n')
+  // Corrupt the ledger the way Agent 3 did: .git still exists, HEAD/objects dead.
+  fs.writeFileSync(path.join(eng, '.git', 'HEAD'), 'ref: refs/heads/does-not-exist\n')
+  fs.rmSync(path.join(eng, '.git', 'objects'), { recursive: true, force: true })
+  fs.mkdirSync(path.join(eng, '.git', 'objects'), { recursive: true })
+
+  const doctor = runFde(sandbox, ['doctor'])
+  assert.notEqual(doctor.status, 0)
+  assert.match(doctor.stdout, /BROKEN|UNVERSIONED/i)
+
+  const garden = runFde(sandbox, ['garden'])
+  assert.equal(garden.status, 0, garden.stderr)
+  assert.match(garden.stdout, /BROKEN|NOT reversible/i)
+  assert.doesNotMatch(garden.stdout, /reversible via memory git\)/)
+})
+
+test('receipts caveats ON RECORD hits in dirty memory files', () => {
+  const sandbox = makeSandbox('receipts-dirty')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'dirtco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'decision', 'descope reporting until audit']).status, 0)
+  const eng = engagementPath(sandbox, 'dirtco')
+  const decisions = fs.readFileSync(path.join(eng, 'decisions.md'), 'utf8')
+  fs.writeFileSync(
+    path.join(eng, 'decisions.md'),
+    decisions.replace('descope reporting until audit', 'descope reporting until audit (backdated hand edit)')
+  )
+  const r = runFde(sandbox, ['receipts', 'descope'])
+  assert.equal(r.status, 0, r.stderr)
+  assert.match(r.stdout, /ON RECORD/)
+  assert.match(r.stdout, /dirty/i)
+})
+
+test('debrief --smart caps long preview lines and routes Decided: to decisions', () => {
+  const sandbox = makeSandbox('smart-cap')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'smartco']).status, 0)
+  const long = 'x'.repeat(8000)
+  const notes = `Decided: freeze prompts for the pilot\nNoise line ${long}\n`
+  const notesPath = path.join(sandbox.workspace, 'notes.md')
+  fs.writeFileSync(notesPath, notes)
+  const smart = runFde(sandbox, ['debrief', '--smart', notesPath])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /→ decisions\.md/)
+  assert.match(smart.stdout, /freeze prompts/)
+  assert.doesNotMatch(smart.stdout, /x{500}/, 'preview must not echo the full 8k line')
+  assert.match(smart.stdout, /… \(\d+ chars\)/)
+})
+
+test('garden proposes and applies duplicate open-risk consolidation', () => {
+  const sandbox = makeSandbox('garden-dedupe')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'gardenco']).status, 0)
+  const eng = engagementPath(sandbox, 'gardenco')
+  fs.writeFileSync(
+    path.join(eng, 'risks.md'),
+    '# Risks\n' +
+      '- [2026-05-01] PLC vendor firmware drift on line 3\n' +
+      '- [2026-05-08] PLC vendor firmware drift on line 3 again\n' +
+      '- [2026-05-15] PLC vendor firmware drift still open\n' +
+      '- [2026-05-20] PLC vendor firmware drift on line 3\n'
+  )
+  // Make fingerprints match closely enough (doctor already clusters these).
+  const propose = runFde(sandbox, ['garden'])
+  assert.equal(propose.status, 0, propose.stderr)
+  assert.match(propose.stdout, /duplicate open-risk|Consolidate/i)
+
+  const applied = runFde(sandbox, ['garden', '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  assert.match(applied.stdout, /retired|dedupe/i)
+  const risks = fs.readFileSync(path.join(eng, 'risks.md'), 'utf8')
+  assert.match(risks, /## Retired/i)
+  const open = risks.split(/^##\s+Retired/im)[0]
+  const openBullets = open.split('\n').filter(l => /^-\s*\[\d{4}-\d{2}-\d{2}\]/.test(l.trim()))
+  assert.ok(openBullets.length < 4, `expected fewer open risks after dedupe, got ${openBullets.length}`)
+})


### PR DESCRIPTION
## Summary
- Doctor detects broken `.fde/.git` (not just missing) and shouts UNVERSIONED + repair hint
- Garden stops claiming reversibility when ledger is broken; refuses `--apply`
- Receipts marks ON RECORD hits in dirty agreement files
- Smart debrief caps preview lines; `Decided:` → decisions.md
- Garden proposes/applies duplicate open-risk consolidation

## Test plan
- [x] `npm run check` (65 tests; regressions for all four ground-test findings)
- [ ] Squash-merge → tag `v3.9.14` → `npm publish`
- [ ] `npm view fdeops version` → `3.9.14`


Made with [Cursor](https://cursor.com)