### PR TITLE
fix: 3.10.1 usable pull (CLI-first, Slack recipe, MCP bind)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Second brain for Forward Deployed Engineers. One @fde skill - enter at day one, mid-project, or mid-fire; it routes and does the phase work; engagement memory lands in .fde/ as you confirm judgment.",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.10.1 — 2026-08-13
+
+Launch usability: pull is optional and CLI-first; MCP sink can bind an engagement without env.
+
+### Added
+- **Slack pull recipe** — read a thread as text; never post or sync.
+- **`engagement` argument** on ingest MCP tools — pass the `.fde/` path from `fde resume --bind` when the MCP process is not in a bound workspace.
+
+### Changed
+- Daily path is paste/debrief; connect wires a **source** MCP only. `fde ingest` in the open workspace is the sink.
+- README week table and "won't build" line no longer contradict (pull via your MCP ≠ we ship connectors).
+
 ## 3.10.0 — 2026-08-04
 
 Everything published since 3.9.20: the installer can no longer touch skills it did not create, `<private>` holds under adversarial input, a first run costs nothing, and the front door shows a real session.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Day to day you only need `@fde` and normal English. No command cheat sheet.
 |------|--------------|--------------|
 | **Start of week** | Open your AI coding agent (nothing to paste) | It already knows where you left off - trust, phase, what's next |
 | **After a meeting** | `@fde` debrief these notes *(paste or attach them)* | Proposed updates to the record - you review, then confirm |
-| **Pull from tools** | `@fde` connect Granola *(once)* · then `@fde` pull today's Acme transcript | Wire any source MCP you choose; FDEOps stages → proposes → you confirm. Recipes: [mcp/recipes/](mcp/recipes/) |
+| **Optional: pull from a tool** | `@fde` connect Granola *(once)* · then `@fde` pull today's Acme transcript | You add that source MCP (Granola, Slack, Notion, …). FDEOps only **pulls** on request — no push, no sync. Recipes: [mcp/recipes/](mcp/recipes/) |
 | **Before a stakeholder meeting** | `@fde` prep me for tomorrow's meeting with the sponsor | A short brief from what you already logged - not a blank chat |
 | **Someone disputes scope** | `@fde` when did we agree to drop that feature? | Dated answers from the record (or a clear gap if nothing was logged) |
 | **End of week** | `@fde` draft the sponsor update from the record | Status grounded in what actually happened |
@@ -110,7 +110,7 @@ npx fdeops resume                 # prints a short "where we are" for this clien
 - **You** describe the situation with `@fde` (or plain language once the skill is loaded)
 - **Session start / end** - small hooks load where you left off and capture what changed (no re-paste)
 - **Local CLI** - memory writes, search, and status with no model tokens; the agent runs it. You do not need to learn it for daily use ([docs/USAGE.md](docs/USAGE.md))
-- **Pluggable pull (ingest)** - FDEOps is the **sink**, not a connector pack. You add any source MCP (Granola, Notion, Drive, …) in Cursor/Claude; say `@fde connect …` for a guided config + recipe, then pull in plain language. Raw text → `.inbox/` → propose → you confirm → `.fde/`. No ambient sync; nothing unreviewed enters the fieldbook. See [mcp/recipes/](mcp/recipes/).
+- **Pluggable pull (optional)** - FDEOps is the **sink**, not a connector pack. Paste is the daily path. To pull, you add a source MCP (Granola, Slack, Notion, …) in Cursor/Claude; `@fde connect …` walks config. We never push, never sync, never store their tokens. Raw text → `.inbox/` → propose → you confirm → `.fde/`. Recipes: [mcp/recipes/](mcp/recipes/).
 
 fdeops complements repo memory: CLAUDE.md holds how the *code* works; the fieldbook holds how the *client engagement* works.
 
@@ -146,7 +146,10 @@ Overlays for regulated domains (AI, fintech, healthcare, government) activate on
 
 ## The field methods
 
-You never pick one - you describe the situation and `@fde` routes. They are listed here because the methodology is the product, and it should be readable before you install anything. **37 methods across 6 domains**, each one a method (the thinking, the artifact it drafts, the checkpoint with you), not advice:
+You never pick one - you describe the situation and `@fde` routes. **37 methods across 6 domains**, each a method (thinking, artifact, checkpoint), not advice. Full matrix: [docs/skills.md](docs/skills.md) · phrases: [docs/skills-reference.md](docs/skills-reference.md).
+
+<details>
+<summary><strong>All 37 methods</strong> (land → close)</summary>
 
 | Domain | Methods |
 |--------|---------|
@@ -157,9 +160,9 @@ You never pick one - you describe the situation and `@fde` routes. They are list
 | **5. Ship & Verify** - production, with a way back | [ship](skills/fde/references/ship.md) · [review](skills/fde/references/review.md) · [rollback-drill](skills/fde/references/rollback-drill.md) · [qa-live](skills/fde/references/qa-live.md) |
 | **6. Operate & Close** - the part that decides renewals | [status](skills/fde/references/status.md) · [demo-prep](skills/fde/references/demo-prep.md) · [debrief](skills/fde/references/debrief.md) · [exec-narrative](skills/fde/references/exec-narrative.md) · [dashboard](skills/fde/references/dashboard.md) · [multi-customer-ops](skills/fde/references/multi-customer-ops.md) · [close](skills/fde/references/close.md) · [handoff-engineering](skills/fde/references/handoff-engineering.md) · [pattern-extract](skills/fde/references/pattern-extract.md) · [red-team](skills/fde/references/red-team.md) · [ingest](skills/fde/references/ingest.md) · [ingest-connect](skills/fde/references/ingest-connect.md) |
 
