### PR TITLE
fix: 3.14.1 — map is the embed, left to right

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,19 +1,17 @@
 ---
-description: The brief is wrong — find who must agree before more code
+description: Land the embed — brief and trust before code
 ---
 
-Load `@fde` (`skills/fde/SKILL.md`). Situation: **the brief is wrong**.
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
 Say: "If this works, who in their company would have to agree that it worked?"
 
-Run `fde resume` (fallback: `npx --yes fdeops resume`) to load bounded context. Read `references/discover.md` and follow it — shadow processes, real problem, not the slide deck.
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/land.md` and follow it. Brief, access, stakeholders, what “done” is.
 
-Playback 2–3 lines: who decides, what you think the real problem is, and the next move. Confirm before any write to `.fde/`.
+Confirm before any write to `.fde/`. Do not invent names or quotes.
 
-Do not invent stakeholders or quotes. Missing names → `unknown - ask: <question>`.
-
-Done when: you have named the acceptance owner and a discover next step the human agrees to.
+Done when: the brief and who decides are on the record, and the human agrees the next move.
 
 Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,0 +1,15 @@
+---
+description: Close the embed — they can run it without you
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/close.md` and follow it. Handoff, receipts that survive you, what they operate.
+
+Confirm before any write to `.fde/`. Do not invent a clean ending the record does not show.
+
+Done when: handoff is on the record and the human agrees they are replaceable.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,0 +1,17 @@
+---
+description: Find the real problem — brief is a hypothesis
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+Say: "If this works, who in their company would have to agree that it worked?"
+
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/discover.md` and follow it. Evidence from the repo and the room — not the slide deck.
+
+Confirm before any write to `.fde/`. Do not invent stakeholders or quotes.
+
+Done when: reality vs brief is named, and the human agrees the next move.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,17 @@
+---
+description: Plan the sequence — backwards from done
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/plan.md` and follow it. Sequence backwards from done, PR-sized slices, who signs.
+
+Do not invent a plan the record cannot support. Missing success criteria → `unknown - ask: <question>`.
+
+Confirm before any write to `.fde/`.
+
+Done when: order, slices, and “done” are on the record and the human agrees.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,0 +1,17 @@
+---
+description: Ship a slice — pre-flight, then live
+---
+
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.
+
+If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
+
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/ship.md` and follow it. Pre-flight, who needs to know, rollback.
+
+Host agent writes the code. You log what shipped and whether it was accepted. Do not load `archive/sdlc/`.
+
+Confirm before any write to `.fde/`. Do not ship on “probably fine.”
+
+Done when: go-live checks are on the record, or the human has named what still blocks live.
+
+Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 3.14.1 — 2026-08-28
+
+### Changed
+- **Front-door map is the embed** — LAND → DISCOVER → PLAN → SHIP → PROVE → CLOSE, with `/brief` `/discover` `/plan` `/ship` `/got` `/close` under the boxes. Commands table is the job, left to right.
+
 ## 3.14.0 — 2026-08-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -11,30 +11,32 @@ The AI coding agent forgets the client. fdeops is the countersigned record — p
 [![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen)](https://nodejs.org)
 
 ```text
