### PR TITLE
Fit intent-vs-diff gate into ship/review (3.9.16)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Second brain for Forward Deployed Engineers. One @fde skill - enter at day one, mid-project, or mid-fire; it routes and does the phase work; engagement memory lands in .fde/ as you confirm judgment.",
-  "version": "3.9.15",
+  "version": "3.9.16",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.9.16 — 2026-07-21
+
+Intent vs diff gate — scope-creep detector fitted into ship/review (not a new skill).
+
+### Added
+- **Intent vs diff** on ship (before pre-blast): KEEP / JUSTIFY / SPLIT / DROP every path against the stated slice; SPLIT/DROP still in tree = fix-first; receipt in `delivery.md`.
+- **Review Stage 1** uses the same verdict table; JUSTIFY needs a written sentence or it fails.
+- Router phrases for “diff grew / scope creep in the PR” → review (+ ship if going live). Distinct from stakeholder `scope-defense`.
+
+### Changed
+- Build review gate names intent vs diff explicitly; skills-reference ship/review rows updated.
+
 ## 3.9.15 — 2026-07-21
 
 Input hygiene from the ugly edge-case round.

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -58,8 +58,8 @@ Each reference is a **method, not advice**: the thinking the agent does, the art
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [ship](../skills/fde/references/ship.md) | Pre-flight + canary + rollback + **scale-readiness gate** + **progressive adoption** | Ready to deploy, going live, pre-flight check |
-| [review](../skills/fde/references/review.md) | Scope first (did we build what was agreed), then safety | Review this change, is it safe, does it match what we agreed |
+| [ship](../skills/fde/references/ship.md) | **Intent vs diff** (KEEP/JUSTIFY/SPLIT/DROP) + pre-flight + canary + rollback + **scale-readiness** + **progressive adoption** | Ready to deploy, going live, pre-flight check |
+| [review](../skills/fde/references/review.md) | Stage 1 **intent vs diff** (KEEP/JUSTIFY/SPLIT/DROP), then safety | Review this change, is it safe, does it match what we agreed, scope creep in the PR |
 | [rollback-drill](../skills/fde/references/rollback-drill.md) | Test the escape route on staging before you need it at 2am | "We can always revert" - need to actually test the escape route |
 | [qa-live](../skills/fde/references/qa-live.md) | Test from the user's chair, real browser, five perspectives | Need to test from user perspective, "works on my machine" |
 
@@ -106,8 +106,8 @@ The 10 phases most engagements actually run through, with what gets written wher
 | [close](../skills/fde/references/close.md) | Engagement ending | Retrospective with receipts; pattern extraction; the 2am handoff | `retrospectives/` `patterns.md` `handoff.md` |
 | [plan](../skills/fde/references/plan.md) | Scope clear, needs sequencing | Backwards from success; fragile first; PR-sized tasks; acceptance-criteria gate | `decisions.md` |
 | [build](../skills/fde/references/build.md) | Agreed slice ready | Blast radius declared; characterisation tests on legacy; Strangler Fig; cleanup pass | `decisions.md` `risks.md` `delivery.md` |
-| [review](../skills/fde/references/review.md) | Change needs a merge gate | Stage 1 scope vs `decisions.md`, then 5-dimension safety; review-fix loop until clean | `decisions.md` |
-| [ship](../skills/fde/references/ship.md) | Ready to deploy | Pre-flight incl. CAB; canary with rollback-on-anomaly; pulse defined before closing the laptop | `delivery.md` |
+| [review](../skills/fde/references/review.md) | Change needs a merge gate | Stage 1 KEEP/JUSTIFY/SPLIT/DROP vs stated intent, then 5-dimension safety; review-fix loop until clean | `decisions.md` |
+| [ship](../skills/fde/references/ship.md) | Ready to deploy | Intent vs diff receipt, then pre-flight/CAB; canary with rollback-on-anomaly; pulse before closing the laptop | `delivery.md` |
 
 ---
 

