### PR TITLE
docs: sharpen README elevator pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
-One `@fde` skill over a local client notebook (the **fieldbook** under `.fde/`) - one folder per client. The **system of record for embeds** - Forward Deployed Engineers and anyone living on a client site from first meeting to handoff. Feels like a second brain; behaves like a defensible record (dated, sourced, yours). Works the same for consultants, agency developers, solutions architects, and fractional CTOs.
+**Memory + methodology + skills, in one kit.** Skill packs teach your AI agent how to build. None of them remember who the client is, what was decided, or what's safe to ship. FDEOps adds the missing layer: a private fieldbook per engagement (`.fde/`), a field methodology (land → close), and one `@fde` skill that routes it all. Built for Forward Deployed Engineers, and anyone embedded in client work: consultants, agency developers, solutions architects, fractional CTOs. Feels like a second brain; behaves like a defensible record (dated, sourced, yours).
 
 ```
   land      discover      plan      build      ship      close


### PR DESCRIPTION
## Summary
- Replace the README opening paragraph with the memory + methodology + skills elevator pitch
- Positions FDEOps against skill packs (what they teach vs what they forget) and names the dual audience
- Docs-only, no version bump

## Test plan
- [x] npm run check (68/68 pass)
- [x] No em dashes in the new copy

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/18" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->