### PR TITLE
docs: category line — forward deployed engineering skills for AI coding agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,13 +5,13 @@
     "url": "https://github.com/suboss87"
   },
   "metadata": {
-    "description": "Engagement memory for AI coding agents — one @fde skill, local .fde/ client record."
+    "description": "Forward deployed engineering skills for AI coding agents — one @fde skill, local .fde/ client record."
   },
   "plugins": [
     {
       "name": "fdeops",
       "source": "./",
-      "description": "Engagement memory for AI coding agents. One @fde skill is the client record: the brief is wrong, they went quiet, when did we agree, what they got. Dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm. For Forward Deployed Engineers running several clients at once."
+      "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record: the brief is wrong, they went quiet, when did we agree, what they got. Dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm. For Forward Deployed Engineers running several clients at once."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "description": "Engagement memory for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
+  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
   "version": "3.13.1",
   "category": "productivity",
   "tags": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+- **Category line** — Forward deployed engineering skills for AI coding agents.
+
 ## 3.13.1 — 2026-08-28
 
 Slash commands for the four situations, and the nickname “four days” is gone from the front door.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # FDEOps
 
-**The AI coding agent forgets the client. fdeops is the countersigned record — promised, measured, accepted.**
+**Forward deployed engineering skills for AI coding agents.**
+
+The AI coding agent forgets the client. fdeops is the countersigned record — promised, measured, accepted.
 
 [![npm version](https://img.shields.io/npm/v/fdeops.svg)](https://www.npmjs.com/package/fdeops)
 [![CI](https://github.com/suboss87/fdeops/actions/workflows/validate.yml/badge.svg)](https://github.com/suboss87/fdeops/actions)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "version": "3.13.1",
-  "description": "Engagement memory for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
+  "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",
     "fde": "bin/fde.js"

--- a/plugin.json
+++ b/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
   "version": "3.13.1",
-  "description": "Engagement memory for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
+  "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",
     "url": "https://github.com/suboss87"


### PR DESCRIPTION
## Summary
- README, npm, and plugin descriptions lead with **Forward deployed engineering skills for AI coding agents.**
- GitHub About is already that line (was still “second brain” + land-through-handoff).

One `@fde` skill. Not a 24-pack.

## Test plan
- [x] `node bin/check.js` green
- [x] GitHub About updated
- [ ] Merge so README on Main matches About


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/56" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->