-Plus five overlays that activate on signal rather than being chosen - [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) - which add the checks that domain demands to whatever method is already running.
+Plus five overlays that activate on signal rather than being chosen - [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md).
 
-Every method, with the exact phrases that route to it: **[docs/skills-reference.md](docs/skills-reference.md)**.
+</details>
 
 ---
 
@@ -238,6 +241,6 @@ Built and maintained by **[Subash Natarajan](https://www.linkedin.com/in/subashn
 
 Thanks to builders whose craft helped sharpen the thinking behind this kit, among them [Andrej Karpathy](https://karpathy.ai/)'s engineering guidelines and the [agentic engineering workflow](https://github.com/pawel-cell/micky-podcast-agentic-engineering) notes from David Ondrej / Michael Shimeles. FDEOps itself is handcrafted for field work; any resemblance is inspiration, not a fork.
 
-**What we won't build:** SaaS sync or Slack/Notion connectors inside the CLI, CRM as core, hardware capture, or generic code-craft skill packs (TDD/review already exist elsewhere - FDEOps owns the engagement, not the keyboard). The `fde` CLI stays local-only.
+**What we won't build:** SaaS sync, Slack/Notion/Granola **connectors or push** inside the CLI, CRM as core, hardware capture, or generic code-craft skill packs (TDD/review already exist elsewhere - FDEOps owns the engagement, not the keyboard). You may **pull** from those tools via *your* MCP; the `fde` CLI stays local-only.
 
 [FDE Methodology](FDE-METHODOLOGY.md) - [SECURITY.md](SECURITY.md) - [PRIVACY.md](PRIVACY.md) - [Repo layout](docs/REPO_LAYOUT.md) - [Skills matrix](docs/skills.md) - MIT

--- a/bin/check.js
+++ b/bin/check.js
@@ -499,7 +499,7 @@ if (!fs.existsSync(path.join(root, 'mcp', 'fdeops-ingest', 'server.js'))) {
 } else if (!fs.existsSync(path.join(root, 'skills', 'fde', 'references', 'ingest-connect.md'))) {
   fail('skills/fde/references/ingest-connect.md missing')
 } else {
-  for (const recipe of ['file.md', 'granola.md', 'notion.md']) {
+  for (const recipe of ['file.md', 'granola.md', 'slack.md', 'notion.md']) {
     if (!fs.existsSync(path.join(root, 'mcp', 'recipes', recipe))) fail(`mcp/recipes/${recipe} missing`)
   }
   if (!read('README.md').includes('mcp/recipes')) fail('README must point at mcp/recipes for connect clarity')

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -60,11 +60,11 @@ Not sure which client a workspace writes to? `fde resume --bind` shows the bindi
 
 ## Ingest: pull large artifacts → same confirm loop
 
-When a transcript or email is too large to paste, or lives in Granola/Gmail/Notion:
+When a transcript or email is too large to paste, or lives in Granola/Slack/Notion:
 
-**Connect once (plain language):** `@fde I want to connect Granola` (or Notion / a new MCP). The agent runs a capability check, emits an `mcp.json` snippet from [mcp/recipes/](../mcp/recipes/), and asks you to save + reload in Cursor/Claude — it cannot silently install host MCPs. Then: `@fde what can you pull?`
+**Daily without MCP:** paste to `@fde` or `fde ingest stage` a file. That is the complete product.
 
-**Pull:** `@fde make sure Acme is up to date — pull what's relevant`. It binds the engagement, uses **your** configured source MCPs to fetch raw text (fdeops does not bundle Gmail/Granola), stages with `fde ingest stage`, proposes with `fde ingest propose`, shows you the routing, and only runs `fde ingest apply` after you confirm. No auto-apply, no background sync.
+**Optional pull:** `@fde I want to connect Granola` (or Slack / Notion). You add **that** source MCP; FDEOps does not bundle it and does not push back. Then `@fde pull today's Acme transcript`. The agent fetches text and runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply).
 
 **Directly (zero tokens, you already have the file):**
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -6,7 +6,7 @@ FDEOps MCP servers follow a **pluggable source model**: core owns the **sink**, 
 
 | Role | Owner | Examples |
 |------|-------|----------|
-| **Source** | FDE configures separately | Granola, Gmail, Notion, custom scrapers |
+| **Source** | FDE configures separately | Granola, Slack, Notion, Gmail, file |
 | **Sink** | FDEOps (`fdeops-ingest`) | stage → propose → apply into engagement memory |
 
 Source MCPs fetch raw text from SaaS APIs using credentials the FDE manages. The ingest MCP never stores OAuth tokens or calls external services — it only shells out to the local `fde` CLI.

--- a/mcp/fdeops-ingest/README.md
+++ b/mcp/fdeops-ingest/README.md
@@ -2,7 +2,9 @@
 
 Thin stdio MCP server for the FDEOps **ingest sink** only: **stage → propose → apply**.
 
-This package shells out to the local `fde` CLI. It never calls SaaS APIs. Source MCPs (Granola, Gmail, Notion, etc.) are **separate** — you add those in your own `mcp.json`.
+This package shells out to the local `fde` CLI. It never calls SaaS APIs. Source MCPs (Granola, Slack, Notion, etc.) are **separate** — you add those in your own `mcp.json`.
+
+**Prefer the CLI when this workspace is bound:** `fde ingest stage|list|propose|apply`. Use this MCP when the host did not start in a bound workspace — then pass `engagement` (path to `.fde/` from `fde resume --bind`) on every tool call.
 
 ## Tools
 
@@ -89,4 +91,4 @@ Sources are pluggable and user-configured. This MCP owns the sink only.
 
 ## Zero dependencies
 
-Hand-rolled MCP over stdio (Content-Length framed JSON-RPC). No `@modelcontextprotocol/sdk` required at runtime.
+Hand-rolled MCP over stdio (newline-delimited JSON-RPC). No `@modelcontextprotocol/sdk` required at runtime.

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/mcp/fdeops-ingest/server.js
+++ b/mcp/fdeops-ingest/server.js
@@ -4,7 +4,8 @@
 /**
  * fdeops-ingest MCP — thin stdio sink for FDEOps ingest.
  * Shells out to local `fde` CLI only. Never calls SaaS.
- * MCP stdio transport: Content-Length framed JSON-RPC 2.0.
+ * MCP stdio transport: newline-delimited JSON-RPC 2.0
+ * (Content-Length frames are accepted on input).
  */
 
 const fs = require('fs')
@@ -15,11 +16,17 @@ const PROTOCOL_VERSION = '2024-11-05'
 const SERVER_NAME = 'fdeops-ingest'
 const SERVER_VERSION = require('./package.json').version
 
+const ENGAGEMENT_PROP = {
+  type: 'string',
+  description:
+    'Path to this client\'s .fde/ folder (from `fde resume --bind`). Optional if FDEOPS_ENGAGEMENT is set or the process cwd is already bound.',
+}
+
 const TOOLS = [
   {
     name: 'ingest_stage',
     description:
-      'Stage raw content into the engagement inbox (.inbox/). Does not write .fde/.',
+      'Stage raw content into the engagement inbox (.inbox/). Does not write .fde/. Prefer the fde ingest CLI when the workspace is already bound.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -29,12 +36,13 @@ const TOOLS = [
         },
         source: {
           type: 'string',
-          description: 'Provenance label (e.g. granola, gmail, manual). Default: manual.',
+          description: 'Provenance label (e.g. granola, slack, notion, file, manual). Default: manual.',
         },
         title: {
           type: 'string',
           description: 'Optional human-readable title for the staged item.',
         },
+        engagement: ENGAGEMENT_PROP,
       },
       required: ['content'],
     },
@@ -42,7 +50,10 @@ const TOOLS = [
   {
     name: 'ingest_list',
     description: 'List staged items in the current engagement inbox.',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: {
+      type: 'object',
+      properties: { engagement: ENGAGEMENT_PROP },
+    },
   },
   {
     name: 'ingest_propose',
@@ -55,6 +66,7 @@ const TOOLS = [
           type: 'string',
           description: 'Staged filename or id from ingest_list.',
         },
+        engagement: ENGAGEMENT_PROP,
       },
       required: ['id'],
     },
@@ -63,7 +75,10 @@ const TOOLS = [
     name: 'ingest_apply',
     description:
       'Apply the current debrief proposal into .fde/ memory (requires prior FDE confirm).',
-    inputSchema: { type: 'object', properties: {} },
+    inputSchema: {
+      type: 'object',
+      properties: { engagement: ENGAGEMENT_PROP },
+    },
   },
 ]
 
@@ -128,10 +143,10 @@ function fdeEnv() {
   return env
 }
 
-function runFde(args, stdin) {
+function runFde(args, stdin, extraEnv) {
   const { cmd, prefix } = resolveFde()
   const result = spawnSync(cmd, [...prefix, ...args], {
-    env: fdeEnv(),
+    env: { ...fdeEnv(), ...(extraEnv || {}) },
     input: stdin ?? undefined,
     encoding: 'utf8',
     maxBuffer: 16 * 1024 * 1024,
@@ -142,6 +157,11 @@ function runFde(args, stdin) {
     status: result.status ?? (result.error ? 1 : 0),
     error: result.error ? String(result.error.message || result.error) : null,
   }
+}
+
+function engagementEnv(args) {
+  const p = args && typeof args.engagement === 'string' ? args.engagement.trim() : ''
+  return p ? { FDEOPS_ENGAGEMENT: p } : {}
 }
 
 function cliPayload(out) {
@@ -163,6 +183,7 @@ function toolError(payload) {
 
 function handleToolCall(name, args) {
   args = args || {}
+  const extraEnv = engagementEnv(args)
 
   switch (name) {
     case 'ingest_stage': {
@@ -172,23 +193,23 @@ function handleToolCall(name, args) {
       const source = args.source || 'manual'
       const cliArgs = ['ingest', 'stage', '--source', source]
       if (args.title) cliArgs.push('--title', args.title)
-      const out = runFde(cliArgs, args.content)
+      const out = runFde(cliArgs, args.content, extraEnv)
       const payload = cliPayload(out)
       return out.status === 0 ? toolResult(payload) : toolError(payload)
     }
     case 'ingest_list': {
-      const out = runFde(['ingest', 'list'])
+      const out = runFde(['ingest', 'list'], undefined, extraEnv)
       const payload = cliPayload(out)
       return out.status === 0 ? toolResult(payload) : toolError(payload)
     }
     case 'ingest_propose': {
       if (!args.id) return toolError('Missing required argument: id')
-      const out = runFde(['ingest', 'propose', String(args.id)])
+      const out = runFde(['ingest', 'propose', String(args.id)], undefined, extraEnv)
       const payload = cliPayload(out)
       return out.status === 0 ? toolResult(payload) : toolError(payload)
     }
     case 'ingest_apply': {
-      const out = runFde(['ingest', 'apply'])
+      const out = runFde(['ingest', 'apply'], undefined, extraEnv)
       const payload = cliPayload(out)
       return out.status === 0 ? toolResult(payload) : toolError(payload)
     }

--- a/mcp/recipes/README.md
+++ b/mcp/recipes/README.md
@@ -1,15 +1,16 @@
 # Ingest source recipes
 
-FDEOps does **not** bundle Granola / Notion / Drive OAuth. These recipes show how an FDE wires a **source MCP** (or file drop) into the FDEOps **sink**.
+FDEOps does **not** bundle Granola / Slack / Notion OAuth and does **not** push to those tools.
 
-**Contract every source must satisfy:** fetch text → `fde ingest stage` (or MCP `ingest_stage`) with `{ source, title, content }` → propose → FDE confirms → apply.
+**Daily (no MCP):** paste notes to `@fde debrief`, or drop a file ([file.md](./file.md)).
+
+**Pull (optional):** you add a **source** MCP. The agent fetches text, then runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply). The `fdeops-ingest` MCP is optional — only if you are not using the CLI from a bound workspace.
 
 | Recipe | When |
 |--------|------|
-| [file.md](./file.md) | Local transcript / export already on disk (no source MCP) |
-| [granola.md](./granola.md) | Meeting transcripts via a Granola-shaped MCP (or export) |
-| [notion.md](./notion.md) | Notion pages / meeting notes via a Notion MCP |
+| [file.md](./file.md) | Transcript / export already on disk, or paste |
+| [granola.md](./granola.md) | Meeting transcripts via a notes MCP (or export) |
+| [slack.md](./slack.md) | Pull a thread/channel as text — never post |
+| [notion.md](./notion.md) | Read a Notion page (or export markdown) |
 
-Also wire the sink once: [fdeops-ingest/README.md](../fdeops-ingest/README.md).
-
-**Natural language:** `@fde I want to connect Granola` → agent follows `skills/fde/references/ingest-connect.md` and this recipe.
+**Natural language:** `@fde I want to connect Granola` (or Slack / Notion) → `skills/fde/references/ingest-connect.md`.

--- a/mcp/recipes/file.md
+++ b/mcp/recipes/file.md
@@ -1,10 +1,10 @@
 # Recipe: local file / paste (no source MCP)
 
-**Use when:** you already have a transcript, `.eml`, or export on disk — or you paste into chat.
+**Use when:** you already have a transcript, `.eml`, or export on disk — or you paste into chat. This is the default FDE path.
 
 ## Setup
 
-None beyond the FDEOps sink (`fde` CLI and optionally `fdeops-ingest` MCP).
+None. Bound workspace + `fde ingest` (or `@fde debrief` for short notes).
 
 ## Pull phrase
 
@@ -12,14 +12,14 @@ None beyond the FDEOps sink (`fde` CLI and optionally `fdeops-ingest` MCP).
 @fde stage this transcript into the fieldbook and propose updates
 ```
 
-(or attach / point at a path)
+(or attach / point at a path, or paste and say debrief)
 
 ## Agent steps
 
-1. Bind engagement.
-2. `fde ingest stage --source file --title "<short>" <path>` (or stdin).
-3. `fde ingest propose <id>` → rewrite prefixes → show FDE → on confirm `fde ingest apply`.
+1. Bind engagement (`fde resume`).
+2. Short paste → debrief verb. Long file → `fde ingest stage --source file --title "<short>" <path>`.
+3. Propose → rewrite prefixes → show FDE → on confirm apply.
 
 ## mcp.json
 
-Not required for the source. Optional sink only — see [../fdeops-ingest/README.md](../fdeops-ingest/README.md).
+Not required.

--- a/mcp/recipes/granola.md
+++ b/mcp/recipes/granola.md
@@ -2,16 +2,19 @@
 
 **Use when:** meeting notes live in Granola (or a similar notes MCP). FDEOps does not ship a Granola server — you add whichever MCP/export path you trust.
 
+Daily path if the notes are already in chat or on disk: paste to `@fde debrief` or [file.md](./file.md). This recipe is only for **pull**.
+
 ## Setup (once)
 
-1. Install / enable a **Granola (or notes) MCP** in Cursor/Claude per that product’s docs.
-2. Add the FDEOps **sink** MCP (`fdeops-ingest`) — [../fdeops-ingest/README.md](../fdeops-ingest/README.md).
-3. Reload MCP / restart the agent host.
-4. Test: `@fde what can you pull?` — agent should see both sink tools and the notes source tools.
+1. Enable a **Granola (or notes) MCP** in Cursor/Claude per that product’s docs.
+2. Reload MCP / restart the host.
+3. Test: `@fde what can you pull?` — notes-source tools should appear.
+
+The sink is **`fde ingest` in this bound workspace.** You do not need `fdeops-ingest` MCP for daily pull.
 
 ### Example mcp.json shape (illustrative)
 
-Replace `granola-mcp` command/args with whatever the real server documents. FDEOps only needs *some* tool that returns transcript text.
+Replace command/args with whatever the real Granola MCP documents. FDEOps only needs *some* tool that returns transcript text.
 
 ```json
 {
@@ -22,19 +25,12 @@ Replace `granola-mcp` command/args with whatever the real server documents. FDEO
       "env": {
         "GRANOLA_API_KEY": "from-your-secrets"
       }
-    },
-    "fdeops-ingest": {
-      "command": "node",
-      "args": ["/absolute/path/to/fdeops/mcp/fdeops-ingest/server.js"],
-      "env": {
-        "FDEOPS_ENGAGEMENT": "/Users/you/fde-engagements/acme/.fde"
-      }
     }
   }
 }
 ```
 
-**No Granola MCP available?** Export transcript to a file → follow [file.md](./file.md).
+**No Granola MCP available?** Export transcript to a file → [file.md](./file.md).
 
 ## Pull phrase
 
@@ -44,15 +40,15 @@ Replace `granola-mcp` command/args with whatever the real server documents. FDEO
 
 ## Agent steps
 
-1. Capability check — if no notes/Granola tools, run connect flow (`ingest-connect.md`).
-2. Fetch transcript via source MCP (or ask which meeting).
-3. `ingest_stage` / `fde ingest stage --source granola --title "…"`.
-4. Propose → confirm → apply. Never auto-apply.
+1. Capability check — notes-source tools present?
+2. Fetch transcript text (ask which meeting if ambiguous).
+3. `fde ingest stage --source granola --title "<short>"` then propose → confirm → apply.
+4. Extract decisions/risks/next — do not dump the raw transcript into `.fde/`.
 
 ## Common fails
 
 | Symptom | Fix |
 |---------|-----|
-| Agent says it can’t reach Granola | MCP not saved / host not reloaded / wrong env key |
-| Wrong client inbox | Set `FDEOPS_ENGAGEMENT` or bind workspace (`fde resume --init`) |
-| Empty propose | Agent must rewrite `.debrief-propose` with type prefixes |
+| No Granola tools | Source MCP not loaded — they save + reload |
+| Wrong meeting | One clarifying question, then fetch |
+| Wrong engagement | `fde resume` in this workspace before staging |

--- a/mcp/recipes/notion.md
+++ b/mcp/recipes/notion.md
@@ -1,13 +1,14 @@
 # Recipe: Notion docs / meeting notes
 
-**Use when:** useful engagement notes live in Notion. FDEOps does not ship a Notion server — use a Notion MCP (or export markdown).
+**Use when:** useful engagement notes live in Notion. FDEOps does not ship a Notion server — use a Notion MCP (or export markdown). We do not write back to Notion.
 
 ## Setup (once)
 
-1. Enable a **Notion MCP** (official or community) with a token that can read the pages you need.
-2. Add **fdeops-ingest** sink — [../fdeops-ingest/README.md](../fdeops-ingest/README.md).
-3. Reload MCP / restart host.
-4. Test: `@fde what can you pull?`
+1. Enable a **Notion MCP** (official or community) with a token that can **read** the pages you need.
+2. Reload MCP / restart host.
+3. Test: `@fde what can you pull?`
+
+The sink is **`fde ingest` in this bound workspace.** `fdeops-ingest` MCP is optional.
 
 ### Example mcp.json shape (illustrative)
 
@@ -19,13 +20,6 @@
       "args": ["-y", "YOUR-NOTION-MCP-PACKAGE"],
       "env": {
         "NOTION_TOKEN": "from-your-secrets"
-      }
-    },
-    "fdeops-ingest": {
-      "command": "node",
-      "args": ["/absolute/path/to/fdeops/mcp/fdeops-ingest/server.js"],
-      "env": {
-        "FDEOPS_ENGAGEMENT": "/Users/you/fde-engagements/acme/.fde"
       }
     }
   }
@@ -42,15 +36,19 @@
 
 ## Agent steps
 
-1. Capability check — Notion tools present?
-2. Fetch page/block text via Notion MCP (ask which page if ambiguous).
-3. Stage with `--source notion`.
-4. Propose → confirm → apply.
+1. Capability check — Notion read tools present?
+2. Fetch page/block text (ask which page if ambiguous).
+3. `fde ingest stage --source notion --title "<short>"` → propose → confirm → apply.
+
+## Never
+
+- Create or edit Notion pages from FDEOps.
+- Ambient-sync a database.
 
 ## Common fails
 
 | Symptom | Fix |
 |---------|-----|
 | 401 / forbidden | Token lacks access to that workspace/page |
-| Huge page dump | Stage full text in `.inbox/`; propose only short dated facts |
-| Wrong engagement | Bind / `FDEOPS_ENGAGEMENT` |
+| Huge page dump | Stage full text in `.inbox/`; apply only short dated facts |
+| Wrong engagement | Bind this workspace before staging |

--- a/mcp/recipes/slack.md
+++ b/mcp/recipes/slack.md
@@ -1,0 +1,61 @@
+# Recipe: Slack (pull only)
+
+**Use when:** useful context lives in a Slack thread or channel. FDEOps does **not** ship a Slack server, does **not** post messages, and does **not** sync channels.
+
+You add whatever Slack MCP your host already supports. We only accept **text you pulled**, then the same confirm loop as a debrief.
+
+## Setup (once)
+
+1. Enable a **Slack MCP** (official or community) with read access to the threads you need.
+2. Reload MCP / restart the host.
+3. Test: `@fde what can you pull?` — Slack fetch tools should appear. The FDEOps **CLI** (`fde ingest`) is the sink if this workspace is bound; you do not need `fdeops-ingest` MCP for daily use.
+
+### Example mcp.json shape (illustrative)
+
+Replace the Slack server with whatever that MCP actually documents. Do not invent a package name.
+
+```json
+{
+  "mcpServers": {
+    "slack": {
+      "command": "npx",
+      "args": ["-y", "YOUR-SLACK-MCP-PACKAGE"],
+      "env": {
+        "SLACK_BOT_TOKEN": "from-your-secrets"
+      }
+    }
+  }
+}
+```
+
+Optional sink MCP (only if you are not running `fde ingest` from this workspace): see [../fdeops-ingest/README.md](../fdeops-ingest/README.md). Pass `engagement` as the path to this client's `.fde/` (from `fde resume --bind`).
+
+**No Slack MCP?** Copy the thread to a file or paste into chat → [file.md](./file.md) or `@fde debrief`.
+
+## Pull phrase
+
+```text
+@fde pull yesterday's #acme-launch thread into the fieldbook
+```
+
+## Agent steps
+
+1. Capability check — Slack **read** tools present? If not → this recipe, then stop.
+2. Fetch the thread/channel as **text** (ask which channel/thread if ambiguous).
+3. `fde ingest stage --source slack --title "<short>"` (CLI in this bound workspace).
+4. Propose → FDE confirms → apply. Extract decisions/risks/asks — do not dump the thread into `.fde/`.
+
+## Never
+
+- Post, reply, or react in Slack from FDEOps.
+- Background-sync a channel.
+- Auto-apply.
+
+## Common fails
+
+| Symptom | Fix |
+|---------|-----|
+| No Slack tools | Source MCP not loaded — they save + reload; we cannot silent-install |
+| Missing channel | Token/scopes cannot read that workspace — their Slack admin, not FDEOps |
+| Huge dump | Stage full text in `.inbox/`; apply only short dated facts |
+| Wrong client | Bind this workspace (`fde resume`) before staging |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Field kit for engineers embedded in client work - a real CLI (recon, memory, portfolio), one @fde skill with field judgment on top, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.10.0",
+  "version": "3.10.1",
   "description": "Engagement fieldbook for Forward Deployed Engineers: per-client memory in local .fde/ files, one @fde skill, land to close methodology. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -83,8 +83,8 @@ When NOT to interrogate or challenge: unambiguous one-liners, mechanical ops, FD
 | (session entry / where are we) | `fde resume` or use injected TRIAGE; `fde resume --init <name>` only if unbound |
 | Day-1 look at the repo | `fde scan` - then you interpret against the brief |
 | "Debrief these notes" / pastes meeting notes | Prefer `fde debrief --smart <notes>` → **you** (the agent) rewrite `.debrief-propose` with `decision:`/`risk:`/`delivery:`/`contact:`/`next:` prefixes where needed → show FDE → on confirm `fde debrief --apply`. `--smart` is a prefix/keyword gate, not a brain. Fallback: structure prefixed lines yourself, show FDE, then `fde debrief` |
-| "Make sure we're up to date" / "pull relevant info" / "pull from Granola/email/transcript" | Bind engagement; **capability check** (which source MCPs exist this session — never pretend). If missing → connect flow. Else fetch → `fde ingest stage` → `fde ingest propose` → rewrite prefixes → show FDE → on confirm `fde ingest apply`. **Never auto-apply. Never ambient sync.** Detail: `references/ingest.md` |
-| "Connect a new MCP" / "connect Granola/Notion" / "what can you pull?" | Follow `references/ingest-connect.md`: ask which source → emit `mcp.json` from `mcp/recipes/` + sink block → they save/reload in Cursor/Claude → verify tools → optional test stage to `.inbox/` only. You cannot silently install host MCPs. |
+| "Make sure we're up to date" / "pull relevant info" / "pull from Granola/Slack/transcript" | Bind engagement; **capability check** (which *source* MCPs exist — never pretend). If missing → connect flow. Else fetch text → `fde ingest stage` **in this workspace** → propose → rewrite prefixes → show FDE → on confirm `fde ingest apply`. MCP sink is optional; if used, pass `engagement` from `fde resume --bind`. **Never auto-apply. Never push. Never ambient sync.** Detail: `references/ingest.md` |
+| "Connect a new MCP" / "connect Granola/Slack/Notion" / "what can you pull?" | Follow `references/ingest-connect.md`: source MCP only; sink is `fde ingest` here. They save/reload; you cannot silent-install. Paste still works with no MCP. |
 | "Prep me for the meeting with …" / walk-in brief | `fde prep "<short label>"` - present the brief in plain language; do not invent facts missing from `.fde/` |
 | "When did we agree…?" / scope dispute | `fde receipts <term>` - answer with dates; no hit = gap, not proof |
 | "Draft the sponsor update" / how are we doing | `fde status` then follow `references/status.md` for the narrative |
@@ -271,8 +271,8 @@ Running the engagement and ending it well.
 | Weekly update due, "need to send the sponsor something" | status | `references/status.md` |
 | Demo coming up, show-and-tell, exec walkthrough | demo-prep | `references/demo-prep.md` |
 | Just out of a meeting, raw notes, "they said…", "debrief" | debrief | the debrief verb (above) + `references/debrief.md` |
-| Make sure we're up to date, pull what's relevant, fetch from Granola/Gmail/transcript | ingest | `references/ingest.md` (capability check → stage → propose → confirm → apply) |
-| Connect a new MCP / connect Granola or Notion / what can you pull | ingest-connect | `references/ingest-connect.md` (+ `mcp/recipes/`) |
+| Make sure we're up to date, pull what's relevant, fetch from Granola/Slack/Gmail/transcript | ingest | `references/ingest.md` (capability check → stage → propose → confirm → apply) |
+| Connect a new MCP / connect Granola Slack or Notion / what can you pull | ingest-connect | `references/ingest-connect.md` (+ `mcp/recipes/`) |
 | Prep me for a meeting / walk-in brief / "what should I know before I talk to…" | - | run `fde prep "<label>"`, present in plain language |
 | Sponsor's boss needs a summary, board update, justify continued investment | exec-narrative | `references/exec-narrative.md` |
 | Status across all my customers | dashboard | `references/dashboard.md` |

--- a/skills/fde/references/ingest-connect.md
+++ b/skills/fde/references/ingest-connect.md
@@ -1,36 +1,34 @@
 # ingest-connect - wire a source MCP in plain language
 
-**Enter when:** the FDE says "I want to connect a new MCP", "connect Granola / Notion / Drive", "how do I pull from …", or a pull request fails because no source tools exist.
+**Enter when:** the FDE says "I want to connect a new MCP", "connect Granola / Slack / Notion", "how do I pull from …", or a pull request fails because no source tools exist.
 
-**Read first:** `references/ingest.md` (sink contract). Recipe pack: `mcp/recipes/` in the fdeops install (file, granola, notion).
+**Read first:** `references/ingest.md` (sink contract). Recipes: `mcp/recipes/` (file, granola, slack, notion).
 
 **Who runs setup:** you guide; the **host** (Cursor/Claude) must save MCP config. You cannot silently install servers into the host.
 
 ## Honest contract
 
-- FDEOps = **sink** (`fdeops-ingest` / `fde ingest`). Sources = **whatever MCP the FDE adds**.
-- You produce a ready config snippet + steps. They save + reload. Then you verify with a capability check + optional test stage.
-- Never invent that Granola/Notion is available if tools are missing. Never ambient sync. Never auto-apply to `.fde/`.
+- **Daily work does not need a source MCP.** Paste notes → debrief. File on disk → `fde ingest`.
+- **Connect means a source**, not FDEOps. Granola/Slack/Notion credentials stay with that MCP. FDEOps never pushes, never ambient-syncs, never stores their tokens.
+- **Sink is the CLI in this bound workspace** (`fde ingest`). `fdeops-ingest` MCP is optional. If you use it, pass `engagement` as the `.fde/` path from `fde resume --bind` (MCP servers often do not inherit the workspace bind).
+- Never invent that Granola/Slack is available if tools are missing. Never auto-apply to `.fde/`.
 
 ## Method
 
-1. **Ask one question** — which source? (`file` / `granola` / `notion` / other name). If "other", ask for the MCP package or docs URL they intend to use.
+1. **Ask one question** — which source? (`file` / `granola` / `slack` / `notion` / other). If "other", ask for the MCP they intend to use. If they just want paste → send them to debrief and stop.
 2. **Capability check (current session)** — list MCP tools you can actually call:
-   - Sink present? (`ingest_stage` / `ingest_list` / or `fde ingest` CLI)
-   - Source present? (anything that can fetch that system's content)
+   - Sink: `fde ingest` CLI (preferred) and/or `ingest_stage`
+   - Source: anything that can **fetch** that system's content (not post)
    - Say clearly: *available now* vs *needs config*.
-3. **Emit config** — open the matching recipe under `mcp/recipes/<source>.md`. Fill absolute paths:
-   - path to `mcp/fdeops-ingest/server.js` (from this fdeops install)
-   - `FDEOPS_ENGAGEMENT` → this client's `…/<slug>/.fde`
-   - placeholders for source API keys (tell them to paste secrets into host env — do not commit keys into the fieldbook)
-4. **Tell them where to paste** — Cursor: MCP settings / `~/.cursor/mcp.json` (or project MCP). Claude Code: MCP config per their docs. One sentence: save → reload MCP / restart session.
-5. **Verify** — after they confirm reload: re-run capability check. If source tools appear, offer a **test pull** into `.inbox/` only (stage + show list). Stop before apply unless they ask to propose.
-6. **Handoff phrase** — give them the daily line, e.g. `@fde pull today's Acme Granola into the fieldbook`.
+3. **Emit config for the source only** — open `mcp/recipes/<source>.md`. Fill placeholders from *that product's* docs. Tell them to paste secrets into host env — never into `.fde/`.
+4. **Tell them where to paste** — Cursor MCP settings / `mcp.json`. Claude Code: their MCP config. Save → reload MCP / restart session.
+5. **Verify** — after reload: re-run capability check. If source tools appear, offer a **test pull** staged to `.inbox/` only. Stop before apply unless they ask to propose.
+6. **Handoff phrase** — e.g. `@fde pull today's Acme Granola into the fieldbook`.
 
-## If they only want the sink
+## If they only want paste / files
 
-Still wire `fdeops-ingest` (or rely on CLI). File drops work with [mcp/recipes/file.md](../../../mcp/recipes/file.md) without any source MCP.
+Do not add MCP. Use debrief or [mcp/recipes/file.md](../../../mcp/recipes/file.md).
 
 ## Checkpoint
 
-Before ending connect: (1) sink reachable, (2) source reachable or honest gap, (3) they know the pull phrase. Do not write `.fde/` during connect.
+Before ending connect: (1) they know paste still works, (2) source reachable or honest gap, (3) they know the pull phrase. Do not write `.fde/` during connect.

--- a/skills/fde/references/ingest.md
+++ b/skills/fde/references/ingest.md
@@ -2,7 +2,7 @@
 
 **Enter when:** the FDE wants to catch the engagement up from external sources — "make sure Acme is up to date," "pull what's relevant," "grab today's Granola and Denise's last email." Raw transcripts and long emails that are too big to paste usefully.
 
-**Connect / capability (different entry):** "connect a new MCP", "connect Granola/Notion", "what can you pull?" → `references/ingest-connect.md` first. Recipes: `mcp/recipes/` (file, granola, notion).
+**Connect / capability (different entry):** "connect a new MCP", "connect Granola/Slack/Notion", "what can you pull?" → `references/ingest-connect.md` first. Recipes: `mcp/recipes/` (file, granola, slack, notion).
 
 **Read first:** `context.md` (what's already logged, what's stale). Bind the engagement before staging anything.
 
@@ -11,7 +11,8 @@
 ## Honest contract (read once)
 
 - FDEOps owns the **sink only**: stage raw pulls → propose → confirm → apply. Nothing writes `.fde/` unreviewed.
-- **Source MCPs are the FDE's.** Granola, Gmail, Notion, custom — whatever they configured in Cursor/Claude. fdeops does not bundle OAuth, connectors, or ambient sync.
+- **Source MCPs are the FDE's.** Granola, Slack, Notion, Gmail, custom — whatever they configured in Cursor/Claude. fdeops does not bundle OAuth, connectors, or ambient sync, and **does not push** to those tools.
+- Prefer **`fde ingest` in this bound workspace.** Optional `fdeops-ingest` MCP: pass `engagement` (path to `.fde/` from `fde resume --bind`) because MCP cwd often is not the client workspace.
 - The core `fde` CLI stays local (git + file reads). Source credentials live with that MCP; fdeops never stores them.
 - After apply, raw stays in `.inbox/`; the system of record (`.fde/`) stays thin dated facts.
 
@@ -20,7 +21,7 @@
 List what you can actually call **this session**:
 
 1. **Sink** — `ingest_stage` / `fde ingest` available?
-2. **Sources** — which fetch tools exist (Granola-shaped, Notion, Drive, file-only)?
+2. **Sources** — which fetch tools exist (Granola-shaped, Slack, Notion, Drive, file-only)?
 3. Tell the FDE in one line: *I can pull from X; Y is not connected.* If they asked to pull Y and it is missing → switch to `ingest-connect.md`. Never pretend a source exists.
 
 ## Ground loop (you do this work)
@@ -67,6 +68,6 @@ Before apply, read back the 2–3 most consequential captures in one breath — 
 
 ## Principles
 
-- Pull on request, not on a schedule. No auto-poll, no vacuum of inbox or Slack.
+- Pull on request, not on a schedule. No auto-poll, no vacuum of inbox or Slack. No posting back.
 - Staging is not memory. Only `--apply` after confirm writes `.fde/`.
 - Large artifact → ingest stage first; pasted short notes → debrief verb directly (`references/debrief.md`).

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -2296,6 +2296,61 @@ test('ingest_propose over MCP keeps <private> content out of the model-facing re
   assert.match(proposeText, /private - redacted/)
 })
 
+test('ingest MCP stage works via engagement argument without FDEOPS_ENGAGEMENT env', async () => {
+  const sandbox = makeSandbox('mcp-eng-arg')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'engarg']).status, 0)
+  const server = path.join(root, 'mcp', 'fdeops-ingest', 'server.js')
+  const proc = spawn(process.execPath, [server], {
+    cwd: root,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+    },
+  })
+  const lines = []
+  let buf = ''
+  proc.stdout.on('data', (d) => {
+    buf += d
+    while (buf.includes('\n')) {
+      const line = buf.slice(0, buf.indexOf('\n')).trim()
+      buf = buf.slice(buf.indexOf('\n') + 1)
+      if (line) lines.push(JSON.parse(line))
+    }
+  })
+  const send = (msg) => proc.stdin.write(`${JSON.stringify(msg)}\n`)
+  const waitFor = async (count) => {
+    const deadline = Date.now() + 10000
+    while (lines.length < count && Date.now() < deadline) await new Promise(r => setTimeout(r, 50))
+  }
+
+  send({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 't', version: '1' } } })
+  send({
+    jsonrpc: '2.0',
+    id: 2,
+    method: 'tools/call',
+    params: {
+      name: 'ingest_stage',
+      arguments: {
+        source: 'slack',
+        title: 'standup',
+        engagement: engagementPath(sandbox, 'engarg'),
+        content: 'decision: freeze scope until Friday\n',
+      },
+    },
+  })
+  await waitFor(2)
+  proc.kill()
+  assert.equal(lines.length, 2, `expected 2 replies, got ${JSON.stringify(lines)}`)
+  assert.equal(lines[1].result.isError, undefined)
+  const text = lines[1].result.content.map(c => c.text).join('\n')
+  assert.match(text, /staged|inbox|standup/i)
+  const inbox = path.join(sandbox.home, 'fde-engagements', 'engarg', '.inbox')
+  const files = fs.readdirSync(inbox).filter(f => f.endsWith('.md'))
+  assert.equal(files.length, 1)
+})
+
 test('ingest MCP server speaks newline-delimited stdio as the MCP transport requires', async () => {
   const server = path.join(root, 'mcp', 'fdeops-ingest', 'server.js')
   const proc = spawn(process.execPath, [server], { cwd: root, stdio: ['pipe', 'pipe', 'pipe'] })


### PR DESCRIPTION
## Summary
- Daily loop is paste/debrief; pull is optional via *your* source MCP (no push, no sync)
- Slack recipe (read-only). Granola/Notion recipes no longer require the ingest MCP
- Ingest MCP tools accept `engagement` so they work when cwd is not the client folder
- README: honest week row, method matrix behind details, won't-build line matches pull

## Test plan
- [x] 93/93 tests including MCP engagement-arg
- [x] `node bin/check.js`

Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/40" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->