### PR TITLE
feat: 3.14.0 — command map and method cards

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.13.2",
+  "version": "3.14.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/agreed.md
+++ b/.claude/commands/agreed.md
@@ -4,8 +4,18 @@ description: When did we agree? — dated receipts, not memory
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**
 
-If unbound: ask the client name once, then **you** run `fde resume --init`.
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Do not argue from chat memory. Run `fde receipts <term>` (or `npx --yes fdeops receipts <term>`). Answer with dates. No hit is a gap, not proof.
+Do not argue from chat memory. Search the record.
 
-Not for TypeScript errors, unit tests, refactors, or git commits.
+Run `fde receipts <term>` (fallback: `npx --yes fdeops receipts <term>`). Use the term the human named — topic, person, deliverable, or date window.
+
+Answer with dated receipts: who said it, when, and where it lives in `.fde/`. No reference file needed unless the hit spans multiple files.
+
+No hit is a gap, not proof. Say so plainly and ask one question that would close the gap.
+
+Do not invent meetings, quotes, or commitments. If the record is silent, the answer is "not in the record yet."
+
+Done when: you have cited dated receipts for the term or named the specific gap to fill.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,12 +1,19 @@
 ---
-description: The brief is wrong — find the real problem before more code
+description: The brief is wrong — find who must agree before more code
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **the brief is wrong**.
 
