### PR TITLE
Clarify skills layers + publish non-goals

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,4 +197,6 @@ Built and maintained by **[Subash Natarajan](https://www.linkedin.com/in/subashn
 
 Thanks to builders whose craft helped sharpen the thinking behind this kit, among them [Andrej Karpathy](https://karpathy.ai/)'s engineering guidelines and the [agentic engineering workflow](https://github.com/pawel-cell/micky-podcast-agentic-engineering) notes from David Ondrej / Michael Shimeles. FDEOps itself is handcrafted for field work; any resemblance is inspiration, not a fork.
 
+**What we won't build:** SaaS sync or Slack/Notion connectors inside the CLI, CRM as core, hardware capture, or generic code-craft skill packs (TDD/review already exist elsewhere - FDEOps owns the engagement, not the keyboard). The `fde` CLI stays local-only.
+
 [FDE Methodology](FDE-METHODOLOGY.md) - [SECURITY.md](SECURITY.md) - [PRIVACY.md](PRIVACY.md) - [Repo layout](docs/REPO_LAYOUT.md) - [Skills matrix](docs/skills.md) - MIT

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,8 +1,14 @@
-# The skills matrix - 35 skills + 5 overlays
+# One skill, three layers
 
-One skill (`@fde`) routes across six domains. You never pick a method by name - describe your situation and the router picks. This page is the full map; per-method details live in [skills-reference.md](./skills-reference.md).
+One skill (`@fde`) routes by situation - you never pick a method by name. Three layers:
 
-## 35 skills across 6 domains
+1. **Daily** - prep, debrief, receipts, status, triage / doctor
+2. **Engagement** - land → discover → plan → build → ship → close (the methods below)
+3. **Overlays** - ai / fintech / healthcare / gov / artifacts (plus eval-pack as an AI companion)
+
+The full map is below; per-method details live in [skills-reference.md](./skills-reference.md).
+
+## Engagement methods (35 across 6 domains)
 
 | Domain | Skills | What it covers |
 |--------|--------|---------------|


### PR DESCRIPTION
## Summary
- `docs/skills.md` leads with **One skill, three layers** (daily / engagement / overlays) instead of “35 skills + 5 overlays”
- README Contributing: short **What we won't build** (no SaaS sync/connectors in CLI, no CRM core, no hardware, no generic craft packs)

## Test plan
- [x] `npm run check` (68 tests)
- [ ] Spot-check skills.md title and README restraint line


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->