### PR TITLE
feat: 3.13.1 — slash commands for the four situations

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "url": "https://github.com/suboss87"
   },
   "metadata": {
-    "description": "Engagement memory for AI coding agents - one @fde skill, phase methods, and local .fde/ client memory."
+    "description": "Engagement memory for AI coding agents — one @fde skill, local .fde/ client record."
   },
   "plugins": [
     {
       "name": "fdeops",
       "source": "./",
-      "description": "Engagement memory for AI coding agents. One entry point that routes by situation (land, discover, build, rescue, ship, close), does the phase work, and keeps per-client memory - sponsor, promise, decision, acceptance, dated - in local .fde/ files. For Forward Deployed Engineers running several clients at once; healthcare, fintech, and government overlays included."
+      "description": "Engagement memory for AI coding agents. One @fde skill is the client record: the brief is wrong, they went quiet, when did we agree, what they got. Dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm. For Forward Deployed Engineers running several clients at once."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Engagement memory for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "category": "productivity",
   "tags": [
     "community-managed"
@@ -13,6 +13,8 @@
   "homepage": "https://github.com/suboss87/fdeops",
   "repository": "https://github.com/suboss87/fdeops",
   "license": "MIT",
+  "skills": "./skills",
+  "commands": "./.claude/commands",
   "keywords": [
     "engagement-memory",
     "agent-memory",

--- a/.claude/commands/agreed.md
+++ b/.claude/commands/agreed.md
@@ -1,0 +1,11 @@
+---
+description: When did we agree? — dated receipts, not memory
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**
+
+If unbound: ask the client name once, then **you** run `fde resume --init`.
+
+Do not argue from chat memory. Run `fde receipts <term>` (or `npx --yes fdeops receipts <term>`). Answer with dates. No hit is a gap, not proof.
+
+Not for TypeScript errors, unit tests, refactors, or git commits.

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,0 +1,12 @@
+---
+description: The brief is wrong — find the real problem before more code
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **the brief is wrong**.
+
+If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init`. Never tell the human to type it.
+
+Ask: "If this works, who in their company would have to agree that it worked?"
+Run `fde resume` (or `npx --yes fdeops resume`), then follow `references/discover.md`. Confirm before write.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -1,0 +1,11 @@
+---
+description: After a meeting — notes into the record, you confirm
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Highest-frequency loop: messy notes → proposed routing → human confirms → write.
+
+If unbound: ask the client name once, then **you** run `fde resume --init`. If they already pasted notes, go straight to debrief after bind.
+
+Prefer `fde debrief --smart` (or `npx --yes fdeops debrief --smart`). Rewrite the propose file with type prefixes where needed. Show the human the routing in plain language. Only `--apply` after they confirm. Never ask them to run the CLI. Detail: `references/debrief.md`.
+
+Not for TypeScript errors, unit tests, refactors, or git commits.

--- a/.claude/commands/got.md
+++ b/.claude/commands/got.md
@@ -1,0 +1,11 @@
+---
+description: What did they get? — promised, measured, accepted
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **what did they get?**
+
+If unbound: ask the client name once, then **you** run `fde resume --init`.
+
+Run `fde status` (or `npx --yes fdeops status`). Read the ledger out loud: promised → measured → accepted. A number nobody signed is claimed, not delivered. Then follow `references/status.md`. Confirm before write.
+
+Not for TypeScript errors, unit tests, refactors, or git commits.

--- a/.claude/commands/quiet.md
+++ b/.claude/commands/quiet.md
@@ -1,0 +1,12 @@
+---
+description: They went quiet — process gap vs trust problem
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.
+
+If unbound: ask the client name once, then **you** run `fde resume --init`.
+
+Ask: "Is this a process gap, or a trust problem?"
+Log the trust signal with `fde log contact "…" --signal amber|red|green` (or `npx --yes fdeops log …`). Then follow `references/rescue.md` for a trust fire. Confirm before write.
+
+Not for TypeScript errors, unit tests, refactors, or git commits.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - working in the fdeops repository
 
-This repository **is** fdeops - the second brain for Forward Deployed Engineers. One `@fde` skill routes an entire client engagement across six domains, the `fde` CLI does the deterministic work, and per-customer memory lands in `.fde/` files as a side effect of the work (you still confirm judgment).
+This repository **is** fdeops — the engagement record for Forward Deployed Engineers. One `@fde` skill, the `fde` CLI for deterministic work, and per-customer memory in `.fde/` as a side effect of the work (you still confirm judgment).
 
 ## If you are helping use fdeops in an engagement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.13.1 — 2026-08-28
+
+Slash commands for the four situations, and the nickname “four days” is gone from the front door.
+
+### Added
+- **Claude Code slash commands** — `/brief` `/quiet` `/agreed` `/got` `/debrief` load `@fde`. Same skill; a menu, not a second method pack.
+
+### Changed
+- **README week table** names the situation, the chat, and the slash command. “Why this exists” is four numbered problems, not land→build→close.
+- **Plugin** declares `skills` + `commands` in `.claude-plugin/plugin.json`.
+- **Dropped the “four days” nickname** on the public surface. The product is still those four situations; we just say them.
+
 ## 3.13.0 — 2026-08-28
 
 Four-day front: the skill is the engagement record, not a land-to-close operating system.

--- a/README.md
+++ b/README.md
@@ -8,40 +8,32 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
-One `@fde` skill. Four days on an embed:
-
-**the brief is wrong · they went quiet · when did we agree · what did they get**
-
-The host agent still writes the TypeScript, runs the tests, and makes the commits. This skill is the engagement record. Do not ask `@fde` to review a unit test.
-
-Talk in plain language. The AI coding agent runs the plumbing. You confirm anything that enters the record.
+One `@fde` skill. Say what is happening: the brief is wrong, they went quiet, when did we agree, what did they get. The host agent still writes the TypeScript. This skill is the engagement record.
 
 ---
 
 ## The week
 
-`@fde` plus English. No cheat sheet.
+What you are doing. `@fde` plus English — no cheat sheet. Claude Code also gets slash commands that load the same skill.
 
-| When | What you say | What you get |
-|------|--------------|--------------|
-| **The brief is wrong** | `@fde this is Acme. Brief says they want a portal.` | Real problem, or a gap. First chat: you name the client; the AI coding agent binds. |
-| **They went quiet** | `@fde the sponsor went quiet` | Trust signal in the record — process gap vs trust problem. |
-| **When did we agree?** | `@fde when did we agree to drop that?` | Dated receipts, or a clear gap. |
-| **What did they get?** | `@fde what did they get this week` | Friday ledger: promised → measured → accepted. |
-| **After a meeting** | `@fde` debrief these notes *(paste or attach)* | Proposed updates. You review, then confirm. |
-| **Optional: pull** | `@fde` connect Granola *(once)* · `@fde` pull today's Acme transcript | You add that source MCP. We **pull** on request — no push, no sync. [mcp/recipes/](mcp/recipes/) |
+| What you're doing | Command | Principle |
+|-------------------|---------|-----------|
+| **The brief is wrong** | `@fde this is Acme. Brief says they want a portal.` · `/brief` | Real problem before more code |
+| **They went quiet** | `@fde the sponsor went quiet` · `/quiet` | Process gap vs trust problem |
+| **When did we agree?** | `@fde when did we agree to drop that?` · `/agreed` | Dated receipts, or a gap |
+| **What did they get?** | `@fde what did they get this week` · `/got` | Promised → measured → accepted |
+| **After a meeting** | `@fde` debrief these notes *(paste)* · `/debrief` | Proposed updates. You confirm. |
+| **Optional: pull** | `@fde` connect Granola · `@fde` pull today's transcript | You add that source MCP. We **pull** on request. [mcp/recipes/](mcp/recipes/) |
 
-Same folder every time: `~/fde-engagements/<client>/.fde/`.
-
-**Words used here, once:** *engagement* - one client's body of work, one folder. *Fieldbook* - that folder (`.fde/`), the record itself. *Brief vs reality* - what they said the problem was, and what it turned out to be. *Terrain* - their systems and org as you actually found them. *Trust signal* - green / amber / red on one relationship. *Receipts* - the dated line proving something was agreed. *Vault* - the Obsidian copy `fde vault` generates to read it all in one window.
+First chat: you name the client; the AI coding agent binds. Same folder every time: `~/fde-engagements/<client>/.fde/`.
 
 ---
 
 ## Quickstart
 
-**1. Install** (30 seconds). Pick one — both copies `@fde` twice.
+**30-second setup.** Pick one — both copies `@fde` twice.
 
-Claude Code (hooks before you type):
+Claude Code (hooks before you type; slash commands `/brief` `/quiet` `/agreed` `/got` `/debrief`):
 
 ```text
 /plugin marketplace add suboss87/fdeops
@@ -54,7 +46,7 @@ Cursor, Codex, and any host that speaks the skills CLI:
 npx skills add suboss87/fdeops --skill fde
 ```
 
-**2. One chat.** Name the client. The AI coding agent binds the engagement; you never type the CLI.
+**Then one chat.** Name the client. The AI coding agent binds the engagement; you never type the CLI.
 
 ```text
 @fde this is Acme
@@ -85,6 +77,28 @@ npx fdeops resume               # where we are
 
 ---
 
+## Why this exists
+
+### 1. The brief is wrong
+
+The most common failure on an embed is building the portal they asked for. Ops has been running a spreadsheet for two years. `/brief` — one question: who in their company would have to agree it worked?
+
+### 2. They went quiet
+
+A sponsor who stops answering is not a Jira gap. It is a trust color. `/quiet` — process vs trust, then a dated signal in the record.
+
+### 3. When did we agree?
+
+Arguments from memory lose. `/agreed` searches dated receipts. No hit is a gap, not proof.
+
+### 4. What did they get?
+
+A number only you agree with is claimed, not delivered. `/got` reads promised → measured → accepted out loud.
+
+Ordinary TypeScript, unit tests, and git commits stay in the host agent. Do not ask `@fde` to review a unit test.
+
+---
+
 ## See it
 
 ```bash
@@ -103,32 +117,18 @@ Two things a chat window cannot do: **nothing is written until you confirm**, an
 
 ## How it works
 
-- **You** describe the situation with `@fde` (or plain language once the skill is loaded). First chat: you name the client; the AI coding agent runs the bind.
+- **You** describe the situation with `@fde` (or `/brief` `/quiet` `/agreed` `/got` `/debrief` on Claude Code). First chat: you name the client; the AI coding agent runs the bind.
 - **Hooks (Claude Code)** load where you left off and snapshot on the way out. Other hosts: same CLI and files; you call `@fde`.
 - **Local CLI** — writes, receipts, status. Zero model tokens. The AI coding agent runs it; you do not live in the CLI. Friday, `fde status` prints promised → measured → accepted. [docs/USAGE.md](docs/USAGE.md)
 - **Pull (optional)** — FDEOps is the sink. Paste is the daily path. A source MCP you add (Granola, Slack, Notion, …) can fetch text; `@fde connect …` walks config. No push, no sync, no tokens in `.fde/`. [mcp/recipes/](mcp/recipes/)
 
 `CLAUDE.md` is how the *code* works. The fieldbook is how the *engagement* works. The record lives at `~/fde-engagements/<client>/.fde/` — not inside any vendor.
 
+**Words used here, once:** *engagement* - one client's body of work, one folder. *Fieldbook* - that folder (`.fde/`), the record itself. *Brief vs reality* - what they said the problem was, and what it turned out to be. *Terrain* - their systems and org as you actually found them. *Trust signal* - green / amber / red on one relationship. *Receipts* - the dated line proving something was agreed. *Vault* - the Obsidian copy `fde vault` generates to read it all in one window.
+
 ### Switch coding agents anytime
 
 Change hosts, install `@fde` on the new one, bind if needed, keep talking. The client record does not move.
-
-<details>
-<summary>Engagement verbs</summary>
-
-| Verb | When |
-|------|------|
-| **land** | First days — brief, stakeholders, success |
-| **discover** | The brief is wrong — evidence from the repo |
-| **plan** | Sequence backwards from done, PR-sized |
-| log delivery | After the host agent codes — what shipped, how it rolls back |
-| **ship** | Pre-flight, canary, rollback |
-| **close** | Handoff, retro, receipts that survive you |
-
-Overlays (AI, fintech, healthcare, gov) fire on signal. [docs/skills.md](docs/skills.md)
-
-</details>
 
 ---
 
@@ -161,7 +161,7 @@ Local HTML: trust, phase, next, the record. `@fde` dashboard, or `npx fdeops das
 
 | You are | What this is |
 |---------|----------------|
-| **Forward Deployed Engineer** | The job this was built for — first meeting through handoff |
+| **Forward Deployed Engineer** | The job this was built for — client work that has to survive Monday morning |
 | **Consultant / contractor on site** | The engagement stops resetting every morning |
 | **Solutions architect** | Politics and architecture in the same record |
 | **Agency, 3–5 clients** | One `.fde/` each — they stop blurring |

--- a/bin/check.js
+++ b/bin/check.js
@@ -535,6 +535,16 @@ const plugin = JSON.parse(read('.claude-plugin/plugin.json'))
 if (pkg.version !== plugin.version) {
   fail(`version mismatch package.json ${pkg.version} vs plugin ${plugin.version}`)
 } else ok('plugin version aligned')
+if (plugin.commands !== './.claude/commands' || plugin.skills !== './skills') {
+  fail('.claude-plugin/plugin.json must declare skills and commands')
+} else {
+  for (const cmd of ['brief', 'quiet', 'agreed', 'got', 'debrief']) {
+    const rel = `.claude/commands/${cmd}.md`
+    if (!fs.existsSync(path.join(root, rel))) fail(`${rel} missing`)
+    else if (!read(rel).includes('@fde')) fail(`${rel} must load @fde`)
+  }
+  ok('slash commands load @fde')
+}
 
 if (!fs.existsSync(path.join(root, 'mcp', 'fdeops-ingest', 'server.js'))) {
   fail('mcp/fdeops-ingest/server.js missing (ingest MCP sink)')

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -2,8 +2,9 @@
 
 | Path | Purpose |
 |------|---------|
-| `skills/fde/` | **The one skill** - router (`SKILL.md`) + 31 routed methods, 5 overlays, and AI companion `eval-pack` under `references/` - installed to `~/.claude/skills/` |
-| `skills/fde/archive/sdlc/` | Archived SDLC methods (`build`, `debug`, `observability`, `qa-live`, `security-audit`, `test-on-legacy`) - kept for history, **not routed** |
+| `skills/fde/` | **The one skill** - router (`SKILL.md`) + 31 routed methods, 5 overlays, and AI companion `eval-pack` under `references/` |
+| `skills/fde/archive/sdlc/` | Archived SDLC methods — kept for history, **not routed** |
+| `.claude/commands/` | Slash commands for Claude Code (`/brief` `/quiet` `/agreed` `/got` `/debrief`) — thin prompts that load `@fde` |
 | `adapters/` | Thin per-tool pointers (Codex/`AGENTS.md`, Gemini, Cursor, Copilot, local LLMs) - `node bin/install.js adapters <dir>` |
 | `templates/.fde/` | Core memory templates for `fde resume --init` (phase artifacts are created by phases on demand; `evals.md` is optional) |
 | `examples/` | Fictional walkthroughs with sample `.fde/` files |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,7 +4,7 @@
 
 **Terminology:** [README § Who this is for](../README.md#who-this-is-for) - **"agent" = AI software, not a human.**
 
-**Start here:** [README](../README.md) (four days → 30-second install → one chat).
+**Start here:** [README](../README.md) (what is happening → 30-second install → one chat).
 
 Day-to-day reference below.
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -3,7 +3,7 @@
 One skill (`@fde`) routes by situation - you never pick a method by name. Three layers:
 
 1. **Daily** - prep, debrief, receipts, status, triage / doctor
-2. **Engagement** - four days (brief wrong, they went quiet, when did we agree, what they got) plus the methods below
+2. **Engagement** - brief wrong, they went quiet, when did we agree, what they got — plus the methods below
 3. **Overlays** - ai / fintech / healthcare / gov / artifacts (plus eval-pack as an AI companion)
 
 The full map is below; per-method details live in [skills-reference.md](./skills-reference.md).

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
-  "version": "3.13.0",
-  "description": "Engagement memory for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill for the four days of an embed, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
+  "version": "3.13.1",
+  "description": "Engagement memory for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",
     "fde": "bin/fde.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.13.0",
-  "description": "Engagement memory for AI coding agents: per-client memory in local .fde/ files, one @fde skill, the four days of an embed. Local-only, no network.",
+  "version": "3.13.1",
+  "description": "Engagement memory for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",
     "url": "https://github.com/suboss87"

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -7,19 +7,25 @@ description: Keeps engagement memory for client work - sponsor, promise, what sh
 
 ## Purpose
 
-This skill is the **engagement record** for one client — not a land-through-close operating system, and not a coding skill. Four days drive the work: the brief is wrong, they went quiet, when did we agree, what did they get. You read `.fde/`, route, do the judgment, **confirm with the FDE, then write**. The host agent writes the code; you log what they got.
+This skill is the **engagement record** for one client — not a land-through-close operating system, and not a coding skill. Lead with what is happening: the brief is wrong, they went quiet, when did we agree, what did they get. You read `.fde/`, route, do the judgment, **confirm with the FDE, then write**. The host agent writes the code; you log what they got.
 
 Every routed method still produces a concrete artifact in `.fde/`. The artifact is the deliverable AND the memory.
+
+## When to use
+
+- They named a client, pasted meeting notes, or asked what was agreed
+- The brief feels wrong, a sponsor went quiet, or Friday needs the ledger
+- A new embed, and `fde resume` is unbound — ask the name once, then **you** init
 
 ## When NOT to use
 
 `@fde` is the client record. Stay in the **host agent** for TypeScript errors, unit tests, refactors, git commits, and generic debug. Do not load `archive/sdlc/`. Agreed slice + code: implement in the host agent, then `fde log delivery`.
 
-## Four days (use these first)
+## Use these first
 
-Name the day, not the phase. Each moment: one sentence to say, one CLI verb, then stop. Coding, tests, and generic debug stay in the host agent.
+Name what's happening, not a phase. Each moment: one sentence to say, one CLI verb, then stop. Coding, tests, and generic debug stay in the host agent.
 
-| The day | Sentence to say | You run | Then read |
+| What's happening | Sentence to say | You run | Then read |
 |---------|-----------------|---------|-----------|
 | **The brief is wrong** | "If this works, who in their company would have to agree that it worked?" | `fde resume` then follow discover | `references/discover.md` |
 | **They went quiet** | "Is this a process gap, or a trust problem?" | `fde log contact "…" --signal amber\|red\|green` | `references/rescue.md` (trust fire) |
@@ -49,7 +55,7 @@ If you catch yourself saying "run `fde debrief --smart notes.txt`" to the human 
 1. Run `fde resume` (fallbacks, in order: `node ~/.claude/fdeops/fde.js resume`, then `npx --yes fdeops resume`). Bounded `context.md` only. `fde resume --full` if you genuinely need the whole log.
 2. If **NO ENGAGEMENT**: **do not leave them there.** Ask once: "What should we call this client?" Then **you** run `fde resume --init <slug>`. Never show them the command. After bind, if they pasted notes, go straight to debrief.
 3. Playback 2–3 lines from TRIAGE + bounded `context.md`. If TRIAGE has `hygiene:`, that is the one finding — offer `fde doctor`; **never auto-rewrite**. Else one line, ask where to pick up.
-4. Route (Four days, then the table below). Read **one** `references/*.md`. Confirm with the FDE, then write.
+4. Route (use-these-first table, then the six-domain table). Read **one** `references/*.md`. Confirm with the FDE, then write.
 
 **Path.** Workspace registry (written once by `fde resume --init <name>`) is the normal bind: env override → registry → pointer file → workspace-name match (read-only) → `./.fde`. Writes need a bind (or `FDEOPS_ENGAGEMENT`), not folder name alone. Never install fdeops on infrastructure the FDE does not control.
 

--- a/skills/fde/archive/sdlc/README.md
+++ b/skills/fde/archive/sdlc/README.md
@@ -4,4 +4,4 @@ These files used to sit in `references/` and compete with ordinary coding-agent 
 
 Keep them here for history. Do not load them for a TypeScript error, a unit test, or a deploy checklist — that work stays in the host agent.
 
-Routed FDE work is in `../references/` and the four days in `SKILL.md`.
+Routed FDE work is in `../references/` and the use-these-first table in `SKILL.md`.


### PR DESCRIPTION
## Summary
- Claude Code slash commands `/brief` `/quiet` `/agreed` `/got` `/debrief` load `@fde` (same skill, a menu).
- README week table names the situation, the chat, and the command. Plugin declares `skills` + `commands`.
- Dropped the “four days” nickname on the public surface — those four situations, said in English.

## Test plan
- [x] `node bin/check.js` green (includes slash-command gate)
- [x] `npm test` 121/121
- [ ] After merge: tag `v3.13.1` and confirm GitHub Actions / local `npm publish` so registry is 3.13.1


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/55" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->