-If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init`. Never tell the human to type it.
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Ask: "If this works, who in their company would have to agree that it worked?"
-Run `fde resume` (or `npx --yes fdeops resume`), then follow `references/discover.md`. Confirm before write.
+Say: "If this works, who in their company would have to agree that it worked?"
+
+Run `fde resume` (fallback: `npx --yes fdeops resume`) to load bounded context. Read `references/discover.md` and follow it — shadow processes, real problem, not the slide deck.
+
+Playback 2–3 lines: who decides, what you think the real problem is, and the next move. Confirm before any write to `.fde/`.
+
+Do not invent stakeholders or quotes. Missing names → `unknown - ask: <question>`.
+
+Done when: you have named the acceptance owner and a discover next step the human agrees to.
 
 Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -1,11 +1,21 @@
 ---
-description: After a meeting — notes into the record, you confirm
+description: After a meeting — notes into the record, human confirms
 ---
 
-Load `@fde` (`skills/fde/SKILL.md`). Highest-frequency loop: messy notes → proposed routing → human confirms → write.
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **after a meeting**.
 
-If unbound: ask the client name once, then **you** run `fde resume --init`. If they already pasted notes, go straight to debrief after bind.
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI. If they already pasted notes, bind first, then debrief.
 
-Prefer `fde debrief --smart` (or `npx --yes fdeops debrief --smart`). Rewrite the propose file with type prefixes where needed. Show the human the routing in plain language. Only `--apply` after they confirm. Never ask them to run the CLI. Detail: `references/debrief.md`.
+Run `fde debrief --smart` (fallback: `npx --yes fdeops debrief --smart`). `--smart` is a gate, not a brain — it proposes routing; you still judge.
 
-Not for TypeScript errors, unit tests, refactors, or git commits.
+Rewrite the propose output: add type prefixes where the record needs them. Strip noise; keep their words for quotes and decisions.
+
+Present the routing in plain language: what lands where in `.fde/`, what changed, what is still open. One screen, not a transcript dump.
+
+Only run `fde debrief --apply` (fallback: `npx --yes fdeops debrief --apply`) after the human confirms. Never auto-apply.
+
+Read `references/debrief.md` for prefix rules, file targets, and digest beats.
+
+Done when: the human confirmed the routing and `--apply` wrote the agreed `.fde/` updates.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/got.md
+++ b/.claude/commands/got.md
@@ -4,8 +4,18 @@ description: What did they get? — promised, measured, accepted
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **what did they get?**
 
-If unbound: ask the client name once, then **you** run `fde resume --init`.
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Run `fde status` (or `npx --yes fdeops status`). Read the ledger out loud: promised → measured → accepted. A number nobody signed is claimed, not delivered. Then follow `references/status.md`. Confirm before write.
+Say: "A number nobody signed is claimed, not delivered."
 
-Not for TypeScript errors, unit tests, refactors, or git commits.
+Run `fde status` (fallback: `npx --yes fdeops status`). Read the ledger out loud in order: **promised → measured → accepted**.
+
+Call out gaps: promised but not measured, measured but not accepted, accepted without a named signer. Do not smooth over missing acceptance.
+
+Read `references/status.md` and follow it for how to present the ledger and what to offer next.
+
+Do not invent metrics or sign-off. Numbers without a source in `.fde/` stay `unknown - ask: <question>`.
+
+Done when: the human hears the three-beat ledger and agrees what is actually delivered vs still claimed.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,0 +1,21 @@
+---
+description: Walk-in prep — plain-language readout from the record
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+Take the meeting label from what they said — sponsor sync, steering committee, demo, etc.
+
+Run `fde prep "<label>"` (fallback: `npx --yes fdeops prep "<label>"`). Use their exact label in quotes.
+
+Present the output in plain language: who matters, what was promised, what shipped, open risks, suggested talking points. Lead with what they need to say, not file names.
+
+Do not invent facts missing from `.fde/`. People, numbers, and quotes must come from the record or the repo they pointed at — else mark `unknown - ask: <question>`.
+
+Offer one focused question only if a missing fact changes the prep.
+
+Done when: the human has a spoken-ready prep from the record and knows what is still unknown.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/quiet.md
+++ b/.claude/commands/quiet.md
@@ -1,12 +1,21 @@
 ---
-description: They went quiet — process gap vs trust problem
+description: They went quiet — process gap or trust problem
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.
 
-If unbound: ask the client name once, then **you** run `fde resume --init`.
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Ask: "Is this a process gap, or a trust problem?"
-Log the trust signal with `fde log contact "…" --signal amber|red|green` (or `npx --yes fdeops log …`). Then follow `references/rescue.md` for a trust fire. Confirm before write.
+Say: "Is this a process gap, or a trust problem?"
 
-Not for TypeScript errors, unit tests, refactors, or git commits.
+Run `fde resume` (fallback: `npx --yes fdeops resume`) for recent signal history and open threads.
+
+Log the contact with `fde log contact "<who and what happened>" --signal amber|red|green` (fallback: `npx --yes fdeops log contact "…" --signal …`). Pick the signal from what they said — do not guess.
+
+If this is a trust fire (ghosting, blocked access, sponsor disengaged): read `references/rescue.md` and follow it. If it is a process gap, name the missing step and the smallest unblock.
+
+Playback the signal and next move. Confirm before any write to `.fde/`.
+
+Done when: the contact is logged with a signal and you have a rescue or process next step the human agrees to.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,0 +1,21 @@
+---
+description: Friday sponsor update — value ledger first
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+This is for the sponsor-facing update — not a standup or a code review.
+
+Run `fde status` (fallback: `npx --yes fdeops status`). Lead with the **value ledger**: promised → measured → accepted. That is what the sponsor cares about first.
+
+Read `references/status.md` and follow it for update shape, gaps to call out, and what to offer next.
+
+Name what is delivered vs still claimed. Flag acceptance missing a named signer. Surface one trust or scope signal if the record shows amber or red.
+
+Draft the update in their voice — short, factual, no invented wins. Confirm before any write to `.fde/`.
+
+Done when: the human has a sponsor-ready update grounded in the ledger and agrees what to send or say.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.14.0 — 2026-08-28
+
+### Changed
+- **Command map on the front door** — four situations as a map, then slash commands as method cards. `/prep` and `/status` added. The 31 methods stay in a details block.
+
 ## 3.13.2 — 2026-08-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -10,21 +10,30 @@ The AI coding agent forgets the client. fdeops is the countersigned record — p
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
-One `@fde` skill. The AI coding agent picks the method. You confirm the record. The host agent still writes the TypeScript.
+```text
+  BRIEF WRONG         THEY WENT QUIET        WHEN DID WE AGREE        WHAT DID THEY GET
+ ┌────────────┐      ┌──────────────┐      ┌───────────────┐      ┌─────────────────┐
+ │ real       │      │ process vs   │      │ dated         │      │ promised →      │
+ │ problem    │      │ trust        │      │ receipts      │      │ accepted        │
+ └────────────┘      └──────────────┘      └───────────────┘      └─────────────────┘
+    /brief               /quiet                /agreed                  /got
+```
 
 ---
 
-## The week
+## Commands
 
-What you are doing. English, or a slash command. One skill — you never pick a method.
+What you are doing. Each command is a full procedure that loads `@fde`. One skill; you never pick a method. These four are situations, not a sequence.
 
 | What you're doing | Command | Principle |
 |-------------------|---------|-----------|
-| **The brief is wrong** | `@fde this is Acme. Brief says they want a portal.` · `/brief` | Real problem before more code |
-| **They went quiet** | `@fde the sponsor went quiet` · `/quiet` | Process gap vs trust problem |
-| **When did we agree?** | `@fde when did we agree to drop that?` · `/agreed` | Dated receipts, or a gap |
-| **What did they get?** | `@fde what did they get this week` · `/got` | Promised → measured → accepted |
-| **After a meeting** | `@fde` debrief these notes *(paste)* · `/debrief` | Proposed updates. You confirm. |
+| **The brief is wrong** | `/brief` · `@fde this is Acme. Brief says they want a portal.` | Real problem before more code |
+| **They went quiet** | `/quiet` · `@fde the sponsor went quiet` | Process gap vs trust problem |
+| **When did we agree?** | `/agreed` · `@fde when did we agree to drop that?` | Dated receipts, or a gap |
+| **What did they get?** | `/got` · `@fde what did they get this week` | Promised → measured → accepted |
+| **After a meeting** | `/debrief` · `@fde` debrief these notes *(paste)* | Proposed updates. You confirm. |
+| **Walk-in tomorrow** | `/prep` · `@fde prep me for the sponsor` | Brief from the record, nothing invented |
+| **Friday ledger** | `/status` · `@fde draft the sponsor update` | Promised → measured → accepted |
 | **Optional: pull** | `@fde` connect Granola · `@fde` pull today's transcript | You add that source MCP. We **pull** on request. [mcp/recipes/](mcp/recipes/) |
 
 First chat: you name the client; the AI coding agent binds. Same folder every time: `~/fde-engagements/<client>/.fde/`.
@@ -35,7 +44,7 @@ First chat: you name the client; the AI coding agent binds. Same folder every ti
 
 **30-second setup.** Pick one — both copies `@fde` twice.
 
-Claude Code (hooks before you type; slash commands `/brief` `/quiet` `/agreed` `/got` `/debrief`):
+Claude Code (hooks before you type; slash commands `/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`):
 
 ```text
 /plugin marketplace add suboss87/fdeops
