### PR TITLE
feat: 3.13.2 — one skill, tighter router

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
-## Unreleased
+## 3.13.2 — 2026-08-28
 
 ### Changed
 - **Category line** — Forward deployed engineering skills for AI coding agents.
+- **One skill, tighter router** — `@fde` is the brain; slash commands are the menu; methods stay references. The human never picks a skill.
 
 ## 3.13.1 — 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ The AI coding agent forgets the client. fdeops is the countersigned record — p
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
-One `@fde` skill. Say what is happening: the brief is wrong, they went quiet, when did we agree, what did they get. The host agent still writes the TypeScript. This skill is the engagement record.
+One `@fde` skill. The AI coding agent picks the method. You confirm the record. The host agent still writes the TypeScript.
 
 ---
 
 ## The week
 
-What you are doing. `@fde` plus English — no cheat sheet. Claude Code also gets slash commands that load the same skill.
+What you are doing. English, or a slash command. One skill — you never pick a method.
 
 | What you're doing | Command | Principle |
 |-------------------|---------|-----------|

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -7,154 +7,103 @@ description: Keeps engagement memory for client work - sponsor, promise, what sh
 
 ## Purpose
 
-This skill is the **engagement record** for one client — not a land-through-close operating system, and not a coding skill. Lead with what is happening: the brief is wrong, they went quiet, when did we agree, what did they get. You read `.fde/`, route, do the judgment, **confirm with the FDE, then write**. The host agent writes the code; you log what they got.
-
-Every routed method still produces a concrete artifact in `.fde/`. The artifact is the deliverable AND the memory.
+The **engagement record** for one client. Not a coding skill. Not a land-through-close OS. You pick the method; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript; you log what they got. The artifact is the memory.
 
 ## When to use
 
-- They named a client, pasted meeting notes, or asked what was agreed
+- They named a client, pasted notes, or asked what was agreed
 - The brief feels wrong, a sponsor went quiet, or Friday needs the ledger
-- A new embed, and `fde resume` is unbound — ask the name once, then **you** init
+- Unbound — ask the name once, then **you** run `fde resume --init`
 
 ## When NOT to use
 
-`@fde` is the client record. Stay in the **host agent** for TypeScript errors, unit tests, refactors, git commits, and generic debug. Do not load `archive/sdlc/`. Agreed slice + code: implement in the host agent, then `fde log delivery`.
+TypeScript errors, unit tests, refactors, git commits, generic debug: **host agent**. Do not load `archive/sdlc/`. Agreed slice + code: implement in the host, then `fde log delivery`.
 
 ## Use these first
 
-Name what's happening, not a phase. Each moment: one sentence to say, one CLI verb, then stop. Coding, tests, and generic debug stay in the host agent.
-
 | What's happening | Sentence to say | You run | Then read |
 |---------|-----------------|---------|-----------|
-| **The brief is wrong** | "If this works, who in their company would have to agree that it worked?" | `fde resume` then follow discover | `references/discover.md` |
-| **They went quiet** | "Is this a process gap, or a trust problem?" | `fde log contact "…" --signal amber\|red\|green` | `references/rescue.md` (trust fire) |
+| **The brief is wrong** | "If this works, who in their company would have to agree that it worked?" | `fde resume` then discover | `references/discover.md` |
+| **They went quiet** | "Is this a process gap, or a trust problem?" | `fde log contact "…" --signal amber\|red\|green` | `references/rescue.md` |
 | **When did we agree?** | Don't argue from memory. Search the record. | `fde receipts <term>` | — |
-| **What did they get?** | Read the ledger out loud. A number nobody signed is claimed, not delivered. | `fde status` | `references/status.md` |
+| **What did they get?** | A number nobody signed is claimed, not delivered. | `fde status` | `references/status.md` |
 