--- a/evals/skill-routing/cases.json
+++ b/evals/skill-routing/cases.json
@@ -64,6 +64,15 @@
       "expect": { "cli": ["resume"] }
     },
     {
+      "id": "happy-intent-vs-diff",
+      "kind": "happy",
+      "prompt": "@fde did this PR stay in scope — any scope creep in the diff?",
+      "expect": {
+        "reference_hint": "review",
+        "must_not_load_reference": ["land.md", "discover.md", "scope-defense.md"]
+      }
+    },
+    {
       "id": "happy-redact-adjacent",
       "kind": "happy",
       "prompt": "@fde I accidentally logged a secret earlier - scrub the token sk-live from memory",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.9.15",
+  "version": "3.9.16",
   "description": "Field kit for engineers embedded in client work - a real CLI (recon, memory, portfolio), one @fde skill with field judgment on top, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -49,7 +49,7 @@ These stop confident fiction. They are not optional soft tips.
 | Invent a stakeholder, meeting, or quote to make the narrative rich | **Stop.** Write `unknown - ask: <question>`. One fake name poisons every real citation. |
 | Route to a phase because it "feels senior" while the signal is muddy | **Stop.** Playback + one natural question, or name the ambiguity ("discover or rescue — leaning X because…"). |
 | Fill `success.md` / `terrain.md` with plausible defaults when the brief is thin | **Stop.** Run **brief interrogation** in land/discover (one Q + GUESS + confidence) until you can write without guessing, or leave gaps explicit. |
-| Ship / go-live / irreversible change with "probably fine" | **Stop.** Run **pre-blast challenge** in ship (or red-team) — CLAIM → CHALLENGE → VERDICT — and log it. |
+| Ship / go-live / irreversible change with "probably fine" | **Stop.** Run **intent vs diff** (KEEP/JUSTIFY/SPLIT/DROP) then **pre-blast challenge** in ship (or red-team) — CLAIM → CHALLENGE → VERDICT — and log both. |
 | Grill the FDE with a checklist when they're mid-flow | **Stop.** Playback rule wins. Probe only when a missing fact changes the next move. |
 
 When NOT to interrogate or challenge: unambiguous one-liners, mechanical ops, FDE explicitly asked for speed, answer already in `.fde/`.
@@ -243,6 +243,7 @@ Getting to production without surprises.
 |----------|-------|-----------|
 | Ready to deploy, going live, pre-flight check | ship | `references/ship.md` |
 | Review this change, is it safe, does it match what we agreed | review | `references/review.md` |
+| Diff grew / scope creep in the PR / "did we only build what we said" / KEEP JUSTIFY SPLIT DROP | review (+ ship if going live) | `references/review.md` Stage 1 · `references/ship.md` Intent vs diff |
 | "We can always revert" - need to actually test the escape route | rollback-drill | `references/rollback-drill.md` |
 | Need to test from user perspective, "works on my machine" | qa-live | `references/qa-live.md` |
 

--- a/skills/fde/references/build.md
+++ b/skills/fde/references/build.md
@@ -58,7 +58,7 @@ The spec becomes the test list - every line is something to verify after build.
    - `[DEFERRED]` intentionally left for a later task (state which one)
    Surface the results to the FDE. If any scenario fails, fix it before cleanup. This is not optional - the spec is the contract.
 9. **Cleanup pass after it works.** Dedupe repeated mechanics into the smallest service module; behavior unchanged; re-run the same tests. If you wrote 200 lines and 50 would do, rewrite before review.
-10. **Review gate (before merge):** two stages, in order - (a) **scope**: does the diff match the approved spec and `decisions.md`, nothing more? (b) **safety**: blast radius honest, tests meaningful, rollback real, secrets absent. Fix real findings, re-verify, repeat until clean or blocked on a human decision.
+10. **Review gate (before merge):** two stages, in order - (a) **intent vs diff**: every path KEEP / JUSTIFY / SPLIT / DROP against the stated slice in `decisions.md` (see `review.md` Stage 1); (b) **safety**: blast radius honest, tests meaningful, rollback real, secrets absent. Fix real findings, re-verify, repeat until clean or blocked on a human decision.
 11. **Log and deliver.** Update the artifacts (below). Visible progress beats invisible perfection - every 2–3 tasks something shown to a stakeholder.
 
 **Touching existing code - classify before changing:**

--- a/skills/fde/references/review.md
+++ b/skills/fde/references/review.md
@@ -12,13 +12,29 @@ Thousands of lines or dozens of unrelated files → **stop**, recommend the spli
 
 ## Stage 1 - did we build what we agreed? (you do this work)
 
-Check the diff against `decisions.md` - what was *explicitly decided*, not what seems right:
-- Matches agreed scope?
+Check the diff against the **one-line intent** in `decisions.md` / acceptance criteria — what was *explicitly decided*, not what seems right:
+
+```bash
+git diff <base>...HEAD --stat
+```
+
+For each touched path (or logical hunk), assign one verdict:
+
+| Verdict | Meaning |
+|---------|---------|
+| **KEEP** | Required for the stated intent |
+| **JUSTIFY** | Adjacent but must ship now — write one sentence why, or SPLIT |
+| **SPLIT** | Real work for another PR / Next / kill list — do not merge with this slice |
+| **DROP** | Noise / drive-by — revert before Pass |
+
+Also check:
 - Any sacred system from `trust-profile.md` touched?
 - Any sensitive data newly in scope?
 - Rollback path defined before build still honoured?
 
-**Stage 1 fails → stop.** Quality review on out-of-scope code is wasted work. Record the specific mismatch in `decisions.md`.
+**Stage 1 fails → stop** if any SPLIT/DROP remains, or JUSTIFY lacks a written sentence. Quality review on out-of-scope code is wasted work. Record the mismatch (and the KEEP/JUSTIFY/SPLIT/DROP tally) in `decisions.md`.
+
+Stakeholder "also can you…" mid-build is `scope-defense` — different axis. This stage is **code vs claim**.
 
 ## Stage 2 - is it safe to live with?
 
@@ -48,6 +64,7 @@ Five dimensions, line-specific ("line 47 fails under concurrent writes - no lock
 ## Principles
 
 - Stage 1 before Stage 2. Wrong scope reviewed well is still wrong scope.
+- KEEP / JUSTIFY / SPLIT / DROP — every path gets a verdict; silent extras fail Stage 1.
 - Specific or silent - vague concerns waste everyone's time.
 - No rollback path = first finding.
 - A clean review proves this diff is safe as agreed - not that the feature was right.

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -63,6 +63,28 @@ Score each dimension green/amber/red. This is the gate, not a suggestion:
 
 Write the readiness score (including value + receipts) to `delivery.md` before deploying. The score is the evidence if anything goes wrong.
 
+## Intent vs diff (before pre-blast)
+
+Ship the change you intended — not the drift that snuck in. Run this on the deploy branch against the **one-line intent** from `decisions.md` / `success.md` (the slice you said you were building).
+
+```bash
+git diff <base>...HEAD --stat
+git diff <base>...HEAD
+```
+
+Score every touched path (or logical hunk):
+
+| Path / change | Verdict | Rule |
+|---------------|---------|------|
+| | **KEEP** | Directly required for the stated intent |
+| | **JUSTIFY** | Adjacent but load-bearing — one sentence why it must ship *now*, or split |
+| | **SPLIT** | Real work, wrong PR — park in `decisions.md` kill/Next; do not deploy with this slice |
+| | **DROP** | Noise (format-only, drive-by rename, unrelated tidy) — revert before ship |
+
+**Any SPLIT or DROP still in the tree = fix-first.** JUSTIFY without a written sentence = treat as SPLIT. Log a one-line receipt in `delivery.md`: `intent vs diff: KEEP n · JUSTIFY n · SPLIT n · DROP n — <intent>`.
+
+This is **code drift**, not stakeholder "also can you…" (that is `scope-defense`). Same family as review Stage 1 — ship refuses green when the diff outgrew the claim.
+
 ## Pre-blast challenge (before the deploy button)
 
 For any non-trivial go-live (shared infra, regulated data, irreversible migration, or first prod touch), run this once before canary — not as theater, as a stop-the-line check:
@@ -162,7 +184,7 @@ Adoption isn't a handoff-stage problem - it starts during build. Software that l
 
 ## Checkpoint
 
-Before 100%: canary clean, business metric verified, pulse written into `delivery.md`. Also green: value bucket named, audit receipt dated, eval receipt **n/a or pass**. Missing any of those → not green. For enterprise-scale: scale-readiness gate passed before broad rollout.
+Before 100%: canary clean, business metric verified, pulse written into `delivery.md`. Also green: value bucket named, audit receipt dated, eval receipt **n/a or pass**, **intent vs diff clean** (no unresolved SPLIT/DROP). Missing any of those → not green. For enterprise-scale: scale-readiness gate passed before broad rollout.
 
 ## Principles
 
@@ -170,6 +192,7 @@ Before 100%: canary clean, business metric verified, pulse written into `deliver
 - Roll back on any canary anomaly; investigate safely.
 - Verify the business metric, not just the technical one.
 - No value bucket, no green ship. No pulse, no done.
+- Diff larger than the stated intent without KEEP/JUSTIFY receipts = fix-first.
 - AI path without eval receipt = fix-first; non-AI ships leave eval as n/a.
 - Scale readiness is organizational, not just technical. Check all 8 dimensions.
 - Adoption is measured from day one, not hoped for at launch.


### PR DESCRIPTION
## Summary
- **Not a new skill** — scope-creep detector (KEEP / JUSTIFY / SPLIT / DROP) lives in existing `ship` + `review` (+ light `build` gate).
- Ship runs intent vs diff before pre-blast; unresolved SPLIT/DROP = fix-first; receipt in `delivery.md`.
- Review Stage 1 uses the same table; router phrases for “diff grew / scope creep in the PR”; distinct from stakeholder `scope-defense`.

## Test plan
- [x] `npm run check` (68 tests pass)
- [ ] Spot-check: `@fde did this PR stay in scope?` routes to review Stage 1
- [ ] Confirm no new top-level skill / reference file added


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/15" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->