@@ -79,6 +88,23 @@ npx fdeops resume               # where we are
 
 ---
 
+## Use when
+
+Eight moments on an embed. One `@fde` skill routes each — you never pick a method.
+
+| Moment | What it does | Use when | Command |
+|--------|--------------|----------|---------|
+| **The brief is wrong** | Surfaces the real problem before more code | Kickoff notes don't match what ops actually runs | `/brief` |
+| **They went quiet** | Separates process gap from trust problem; logs a dated signal | The sponsor stops answering | `/quiet` |
+| **When did we agree?** | Searches dated receipts — no hit is a gap, not proof | Someone remembers a commitment differently | `/agreed` |
+| **What did they get?** | Reads promised → measured → accepted out loud | Friday, or anyone asks what shipped | `/got` |
+| **After a meeting** | Routes notes into proposed `.fde/` updates | You paste debrief notes from a call | `/debrief` |
+| **Walk-in tomorrow** | Brief from the record — nothing invented | Sponsor meeting in the morning | `/prep` |
+| **Friday ledger** | Draft sponsor update from the countersigned record | End of week status | `/status` |
+| **Optional: pull** | Fetch transcript or thread via a source MCP you add | You want Granola, Slack, or Notion text pulled on request | `@fde` connect · `@fde` pull |
+
+---
+
 ## Why this exists
 
 ### 1. The brief is wrong
@@ -119,7 +145,7 @@ Two things a chat window cannot do: **nothing is written until you confirm**, an
 
 ## How it works
 
-- **You** describe the situation with `@fde` (or `/brief` `/quiet` `/agreed` `/got` `/debrief` on Claude Code). First chat: you name the client; the AI coding agent runs the bind.
+- **You** describe the situation with `@fde` (or `/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status` on Claude Code). First chat: you name the client; the AI coding agent runs the bind.
 - **Hooks (Claude Code)** load where you left off and snapshot on the way out. Other hosts: same CLI and files; you call `@fde`.
 - **Local CLI** — writes, receipts, status. Zero model tokens. The AI coding agent runs it; you do not live in the CLI. Friday, `fde status` prints promised → measured → accepted. [docs/USAGE.md](docs/USAGE.md)
 - **Pull (optional)** — FDEOps is the sink. Paste is the daily path. A source MCP you add (Granola, Slack, Notion, …) can fetch text; `@fde connect …` walks config. No push, no sync, no tokens in `.fde/`. [mcp/recipes/](mcp/recipes/)