-  BRIEF WRONG         THEY WENT QUIET        WHEN DID WE AGREE        WHAT DID THEY GET
- ┌────────────┐      ┌──────────────┐      ┌───────────────┐      ┌─────────────────┐
- │ real       │      │ process vs   │      │ dated         │      │ promised →      │
- │ problem    │      │ trust        │      │ receipts      │      │ accepted        │
- └────────────┘      └──────────────┘      └───────────────┘      └─────────────────┘
-    /brief               /quiet                /agreed                  /got
+  LAND              DISCOVER           PLAN              SHIP               PROVE              CLOSE
+ ┌────────┐      ┌────────┐      ┌────────┐      ┌────────┐      ┌────────┐      ┌────────┐
+ │  Brief │ ───▶ │ Reality│ ───▶ │ Sequence│───▶ │  Live  │ ───▶ │ Signed │ ───▶ │  They  │
+ │  Trust │      │ Terrain│      │  Align │      │  slice │      │   off  │      │   run  │
+ └────────┘      └────────┘      └────────┘      └────────┘      └────────┘      └────────┘
+  /brief           /discover          /plan             /ship              /got              /close
 ```
 
 ---
 
 ## Commands
 
-What you are doing. Each command is a full procedure that loads `@fde`. One skill; you never pick a method. These four are situations, not a sequence.
+The embed, left to right. Each command loads `@fde` and runs that stage. One skill; you never pick a method.
 
 | What you're doing | Command | Principle |
 |-------------------|---------|-----------|
-| **The brief is wrong** | `/brief` · `@fde this is Acme. Brief says they want a portal.` | Real problem before more code |
-| **They went quiet** | `/quiet` · `@fde the sponsor went quiet` | Process gap vs trust problem |
-| **When did we agree?** | `/agreed` · `@fde when did we agree to drop that?` | Dated receipts, or a gap |
-| **What did they get?** | `/got` · `@fde what did they get this week` | Promised → measured → accepted |
-| **After a meeting** | `/debrief` · `@fde` debrief these notes *(paste)* | Proposed updates. You confirm. |
-| **Walk-in tomorrow** | `/prep` · `@fde prep me for the sponsor` | Brief from the record, nothing invented |
-| **Friday ledger** | `/status` · `@fde draft the sponsor update` | Promised → measured → accepted |
-| **Optional: pull** | `@fde` connect Granola · `@fde` pull today's transcript | You add that source MCP. We **pull** on request. [mcp/recipes/](mcp/recipes/) |
+| Land the embed | `/brief` | Brief and trust before code |
+| Find the real problem | `/discover` | Brief is a hypothesis |
+| Plan the sequence | `/plan` | Backwards from done |
+| Ship a slice | `/ship` | Pre-flight, then live |
+| Prove what they got | `/got` | Promised → measured → accepted |
+| Close the embed | `/close` | They can run it without you |
+| After a meeting | `/debrief` | Proposed updates. You confirm. |
+| Walk-in tomorrow | `/prep` | From the record, nothing invented |
+
+Also: `/quiet` (sponsor went silent) · `/agreed` (scope dispute) · `/status` (Friday readout) · `@fde` connect / pull ([mcp/recipes/](mcp/recipes/))
 
 First chat: you name the client; the AI coding agent binds. Same folder every time: `~/fde-engagements/<client>/.fde/`.
 
@@ -44,7 +46,7 @@ First chat: you name the client; the AI coding agent binds. Same folder every ti
 
 **30-second setup.** Pick one — both copies `@fde` twice.
 
-Claude Code (hooks before you type; slash commands `/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`):
+Claude Code (hooks before you type; slash commands `/brief` `/discover` `/plan` `/ship` `/got` `/close` `/debrief` `/prep`):
 
 ```text
 /plugin marketplace add suboss87/fdeops
@@ -90,18 +92,18 @@ npx fdeops resume               # where we are
 
 ## Use when
 
-Eight moments on an embed. One `@fde` skill routes each — you never pick a method.
+One `@fde` skill. Commands follow the embed. You never pick a method.
 
-| Moment | What it does | Use when | Command |
-|--------|--------------|----------|---------|
-| **The brief is wrong** | Surfaces the real problem before more code | Kickoff notes don't match what ops actually runs | `/brief` |
-| **They went quiet** | Separates process gap from trust problem; logs a dated signal | The sponsor stops answering | `/quiet` |
-| **When did we agree?** | Searches dated receipts — no hit is a gap, not proof | Someone remembers a commitment differently | `/agreed` |
-| **What did they get?** | Reads promised → measured → accepted out loud | Friday, or anyone asks what shipped | `/got` |
-| **After a meeting** | Routes notes into proposed `.fde/` updates | You paste debrief notes from a call | `/debrief` |
-| **Walk-in tomorrow** | Brief from the record — nothing invented | Sponsor meeting in the morning | `/prep` |
-| **Friday ledger** | Draft sponsor update from the countersigned record | End of week status | `/status` |
-| **Optional: pull** | Fetch transcript or thread via a source MCP you add | You want Granola, Slack, or Notion text pulled on request | `@fde` connect · `@fde` pull |
+| Stage | What it does | Use when | Command |
+|-------|--------------|----------|---------|
+| **Land** | Brief, access, who decides | First days, new client, just got the SOW | `/brief` |
+| **Discover** | The real problem vs the slide | The brief does not match what ops runs | `/discover` |
+| **Plan** | Sequence backwards from done | Need order, PRs, what “done” is | `/plan` |
+| **Ship** | Pre-flight, live, rollback | Going to production | `/ship` |
+| **Prove** | Promised → measured → accepted | Anyone asks what they got | `/got` |
+| **Close** | Handoff they can run | You are leaving | `/close` |
+| **Debrief** | Notes into the record | You just left a meeting | `/debrief` |
+| **Prep** | Walk-in brief from the files | Meeting in the morning | `/prep` |
 
 ---
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -262,16 +262,14 @@ if (!readme.includes('AI coding agent')) {
 }
 ok('README clarity sections')
 