-After a meeting, still: `fde debrief --smart` → confirm → `--apply`. Before a walk-in: `fde prep`. Friday: `fde status` (promised → measured → accepted). Notes: dated, sourced, one customer.
+After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde prep`. Friday: `fde status`.
 
-## Audience
+## Human surface vs agent plumbing
 
-- **FDE** = the **human** who types `@fde` (or plain language) in the chat.
-- **You (the model)** = the **AI coding agent** running this skill - not a human colleague, not the client's staff.
+**FDE (human):** `@fde` + English, or `/brief` `/quiet` `/agreed` `/got` `/debrief`. Never a skill catalog.
 
-When this skill says "ask the FDE," it means the human. When it says "write to `.fde/`," you (the AI) write the files.
+**You (agent):** run the CLI. **Never tell the FDE to type** `fde …`. If unbound, you run `fde resume --init` after one question. Never ask them to run the CLI.
 
-## Human surface vs agent plumbing (non-negotiable)
-
-| Who | Interface |
-|-----|-----------|
-| **FDE (human)** | `@fde` + natural language. Examples: "debrief these notes", "prep me for tomorrow's sponsor meeting", "when did we agree to drop that?", "draft the sponsor update". |
-| **You (agent)** | Run the local `fde` CLI for deterministic memory work. Never tell the FDE to type `fde …` (except if setup is missing - then **you** run `fde resume --init <name>` after one clarifying question). |
-
-If you catch yourself saying "run `fde debrief --smart notes.txt`" to the human - **stop**. Run it yourself (or write a temp notes file and run it), then show the human the result in plain language for confirm/reject.
+Fallbacks: `node ~/.claude/fdeops/fde.js …`, then `npx --yes fdeops …`. Skill-only install is not "unavailable."
 
 ## Entry (every session)
 
-1. Run `fde resume` (fallbacks, in order: `node ~/.claude/fdeops/fde.js resume`, then `npx --yes fdeops resume`). Bounded `context.md` only. `fde resume --full` if you genuinely need the whole log.
-2. If **NO ENGAGEMENT**: **do not leave them there.** Ask once: "What should we call this client?" Then **you** run `fde resume --init <slug>`. Never show them the command. After bind, if they pasted notes, go straight to debrief.
-3. Playback 2–3 lines from TRIAGE + bounded `context.md`. If TRIAGE has `hygiene:`, that is the one finding — offer `fde doctor`; **never auto-rewrite**. Else one line, ask where to pick up.
-4. Route (use-these-first table, then the six-domain table). Read **one** `references/*.md`. Confirm with the FDE, then write.
+1. `fde resume` (bounded `context.md`). `--full` only if you need the whole log.
+2. **NO ENGAGEMENT:** ask "What should we call this client?" then **you** init. Pasted notes → debrief after bind.
+3. Playback 2–3 lines. `hygiene:` → offer `fde doctor`; **never auto-rewrite**.
+4. Route. Read **one** `references/*.md`. Confirm, then write.
 
-**Path.** Workspace registry (written once by `fde resume --init <name>`) is the normal bind: env override → registry → pointer file → workspace-name match (read-only) → `./.fde`. Writes need a bind (or `FDEOPS_ENGAGEMENT`), not folder name alone. Never install fdeops on infrastructure the FDE does not control.
+Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on infrastructure they do not control.
 
-**You run the `fde` CLI for deterministic work - never improvise shell, never hand the command to the FDE:**
+| They say | You run |
+|----------|---------|
+| where are we | `fde resume` |
+| day-1 look at the repo | `fde scan` |
+| debrief / pasted notes | `fde debrief --smart` → you rewrite prefixes → confirm → `--apply`. `--smart` is a gate, not a brain. `references/debrief.md` |
+| prep me for … | `fde prep "<label>"` |
+| when did we agree | `fde receipts <term>` |
+| sponsor update / what they got | `fde status` |
+| they went quiet | `fde log contact "…" --signal amber\|green\|red` |
+| fieldbook page | `fde dashboard` |
+| clean up the fieldbook | `fde doctor` — never auto-rewrite |
+| scrub a secret | `fde redact <term>` then `--apply` after confirm |
+| pull Granola/Slack/transcript | capability check → `fde ingest stage` → confirm → apply. Never auto-apply. `references/ingest.md` |
+| connect an MCP | `references/ingest-connect.md` |
+| Obsidian / one window | `fde vault` (`--redacted` for a shared screen) |
 
-| When the FDE says (approx.) | You run |
-|-----------------------------|---------|
-| (session entry / where are we) | `fde resume` or use injected TRIAGE; `fde resume --init <name>` only if unbound |
-| Day-1 look at the repo | `fde scan` - then you interpret against the brief |
-| "Debrief these notes" / pastes meeting notes | Prefer `fde debrief --smart <notes>` → **you** (the agent) rewrite `.debrief-propose` with `decision:`/`risk:`/`delivery:`/`contact:`/`next:` prefixes where needed → show FDE → on confirm `fde debrief --apply`. `--smart` is a prefix/keyword gate, not a brain. Fallback: structure prefixed lines yourself, show FDE, then `fde debrief` |
-| "Make sure we're up to date" / "pull relevant info" / "pull from Granola/Slack/transcript" | Bind engagement; **capability check** (which *source* MCPs exist — never pretend). If missing → connect flow. Else fetch text → `fde ingest stage` **in this workspace** → propose → rewrite prefixes → show FDE → on confirm `fde ingest apply`. MCP sink is optional; if used, pass `engagement` from `fde resume --bind`. **Never auto-apply. Never push. Never ambient sync.** Detail: `references/ingest.md` |
-| "Connect a new MCP" / "connect Granola/Slack/Notion" / "what can you pull?" | Follow `references/ingest-connect.md`: source MCP only; sink is `fde ingest` here. They save/reload; you cannot silent-install. Paste still works with no MCP. |
-| "Prep me for the meeting with …" / walk-in brief | `fde prep "<short label>"` - present the brief in plain language; do not invent facts missing from `.fde/` |
-| "When did we agree…?" / scope dispute | `fde receipts <term>` - answer with dates; no hit = gap, not proof |
-| "Draft the sponsor update" / how are we doing | `fde status` (value ledger first) then follow `references/status.md` |
-| "Log that they went quiet" / trust signal | `fde log contact "…" --signal amber\|green\|red`. If they already named the color ("log that as amber"), that is the confirm — write it. If they only described the situation, playback the color once, then write. |
-| Want the HTML fieldbook | `fde dashboard` |
-| "Open my clients in Obsidian" / one window over everything / "can I show this to the sponsor?" | `fde vault` (add `--redacted` for a shared screen). Derived and disposable: rebuilt from `.fde/` on every run and never read back. Keep logging to the fieldbook, not the vault. |
-| "Clean up the fieldbook" / hygiene / memory feels messy | `fde doctor` - walk issues in plain language; propose fixes; never auto-rewrite without confirm. Includes structural gaps: empty operating map (plan+), stakeholder name forks (Denise vs Denise Chen), duplicates, ship/close risks. Contradictions need judgment (brief vs reality) - doctor is structural; you handle meaning. `fde tidy` proposes safe consolidations (no new facts). |
-| "Scrub this secret / redact that token" (buried line, not just last write) | `fde redact <term>` preview, then `fde redact <term> --apply` after confirm. Undo is last-write only; redact is for buried lines. Remind them to rotate the real credential. |
+## The memory contract
 
-**The debrief verb.** Highest-frequency loop. When the FDE shares notes or says "debrief": **you** run the smart path (write notes to a temp file if needed). `--smart` writes a propose file via deterministic heuristics (existing prefixes + light keywords); authentic rambling notes often land mostly in context until **you** rewrite lines with type prefixes. Show the proposed routing in plain language. Only `--apply` (or pipe prefixed lines) after they confirm. Never ask them to run the CLI. Detail: `references/debrief.md`.
-
-CLI genuinely unavailable (no Node, offline, npx blocked) → use the manual fallbacks inside each reference (still you write files; still never ask the FDE to run setup). A skill-only install is not "unavailable": run the verb through `npx --yes fdeops …` so the gates, dating and redaction still hold.
-
-**Tokens.** CLI work is free. Hooks inject TRIAGE + bounded `context.md` + a pointer — never this full skill (loads on `@fde`). Pull **one** reference when you route; never dump a whole `.fde/` file — bounded resume, or `fde receipts <term>`.
-
-## Anti-invention gates (field anti-slop)
-
-These stop confident fiction. They are not optional soft tips.
-
-| Temptation | Gate |
-|------------|------|
-| Tell the FDE to run `fde debrief` / `fde prep` / `fde receipts` themselves | **Stop.** You run the CLI; they confirm results in plain language. |
-| Invent a stakeholder, meeting, or quote to make the narrative rich | **Stop.** Write `unknown - ask: <question>`. One fake name poisons every real citation. |
-| Route to a phase because it "feels senior" while the signal is muddy | **Stop.** Playback + one natural question, or name the ambiguity ("discover or rescue — leaning X because…"). |
-| Fill `success.md` / `terrain.md` with plausible defaults when the brief is thin | **Stop.** Run **brief interrogation** in land/discover (one Q + GUESS + confidence) until you can write without guessing, or leave gaps explicit. |
-| Ship / go-live / irreversible change with "probably fine" | **Stop.** Run **intent vs diff** (KEEP/JUSTIFY/SPLIT/DROP) then **pre-blast challenge** in ship (or red-team) — CLAIM → CHALLENGE → VERDICT — and log both. |
-| Grill the FDE with a checklist when they're mid-flow | **Stop.** Playback rule wins. Probe only when a missing fact changes the next move. |
-| Sync chat transcripts / agent brain folders into the product git repo for "team share" | **Stop.** Run **session digest** into `.fde/` (judgment only). Transcripts stay local. |
-
-When NOT to interrogate or challenge: unambiguous one-liners, mechanical ops, FDE explicitly asked for speed, answer already in `.fde/`.
-
-## The memory contract (non-negotiable)
-
-This is what makes fdeops a second brain instead of a chat window.
-
-1. **On entry:** resolve the engagement path and read `context.md` via `fde resume` (a bounded view - current state + recent activity). Nothing else until the routed phase needs it; pull other `.fde/` files only when the phase calls for them.
-2. **Deliverable = memory.** The output of every phase IS a `.fde/` file. You never ask the FDE to "update their notes" - producing the work and writing the memory are one action. The phase reference tells you which file.
-3. **Evidence rule.** Every claim in an artifact carries its source: `(validated with: ops lead, Day 5)`, `(churn: 47 commits/90d)`, `(stated, unverified)`. The FDE defends these files in front of skeptical clients - traceable beats plausible.
-4. **No invented facts - ever.** People, names, quotes, meetings, and numbers exist only if the FDE said them or the repo shows them. Never invent a stakeholder, a conversation, or a source to make the narrative richer - one fabricated name poisons every real citation around it. A missing fact is written as `unknown - ask: <the question>`, nothing else.
-5. **On exit (session digest):** before the session ends — and again before opening a PR — capture the *thinking*, not the chat. Propose this digest in plain language; on FDE confirm, write into existing `.fde/` files (never a transcript dump, never a product-repo history folder):
+1. **On entry:** `fde resume` only. Pull other `.fde/` files when the method needs them.
+2. **Deliverable = memory.** The work *is* the `.fde/` file. The reference names which one.
+3. **Evidence.** Every claim has a source. Traceable beats plausible.
+4. **No invented facts.** People, quotes, meetings, numbers: they said it or the repo shows it. Else `unknown - ask: <question>`.
+5. **Session digest** (end of session and before a PR) — thinking, not the chat. Confirm, then write. Never a transcript dump.
 
    | Digest beat | Lands in |
    |-------------|----------|
-   | **TL;DR** (1–2 sentences: what moved) | `context.md` current state / short dated note |
-   | **Key decisions & why** (only real ones) | `decisions.md` dated lines — skip if none |
-   | **Pivot / aha** (course correction that mattered) | one line in `context.md`, or `decisions.md` if it changed the plan |
-   | **Scope + verification** (files/slice + how you checked) | `delivery.md` when code or a PR is in play; else skip |
-   | **Gotchas for the next reader** | `context.md` (teammate / Monday-you) |
-   | **Next action** | existing `## Next action` — **replace** the bullet; never append a second heading |
+   | **TL;DR** | `context.md` |
+   | **Key decisions & why** | `decisions.md` — skip if none |
+   | **Pivot / aha** | `context.md` or `decisions.md` |
+   | **Scope + verification** | `delivery.md` if code/PR; else skip |
+   | **Gotchas** | `context.md` |
+   | **Next action** | existing `## Next action` — **replace**; never append a second heading |
 
-   The `session-stop` hook backstops a thin snapshot; **you** write the meaningful digest. Raw agent transcripts stay on the machine — judgment is what ships in the fieldbook.
-6. **One customer, one folder.** Never merge two engagements into one `.fde/`. Confirm which engagement applies when multiple exist.
-7. **Never delete a code-read section when rewriting an artifact.** `stakeholders.md`'s `## Signal history` holds dated `[signal:...]` tokens that `fde status`/`fde receipts`/the dashboard read verbatim; `risks.md`'s `## Retired` is read the same way. Rewriting either file as an artifact (land, audit, stakeholder-radar) is fine - dropping one of these sections is not. Carry existing entries forward untouched.
+   Judgment ships in the fieldbook. Raw transcripts stay on the machine. The `session-stop` hook is a thin backstop; **you** write the digest.
 
-## Data boundary (confirm before touching their code)
+6. **One customer, one folder.**
+7. Never drop `## Signal history` or `## Retired` when rewriting those files.
 
-- The `fde` CLI is **local only** - `git` + file reads, no AI, no network. Safe in any environment.
-- **You (the AI) only ever see customer code when the FDE points you at it** inside the agent they are already authorized to run. fdeops adds no new data path.
-- **Before reading or generating against customer code, the AI policy must be known.** New engagement, policy unknown → ask it (land phase: "policy on AI-generated code? data that must never touch AI?") *before* loading their code into context. Default to "not permitted" until the FDE confirms.
-- Data tagged `<private>` (sacred data, PHI, cardholder, classified) is **redacted from CLI, dashboard, and hook-injected context**. Do **not** open raw `<private>` blocks with file tools (that bypasses redaction) or paste them into prompts/subagents - work around them, never with them.
-- Locked-down engagement (no AI on their code)? Use the CLI + the fieldbook only. The memory layer is the FDE's own notes, not customer code.
+**Don't invent.** Don't tell them to run the CLI. Don't fill `success.md` / `terrain.md` with guesses. Don't ship on "probably fine" — intent vs diff, then pre-blast. Don't grill mid-flow. Don't sync transcripts into git.
+
+## Data boundary
+
+CLI is local (`git` + files, no network). You see their code only when they point you at it. AI policy unknown → ask before loading code. `<private>` is redacted from CLI/dashboard/hooks — do not open raw private blocks with file tools.
 
 ## Voice
 
-Direct, their words, no "Certainly." Playback 2–4 lines before you act. One sharp question only when a missing fact changes the next move. After writing memory, one directed next move; skip if they're already in flow.
+Direct. Their words. No "Certainly." Playback 2–4 lines, then act. One question only when a missing fact changes the next move.
 
-Ask once on a new engagement: days, weeks, or months of runway? **Sprint** (1–2 days) skip ceremony; **Standard** (1–4 weeks) full sequence; **Programme** (months) plus political mapping and formal handoff. Speed changes depth, not which phases exist.
+New embed: sprint / standard / programme changes depth, not which methods exist. Before first code: safe place to break things, plus AI-code policy. Before go-live: who needs to know, what's the rollback. Before a sponsor artifact: as-is or gut-check first.
 
-### Checkpoint — one question before you cross a line
-
-| Before you… | Ask |
-|-------------|-----|
-| touch their code the first time | "Is there a safe place to break things, or am I in production?" — plus AI-code policy if unknown |
-| deploy or go live | "Who needs to know this is shipping, and what's the rollback if it turns?" |
-| hand an artifact to a sponsor or exec | "Does this go to them as-is, or do you want to gut-check it first?" |
-| act on a pivot (budget cut, new CTO, reprioritisation) | "Is the old plan dead, or just paused?" |
-| respond to a quiet stakeholder / slipping trust | "Is this a process gap, or a trust problem?" |
-
-If `context.md` already answers it, don't ask again.
+Muddy signal: name it ("discover or rescue — leaning X"). Never a phase-picker interview. Default: land if new, audit if takeover.
 
 ## Routing - 6 domains
 
-Route on what you hear, then **read the skill reference from this skill's `references/` directory and follow its method**. Do not improvise from memory - the method is the product.
+Read **one** reference and follow it. Do not improvise from memory.
 
 ### Domain 1 - Embed & Trust
-
-The first days. Getting access, building credibility, understanding the real scope.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
@@ -166,8 +115,6 @@ The first days. Getting access, building credibility, understanding the real sco
 
 ### Domain 2 - Discover & Diagnose
 
-Finding the real problem. Testing what the brief claims.
-
 | You hear | Skill | Reference |
 |----------|-------|-----------|
 | Don't know the real problem, brief feels wrong, shadow processes | discover | `references/discover.md` |
@@ -176,8 +123,6 @@ Finding the real problem. Testing what the brief claims.
 | Need to validate a direction, prototype, demo to de-risk | sketch | `references/sketch.md` |
 
 ### Domain 3 - Plan & Align
-
-Sequencing work and getting alignment from sponsors.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
@@ -188,8 +133,6 @@ Sequencing work and getting alignment from sponsors.
 
 ### Domain 4 - Build & Guard
 
-Safe implementation on someone else's codebase.
-
 | You hear | Skill | Reference |
 |----------|-------|-----------|
 | Large feature, need visible progress every 2–3 days | incremental-build | `references/incremental-build.md` |
@@ -197,8 +140,6 @@ Safe implementation on someone else's codebase.
 | Production down, urgent - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
 
 ### Domain 5 - Ship & Verify
-
-Getting to production without surprises.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
@@ -209,8 +150,6 @@ Getting to production without surprises.
 | "We can always revert" - need to actually test the escape route | rollback-drill | `references/rollback-drill.md` |
 
 ### Domain 6 - Operate & Close
-
-Running the engagement and ending it well.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
@@ -240,38 +179,13 @@ Running the engagement and ending it well.
 | Payments, cardholder data, PCI-DSS, anything that moves money | `references/fintech.md` |
 | Government agency, FedRAMP, ATO, CUI, classified | `references/gov.md` |
 
-## Think before you route
-
-Do not interview them as an intake form. Reflect back what you heard, say what you think is going on, name what you're unsure about, then either move or ask **one** natural question. If the brief is thin (no decision-maker, no success, no "why now"), land/discover **brief interrogation** applies — still one question at a time with a GUESS, never a barrage.
-
-Bad: "Are you in phase land, discover, build, or rescue?"
-Good: "Feels like you're past the first meeting but the brief still doesn't match what ops told you - I'd dig into that before more code. Unless production's actually on fire?"
-
-If the situation maps to multiple skills or none clearly: say so. "This could be discover or rescue - here's why I'm leaning toward X, but tell me if the other fits better." Named uncertainty beats a confident wrong answer. Never silently guess when the signal is ambiguous. See **Anti-invention gates**.
-
-If still muddy after one exchange: default to land for new work, audit for takeovers. Ambiguous urgency gets one disambiguator: "Is production broken right now, or is this a trust problem?"
-
-## Health check
-
-If the FDE says "how are we doing" / "are we on track": load `reality.md`, `risks.md`, `delivery.md`, `stakeholders.md` (not `trust-profile.md` - sensitive data isn't needed for a status read). Four lines, red/amber/green:
-
-- Real problem still matches `reality.md`, or has scope crept?
-- Any stakeholder signal going amber or red?
-- Any risk overdue for action?
-- Value delivered and logged in `delivery.md`?
-
-## Operational edge cases
-
-- **`.fde/` exists but `context.md` is empty:** treat as new session - ask what's happening.
-- **"Ready to build" but no `terrain.md` or plan in `decisions.md`:** route to discover or plan first. Never start code blind. Agreed slice + code work: **you implement in the host agent**; log delivery with `fde log delivery`. Do not load archived SDLC sermons (`archive/sdlc/`).
-- **Taking over mid-flight without `audit.md`:** audit before build.
-- **Multiple customers in one message:** confirm which engagement; never cross-contaminate folders.
+Ready to build with no `terrain.md` / plan: discover or plan first. Takeover without `audit.md`: audit first. Two customers in one message: confirm which folder.
 
 ## Principles
 
 - Never ask the FDE to pick a phase. That's your job.
-- Read `context.md` before speaking. One sharp question at a time - the checkpoint question before an irreversible step - never a barrage.
-- Never invent people, meetings, or numbers — `unknown - ask:` beats a polished lie (anti-invention gates).
+- Read `context.md` before speaking. One sharp question — never a barrage.
+- Never invent people, meetings, or numbers — `unknown - ask:` beats a polished lie.
 - Every phase ends with its artifact written. No artifact, no "done."
 - Evidence on every claim. The FDE will be challenged on these files.
 - Overlays activate on signal, not on request.


### PR DESCRIPTION
## Summary
- One `@fde` skill. The agent picks the method; the human never shops a catalog.
- SKILL.md is a router (~192 lines), not a second OS. 31 methods stay references. Slash commands stay the menu.
- Version 3.13.2. Category line already on Main: Forward deployed engineering skills for AI coding agents.

## Test plan
- [x] `node bin/check.js` green
- [x] `node evals/skill-routing/check.js` PASS
- [ ] After merge: tag `v3.13.2` and `npm publish --access public` (npm is still 3.13.0; Actions still lacks NPM_TOKEN)


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/57" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->