@@ -163,7 +189,7 @@ Local HTML: trust, phase, next, the record. `@fde` dashboard, or `npx fdeops das
 
 | You are | What this is |
 |---------|----------------|
-| **Forward Deployed Engineer** | The job this was built for — client work that has to survive Monday morning |
+| **Forward Deployed Engineer** | Client work that has to survive Monday morning |
 | **Consultant / contractor on site** | The engagement stops resetting every morning |
 | **Solutions architect** | Politics and architecture in the same record |
 | **Agency, 3–5 clients** | One `.fde/` each — they stop blurring |

--- a/bin/check.js
+++ b/bin/check.js
@@ -252,7 +252,7 @@ for (const section of [
   'Quickstart',
   'Engagement memory',
   'Who this is for',
-  'The week',
+  'Commands',
   'Principles',
 ]) {
   if (!readme.includes(section)) fail(`README missing section: ${section}`)
@@ -261,6 +261,18 @@ if (!readme.includes('AI coding agent')) {
   fail('README must say AI coding agent (not ambiguous "agent")')
 }
 ok('README clarity sections')
+
+for (const cmd of ['/brief', '/quiet', '/agreed', '/got', '/debrief', '/prep', '/status']) {
+  if (!readme.includes(cmd)) fail(`README must document slash command ${cmd}`)
+}
+ok('README slash commands documented')
+
+// The front-door command map is a fenced diagram: a stranger should see the
+// four-day situations (and prep/status) before the install block, not infer them
+// from a table buried later.
+if (!readme.slice(0, 4000).includes('THEY WENT QUIET')) {
+  fail('README must include the command-map diagram near the top (expect THEY WENT QUIET in the ASCII map)')
+} else ok('README command-map diagram')
 
 if (readme.includes('your-client-repo')) {
   fail('README must not instruct install in customer repo (your-client-repo)')
@@ -538,7 +550,7 @@ if (pkg.version !== plugin.version) {
 if (plugin.commands !== './.claude/commands' || plugin.skills !== './skills') {
   fail('.claude-plugin/plugin.json must declare skills and commands')
 } else {
-  for (const cmd of ['brief', 'quiet', 'agreed', 'got', 'debrief']) {
+  for (const cmd of ['brief', 'quiet', 'agreed', 'got', 'debrief', 'prep', 'status']) {
     const rel = `.claude/commands/${cmd}.md`
     if (!fs.existsSync(path.join(root, rel))) fail(`${rel} missing`)
     else if (!read(rel).includes('@fde')) fail(`${rel} must load @fde`)

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -4,7 +4,7 @@
 |------|---------|
 | `skills/fde/` | **The one skill** - router (`SKILL.md`) + 31 routed methods, 5 overlays, and AI companion `eval-pack` under `references/` |
 | `skills/fde/archive/sdlc/` | Archived SDLC methods — kept for history, **not routed** |
-| `.claude/commands/` | Slash commands for Claude Code (`/brief` `/quiet` `/agreed` `/got` `/debrief`) — thin prompts that load `@fde` |
+| `.claude/commands/` | Slash commands for Claude Code (`/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`) — method cards that load `@fde` |
 | `adapters/` | Thin per-tool pointers (Codex/`AGENTS.md`, Gemini, Cursor, Copilot, local LLMs) - `node bin/install.js adapters <dir>` |
 | `templates/.fde/` | Core memory templates for `fde resume --init` (phase artifacts are created by phases on demand; `evals.md` is optional) |
 | `examples/` | Fictional walkthroughs with sample `.fde/` files |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -13,7 +13,7 @@ Day-to-day reference below.
 ## New here? (5 minutes)
 
 1. Install from the README (plugin or `npx skills add`), then in chat: `@fde this is Acme` — the AI coding agent binds. Terminal fallback: `fde resume --init <client-name>`
-2. Read **The week** and **Who this is for** in the README
+2. Read **Commands** and **Who this is for** in the README
 3. Skim [examples/garvey-payments/](../examples/garvey-payments/) Day 1 → Day 10
 4. Optional recon, zero config: `npx fdeops scan` in a repo
 5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what they got)

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.13.2",
+  "version": "3.14.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.13.2",
+  "version": "3.14.0",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.13.2",
+  "version": "3.14.0",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -32,7 +32,7 @@ After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde 
 
 ## Human surface vs agent plumbing
 
-**FDE (human):** `@fde` + English, or `/brief` `/quiet` `/agreed` `/got` `/debrief`. Never a skill catalog.
+**FDE (human):** `@fde` + English, or `/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`. Never a skill catalog.
 
 **You (agent):** run the CLI. **Never tell the FDE to type** `fde …`. If unbound, you run `fde resume --init` after one question. Never ask them to run the CLI.
 


### PR DESCRIPTION
## Summary
- Front door is a map: four situations, then a Commands table, then eight Use-when moments.
- Slash commands are method cards (sentence, verb, done-when). `/prep` and `/status` added.
- Still one `@fde` skill. 31 methods stay in a details block.

## Test plan
- [x] `node bin/check.js` green (Commands section, seven command files, ASCII map)
- [x] skill-routing evals PASS
- [ ] After merge: tag `v3.14.0` when you want GitHub Latest + npm


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/58" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->