-for (const cmd of ['/brief', '/quiet', '/agreed', '/got', '/debrief', '/prep', '/status']) {
+for (const cmd of ['/brief', '/discover', '/plan', '/ship', '/got', '/close', '/debrief', '/prep', '/quiet', '/agreed', '/status']) {
   if (!readme.includes(cmd)) fail(`README must document slash command ${cmd}`)
 }
 ok('README slash commands documented')
 
-// The front-door command map is a fenced diagram: a stranger should see the
-// four-day situations (and prep/status) before the install block, not infer them
-// from a table buried later.
-if (!readme.slice(0, 4000).includes('THEY WENT QUIET')) {
-  fail('README must include the command-map diagram near the top (expect THEY WENT QUIET in the ASCII map)')
+// Front-door map is the embed left-to-right (LAND → CLOSE), not a pile of situations.
+if (!readme.slice(0, 4000).includes('LAND') || !readme.slice(0, 4000).includes('/discover')) {
+  fail('README must include the LAND→CLOSE command-map diagram near the top')
 } else ok('README command-map diagram')
 
 if (readme.includes('your-client-repo')) {
@@ -550,7 +548,7 @@ if (pkg.version !== plugin.version) {
 if (plugin.commands !== './.claude/commands' || plugin.skills !== './skills') {
   fail('.claude-plugin/plugin.json must declare skills and commands')
 } else {
-  for (const cmd of ['brief', 'quiet', 'agreed', 'got', 'debrief', 'prep', 'status']) {
+  for (const cmd of ['brief', 'discover', 'plan', 'ship', 'got', 'close', 'debrief', 'prep', 'quiet', 'agreed', 'status']) {
     const rel = `.claude/commands/${cmd}.md`
     if (!fs.existsSync(path.join(root, rel))) fail(`${rel} missing`)
     else if (!read(rel).includes('@fde')) fail(`${rel} must load @fde`)

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -4,7 +4,7 @@
 |------|---------|
 | `skills/fde/` | **The one skill** - router (`SKILL.md`) + 31 routed methods, 5 overlays, and AI companion `eval-pack` under `references/` |
 | `skills/fde/archive/sdlc/` | Archived SDLC methods — kept for history, **not routed** |
-| `.claude/commands/` | Slash commands for Claude Code (`/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`) — method cards that load `@fde` |
+| `.claude/commands/` | Slash commands: `/brief` `/discover` `/plan` `/ship` `/got` `/close` plus `/debrief` `/prep` `/quiet` `/agreed` `/status` — method cards that load `@fde` |
 | `adapters/` | Thin per-tool pointers (Codex/`AGENTS.md`, Gemini, Cursor, Copilot, local LLMs) - `node bin/install.js adapters <dir>` |
 | `templates/.fde/` | Core memory templates for `fde resume --init` (phase artifacts are created by phases on demand; `evals.md` is optional) |
 | `examples/` | Fictional walkthroughs with sample `.fde/` files |

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.14.0",
+  "version": "3.14.1",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -32,7 +32,7 @@ After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde 
 
 ## Human surface vs agent plumbing
 
-**FDE (human):** `@fde` + English, or `/brief` `/quiet` `/agreed` `/got` `/debrief` `/prep` `/status`. Never a skill catalog.
+**FDE (human):** `@fde` + English, or `/brief` `/discover` `/plan` `/ship` `/got` `/close` `/debrief` `/prep`. Never a skill catalog.
 
 **You (agent):** run the CLI. **Never tell the FDE to type** `fde …`. If unbound, you run `fde resume --init` after one question. Never ask them to run the CLI.
 


### PR DESCRIPTION
## Summary
- Front-door map is the embed: LAND → DISCOVER → PLAN → SHIP → PROVE → CLOSE.
- Commands table is what you are doing at each stage (`/brief` `/discover` `/plan` `/ship` `/got` `/close`).
- Quiet / agreed / status stay as extras, not the hero diagram.

## Test plan
- [x] `node bin/check.js` green


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/59" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->