### PR TITLE
docs: /outcome, not /got; drop em dashes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,15 +4,15 @@
     "name": "Subash Natarajan",
     "url": "https://github.com/suboss87"
   },
-  "description": "Forward deployed engineering skills for AI coding agents — one @fde skill, local .fde/ client record.",
+  "description": "Forward deployed engineering skills for AI coding agents - one @fde skill, local .fde/ client record.",
   "metadata": {
-    "description": "Forward deployed engineering skills for AI coding agents — one @fde skill, local .fde/ client record."
+    "description": "Forward deployed engineering skills for AI coding agents - one @fde skill, local .fde/ client record."
   },
   "plugins": [
     {
       "name": "fdeops",
       "source": "./",
-      "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record: the brief is wrong, they went quiet, when did we agree, what they got. Dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm. For Forward Deployed Engineers running several clients at once."
+      "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record: the brief is wrong, they went quiet, when did we agree, what's the outcome. Dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm. For Forward Deployed Engineers running several clients at once."
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what they got - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
+  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
   "version": "3.15.1",
   "category": "productivity",
   "tags": [

--- a/.claude/commands/agreed.md
+++ b/.claude/commands/agreed.md
@@ -1,5 +1,5 @@
 ---
-description: When did we agree? — dated receipts, not memory
+description: When did we agree? - dated receipts, not memory
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**
@@ -8,7 +8,7 @@ If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once
 
 Do not argue from chat memory. Search the record.
 
-Run `fde receipts <term>` (fallback: `npx --yes fdeops receipts <term>`). Use the term the human named — topic, person, deliverable, or date window.
+Run `fde receipts <term>` (fallback: `npx --yes fdeops receipts <term>`). Use the term the human named - topic, person, deliverable, or date window.
 
 Answer with dated receipts: who said it, when, and where it lives in `.fde/`. No reference file needed unless the hit spans multiple files.
 
@@ -18,4 +18,4 @@ Do not invent meetings, quotes, or commitments. If the record is silent, the ans
 
 Done when: you have cited dated receipts for the term or named the specific gap to fill.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: Land the embed — brief and trust before code
+description: Land the embed - brief and trust before code
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`. Do not invent names or quotes.
 
 Done when: the brief and who decides are on the record, and the human agrees the next move.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,5 +1,5 @@
 ---
-description: Close the embed — they can run it without you
+description: Close the embed - they can run it without you
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.
@@ -12,4 +12,4 @@ Confirm before any write to `.fde/`. Do not invent a clean ending the record doe
 
 Done when: handoff is on the record and the human agrees they are replaceable.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -1,12 +1,12 @@
 ---
-description: After a meeting — notes into the record, human confirms
+description: After a meeting - notes into the record, human confirms
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **after a meeting**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI. If they already pasted notes, bind first, then debrief.
 
-Run `fde debrief --smart` (fallback: `npx --yes fdeops debrief --smart`). `--smart` is a gate, not a brain — it proposes routing; you still judge.
+Run `fde debrief --smart` (fallback: `npx --yes fdeops debrief --smart`). `--smart` is a gate, not a brain - it proposes routing; you still judge.
 
 Rewrite the propose output: add type prefixes where the record needs them. Strip noise; keep their words for quotes and decisions.
 
@@ -18,4 +18,4 @@ Read `references/debrief.md` for prefix rules, file targets, and digest beats.
 
 Done when: the human confirmed the routing and `--apply` wrote the agreed `.fde/` updates.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Find the real problem — brief is a hypothesis
+description: Find the real problem - brief is a hypothesis
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.
@@ -8,10 +8,10 @@ If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once
 
 Say: "If this works, who in their company would have to agree that it worked?"
 
-Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/discover.md` and follow it. Evidence from the repo and the room — not the slide deck.
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/discover.md` and follow it. Evidence from the repo and the room - not the slide deck.
 
 Confirm before any write to `.fde/`. Do not invent stakeholders or quotes.
 
 Done when: reality vs brief is named, and the human agrees the next move.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -1,5 +1,5 @@
 ---
-description: What did they get? — promised, measured, accepted
+description: Prove the outcome. Promised, measured, accepted
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **prove**.
@@ -18,4 +18,4 @@ Do not invent metrics or sign-off. Numbers without a source in `.fde/` stay `unk
 
 Done when: the human hears the three-beat ledger and agrees what is actually delivered vs still claimed.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits. Those stay in the host agent.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Plan the sequence — backwards from done
+description: Plan the sequence - backwards from done
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`.
 
 Done when: order, slices, and “done” are on the record and the human agrees.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,21 +1,21 @@
 ---
-description: Walk-in prep — plain-language readout from the record
+description: Walk-in prep - plain-language readout from the record
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Take the meeting label from what they said — sponsor sync, steering committee, demo, etc.
+Take the meeting label from what they said - sponsor sync, steering committee, demo, etc.
 
 Run `fde prep "<label>"` (fallback: `npx --yes fdeops prep "<label>"`). Use their exact label in quotes.
 
 Present the output in plain language: who matters, what was promised, what shipped, open risks, suggested talking points. Lead with what they need to say, not file names.
 
-Do not invent facts missing from `.fde/`. People, numbers, and quotes must come from the record or the repo they pointed at — else mark `unknown - ask: <question>`.
+Do not invent facts missing from `.fde/`. People, numbers, and quotes must come from the record or the repo they pointed at - else mark `unknown - ask: <question>`.
 
 Offer one focused question only if a missing fact changes the prep.
 
 Done when: the human has a spoken-ready prep from the record and knows what is still unknown.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/quiet.md
+++ b/.claude/commands/quiet.md
@@ -1,5 +1,5 @@
 ---
-description: They went quiet — process gap or trust problem
+description: They went quiet - process gap or trust problem
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.
@@ -10,7 +10,7 @@ Say: "Is this a process gap, or a trust problem?"
 
 Run `fde resume` (fallback: `npx --yes fdeops resume`) for recent signal history and open threads.
 
-Log the contact with `fde log contact "<who and what happened>" --signal amber|red|green` (fallback: `npx --yes fdeops log contact "…" --signal …`). Pick the signal from what they said — do not guess.
+Log the contact with `fde log contact "<who and what happened>" --signal amber|red|green` (fallback: `npx --yes fdeops log contact "…" --signal …`). Pick the signal from what they said - do not guess.
 
 If this is a trust fire (ghosting, blocked access, sponsor disengaged): read `references/rescue.md` and follow it. If it is a process gap, name the missing step and the smallest unblock.
 
@@ -18,4 +18,4 @@ Playback the signal and next move. Confirm before any write to `.fde/`.
 
 Done when: the contact is logged with a signal and you have a rescue or process next step the human agrees to.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship a slice — pre-flight, then live
+description: Ship a slice - pre-flight, then live
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`. Do not ship on “probably fine.”
 
 Done when: go-live checks are on the record, or the human has named what still blocks live.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,12 +1,12 @@
 ---
-description: Friday sponsor update — value ledger first
+description: Friday sponsor update - value ledger first
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-This is for the sponsor-facing update — not a standup or a code review.
+This is for the sponsor-facing update - not a standup or a code review.
 
 Run `fde status` (fallback: `npx --yes fdeops status`). Lead with the **value ledger**: promised → measured → accepted. That is what the sponsor cares about first.
 
@@ -14,8 +14,8 @@ Read `references/status.md` and follow it for update shape, gaps to call out, an
 
 Name what is delivered vs still claimed. Flag acceptance missing a named signer. Surface one trust or scope signal if the record shows amber or red.
 
-Draft the update in their voice — short, factual, no invented wins. Confirm before any write to `.fde/`.
+Draft the update in their voice - short, factual, no invented wins. Confirm before any write to `.fde/`.
 
 Done when: the human has a sponsor-ready update grounded in the ledger and agrees what to send or say.
 
-Not for TypeScript errors, unit tests, refactors, or git commits — those stay in the host agent.
+Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,6 +1,6 @@
 ---
 name: Question
-about: Fit, workflow, or how to use fdeops — not a bug
+about: Fit, workflow, or how to use fdeops - not a bug
 labels: question
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - working in the fdeops repository
 
-This repository **is** fdeops — the engagement record for Forward Deployed Engineers. One `@fde` skill, the `fde` CLI for deterministic work, and per-customer memory in `.fde/` as a side effect of the work (you still confirm judgment).
+This repository **is** fdeops - the engagement record for Forward Deployed Engineers. One `@fde` skill, the `fde` CLI for deterministic work, and per-customer memory in `.fde/` as a side effect of the work (you still confirm judgment).
 
 ## If you are helping use fdeops in an engagement
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,55 +1,59 @@
 # Changelog
 
-## 3.15.1 — 2026-08-28
+## Unreleased
+
+`/got` is now `/outcome` (promised, measured, accepted). Em dashes removed from copy.
+
+## 3.15.1 - 2026-08-28
 
 Public copy uses the standard skill-pack words: **skills**, Commands, Quick Start, All 31 Skills, How Skills Work, Why FDEOps. `@fde` is still the one skill a host loads; the 31 remain references it routes to. No invented glossary on the front door.
 
 Public tree: `.agents/` (the contributor `testing-fieldbook` skill) is gone from git, so a bare `npx skills add` only sees `skills/fde`. Attack notes live in `evals/testing-fieldbook.md`. Methodology moved to `docs/methodology.md`.
 
-## 3.15.0 — 2026-08-28
+## 3.15.0 - 2026-08-28
 
-Production front door: command map, 30-second install, method catalog (Use when), then why it exists. README is text — no gif. Stages are LAND → CLOSE everywhere. Unused SDLC archive and staged mock media removed. Leftover `build` phase name aliases to `ship`. Coding stays in the host agent.
+Production front door: command map, 30-second install, method catalog (Use when), then why it exists. README is text - no gif. Stages are LAND → CLOSE everywhere. Unused SDLC archive and staged mock media removed. Leftover `build` phase name aliases to `ship`. Coding stays in the host agent.
 
-## 3.14.1 — 2026-08-28
-
-### Changed
-- **Front-door map is the embed** — LAND → DISCOVER → PLAN → SHIP → PROVE → CLOSE, with `/brief` `/discover` `/plan` `/ship` `/got` `/close` under the boxes. Commands table is the job, left to right.
-
-## 3.14.0 — 2026-08-28
+## 3.14.1 - 2026-08-28
 
 ### Changed
-- **Command map on the front door** — four situations as a map, then slash commands as method cards. `/prep` and `/status` added. The 31 methods stay in a details block.
+- **Front-door map is the embed** - LAND → DISCOVER → PLAN → SHIP → PROVE → CLOSE, with `/brief` `/discover` `/plan` `/ship` `/got` `/close` under the boxes. Commands table is the job, left to right.
 
-## 3.13.2 — 2026-08-28
+## 3.14.0 - 2026-08-28
 
 ### Changed
-- **Category line** — Forward deployed engineering skills for AI coding agents.
-- **One skill, tighter router** — `@fde` is the brain; slash commands are the menu; methods stay references. The human never picks a skill.
+- **Command map on the front door** - four situations as a map, then slash commands as method cards. `/prep` and `/status` added. The 31 methods stay in a details block.
 
-## 3.13.1 — 2026-08-28
+## 3.13.2 - 2026-08-28
+
+### Changed
+- **Category line** - Forward deployed engineering skills for AI coding agents.
+- **One skill, tighter router** - `@fde` is the brain; slash commands are the menu; methods stay references. The human never picks a skill.
+
+## 3.13.1 - 2026-08-28
 
 Slash commands for the four situations, and the nickname “four days” is gone from the front door.
 
 ### Added
-- **Claude Code slash commands** — `/brief` `/quiet` `/agreed` `/got` `/debrief` load `@fde`. Same skill; a menu, not a second method pack.
+- **Claude Code slash commands** - `/brief` `/quiet` `/agreed` `/got` `/debrief` load `@fde`. Same skill; a menu, not a second method pack.
 
 ### Changed
 - **README week table** names the situation, the chat, and the slash command. “Why this exists” is four numbered problems, not land→build→close.
 - **Plugin** declares `skills` + `commands` in `.claude-plugin/plugin.json`.
 - **Dropped the “four days” nickname** on the public surface. The product is still those four situations; we just say them.
 
-## 3.13.0 — 2026-08-28
+## 3.13.0 - 2026-08-28
 
 Four-day front: the skill is the engagement record, not a land-to-close operating system.
 
 ### Changed
-- **Four days first** — the brief is wrong, they went quiet, when did we agree, what did they get. `@fde` leads with those moments; the six-domain router stays behind them.
-- **First chat binds** — name the client (`@fde this is Acme`); the agent runs `fde resume --init`. The FDE never types the CLI. Terminal `--init` remains the fallback.
-- **Generic SDLC left the router** — `build`, `debug`, `observability`, `qa-live`, `security-audit`, and `test-on-legacy` live in `skills/fde/archive/sdlc/`. Routed count is 31 methods + 5 overlays. Coding, tests, and commits stay in the host agent.
-- **Friday status leads with the value ledger** — promised → measured → accepted, then trust. A number nobody signed is claimed, not delivered.
+- **Four days first** - the brief is wrong, they went quiet, when did we agree, what did they get. `@fde` leads with those moments; the six-domain router stays behind them.
+- **First chat binds** - name the client (`@fde this is Acme`); the agent runs `fde resume --init`. The FDE never types the CLI. Terminal `--init` remains the fallback.
+- **Generic SDLC left the router** - `build`, `debug`, `observability`, `qa-live`, `security-audit`, and `test-on-legacy` live in `skills/fde/archive/sdlc/`. Routed count is 31 methods + 5 overlays. Coding, tests, and commits stay in the host agent.
+- **Friday status leads with the value ledger** - promised → measured → accepted, then trust. A number nobody signed is claimed, not delivered.
 - **README** teaches the job, then a 30-second install (plugin or `npx skills add --skill fde`). Method catalog is a details block.
 
-## 3.12.0 — 2026-08-27
+## 3.12.0 - 2026-08-27
 
 Vocabulary: standard words on the outside, so nothing has to be learned before it works.
 
@@ -62,7 +66,7 @@ Vocabulary: standard words on the outside, so nothing has to be learned before i
 ### Added
 - **One glossary.** The six words that carry the method (fieldbook, brief vs reality, terrain, trust signal, receipts, vault) are defined once in the README instead of being met scattered and guessed. A gate keeps it in place, and a second gate keeps the description triggering on intent.
 
-## 3.11.1 — 2026-08-27
+## 3.11.1 - 2026-08-27
 
 Adoption: one skill, and the CLI is never missing.
 
@@ -70,7 +74,7 @@ Adoption: one skill, and the CLI is never missing.
 - **A skill-only install had no hands.** `npx skills add` copies the method but not the CLI, and the router's only fallback was `~/.claude/fdeops/fde.js` - absent on Cursor/Codex/anything that is not a Claude Code install - so the agent dropped to writing `.fde/` by hand and lost the dating, gates and `<private>` redaction the CLI enforces. It now reaches for `npx --yes fdeops <verb>` before any manual path; "CLI unavailable" means no Node or no network, not "not installed".
 - **The advertised install pulled a contributor skill.** A bare `npx skills add suboss87/fdeops` also installs `testing-fieldbook`, which is for people working on this repo. The documented command is `--skill fde`, and a gate keeps it that way.
 
-## 3.11.0 — 2026-08-27
+## 3.11.0 - 2026-08-27
 
 One window over every client, without a second memory to maintain.
 
@@ -82,7 +86,7 @@ One window over every client, without a second memory to maintain.
 - The vault is **derived and disposable**: `.fde/` stays the only source of truth, the folder is deleted and rebuilt on every run, it is gitignored, and nothing in it is ever parsed back. Authoritative `.fde/` files gain no frontmatter and no wikilinks - they stay plain markdown a client can read.
 - It refuses to build over `$HOME`, the engagements root, anything inside a `.fde/`, a symlink, or any directory it did not write itself (proved by its `.fdeops-vault` stamp). `--out <dir>` for anywhere else.
 
-## 3.10.4 — 2026-08-20
+## 3.10.4 - 2026-08-20
 
 The same refusal in the automatic paths: hooks no longer capture one client's session into another.
 
@@ -96,7 +100,7 @@ The same refusal in the automatic paths: hooks no longer capture one client's se
 - **A whitespace-only `FDEOPS_ENGAGEMENT` refuses too** - an empty expansion (`export FDEOPS_ENGAGEMENT="$CLIENT"`) read as unset and filed the note under the workspace binding.
 - **`fde resume --init` fails loudly when it cannot bind.** An unwritable `.registry` left the workspace silently unbound with exit 0, so every later command said `NO ENGAGEMENT` for no stated reason.
 
-## 3.10.3 — 2026-08-20
+## 3.10.3 - 2026-08-20
 
 Stability pass: an override that cannot be honored now refuses instead of filing the note under another client.
 
@@ -109,7 +113,7 @@ Stability pass: an override that cannot be honored now refuses instead of filing
 ### Changed
 - The recorded session may live in `README.md` or `docs/USAGE.md`; the gate now enforces reachable-and-reproducible instead of front-door-only (the README lost its embed in 3.10.2, which left `npm run check` red on `Main`).
 
-## 3.10.2 — 2026-08-13
+## 3.10.2 - 2026-08-13
 
 Launch README: honest cold start (hooks vs `@fde`), denser front door.
 
@@ -117,36 +121,36 @@ Launch README: honest cold start (hooks vs `@fde`), denser front door.
 - Week table states Claude Code auto-loads; Cursor/Codex need `@fde` / `resume`. Fieldbook is on disk either way.
 - README tightened: followable, not a tutorial. Method matrix stays behind details.
 
-## 3.10.1 — 2026-08-13
+## 3.10.1 - 2026-08-13
 
 Launch usability: pull is optional and CLI-first; MCP sink can bind an engagement without env.
 
 ### Added
-- **Slack pull recipe** — read a thread as text; never post or sync.
-- **`engagement` argument** on ingest MCP tools — pass the `.fde/` path from `fde resume --bind` when the MCP process is not in a bound workspace.
+- **Slack pull recipe** - read a thread as text; never post or sync.
+- **`engagement` argument** on ingest MCP tools - pass the `.fde/` path from `fde resume --bind` when the MCP process is not in a bound workspace.
 
 ### Changed
 - Daily path is paste/debrief; connect wires a **source** MCP only. `fde ingest` in the open workspace is the sink.
 - README week table and "won't build" line no longer contradict (pull via your MCP ≠ we ship connectors).
 
-## 3.10.0 — 2026-08-04
+## 3.10.0 - 2026-08-04
 
 Everything published since 3.9.20: the installer can no longer touch skills it did not create, `<private>` holds under adversarial input, a first run costs nothing, and the front door shows a real session.
 
 ### Added
-- **`fdeops demo`** — the whole land→close loop on a fake client in one command, then `fdeops demo --clean`. Nothing of yours is touched.
-- **Agent Plugins 1.0.0 conformance** — root `plugin.json` + `mcp.json` alongside the existing `.claude-plugin/`, so non-Claude hosts can load the same skill.
+- **`fdeops demo`** - the whole land→close loop on a fake client in one command, then `fdeops demo --clean`. Nothing of yours is touched.
+- **Agent Plugins 1.0.0 conformance** - root `plugin.json` + `mcp.json` alongside the existing `.claude-plugin/`, so non-Claude hosts can load the same skill.
 - **Worked examples on 12 field methods** (one Acme thread across land→close), a gaming check per success metric, "measured ≠ accepted" gating on the value ledger enforced by `doctor`, and pre-wire/pre-mortem in `stakeholder-radar`.
-- **`media/session.gif` + `media/session.cast`** — a recorded real session in the README, reproducible via `media/record-session.sh`.
+- **`media/session.gif` + `media/session.cast`** - a recorded real session in the README, reproducible via `media/record-session.sh`.
 - **`SECURITY.md`** with a reporting channel that does not depend on a repo setting.
 
 ### Fixed
-- **Installer only removes or overwrites skill directories it created** (#8) — verified by a marker, no writing through symlinks, no partial install reporting success.
-- **`<private>` never reaches a model** — redacted from debrief/ingest dry-run previews, HTML comments stripped before routing, apply refuses when the sealed sidecar is gone, an unclosed marker cannot swallow later notes, and MCP results carry no sealed text.
-- **MCP ingest server speaks newline-delimited stdio**, as the transport requires — it could not have worked with any client before.
-- **A typo'd or flag-only `fdeops` command no longer installs** — `fdeops dmeo` exits 1 with a suggestion; `--help`/`--version` answer and touch nothing.
+- **Installer only removes or overwrites skill directories it created** (#8) - verified by a marker, no writing through symlinks, no partial install reporting success.
+- **`<private>` never reaches a model** - redacted from debrief/ingest dry-run previews, HTML comments stripped before routing, apply refuses when the sealed sidecar is gone, an unclosed marker cannot swallow later notes, and MCP results carry no sealed text.
+- **MCP ingest server speaks newline-delimited stdio**, as the transport requires - it could not have worked with any client before.
+- **A typo'd or flag-only `fdeops` command no longer installs** - `fdeops dmeo` exits 1 with a suggestion; `--help`/`--version` answer and touch nothing.
 - **Each logged contact renders once** in the fieldbook LOG, with its trust signal; `doctor` reports unbalanced `<private>` markers.
-- **`media/record-session.sh` is reproducible** — `doctor`'s expected non-zero exit no longer aborts it, `--session` stays in a throwaway workspace, and a missing `gifsicle` is not fatal.
+- **`media/record-session.sh` is reproducible** - `doctor`'s expected non-zero exit no longer aborts it, `--session` stays in a throwaway workspace, and a missing `gifsicle` is not fatal.
 
 ### Changed
 - Advertised method count is gated against `skills/fde/references/`, so docs cannot drift (37 methods + 5 overlays).
@@ -155,33 +159,33 @@ Everything published since 3.9.20: the installer can no longer touch skills it d
 ### Fixed
 - **mcp.json server-path gate** uses the `${PLUGIN_ROOT}` arg (joining all args was blind on empty args and wrong with extra flags).
 
-## 3.9.20 — 2026-07-31
+## 3.9.20 - 2026-07-31
 
-Ingest connect UX — wire any source MCP in plain language; recipes + capability check.
+Ingest connect UX - wire any source MCP in plain language; recipes + capability check.
 
 ### Added
-- **`@fde` connect flow** — "connect Granola/Notion / a new MCP" / "what can you pull?" → `references/ingest-connect.md` (config snippet, host save/reload, verify; no silent install).
-- **`mcp/recipes/`** — file, granola-shaped, notion-shaped recipes into the ingest sink.
-- **Capability check** before pull — list available sink/source tools; never pretend a source exists.
+- **`@fde` connect flow** - "connect Granola/Notion / a new MCP" / "what can you pull?" → `references/ingest-connect.md` (config snippet, host save/reload, verify; no silent install).
+- **`mcp/recipes/`** - file, granola-shaped, notion-shaped recipes into the ingest sink.
+- **Capability check** before pull - list available sink/source tools; never pretend a source exists.
 
 ### Changed
 - README / USAGE clarify: FDEOps is the sink; sources are user MCPs; connect once then pull in natural language.
 
-## 3.9.19 — 2026-07-29
+## 3.9.19 - 2026-07-29
 
-Ingest sink — pull large artifacts from user-configured source MCPs; same confirm loop as debrief.
+Ingest sink - pull large artifacts from user-configured source MCPs; same confirm loop as debrief.
 
 ### Added
-- **`fde ingest` CLI** — `stage`, `list`, `propose`, `apply` verbs. Raw pulls land in `<engagement>/.inbox/`; apply routes dated facts into `.fde/` (wraps debrief `--smart` / `--apply`). Optional `via:<source>` provenance.
-- **`mcp/fdeops-ingest`** — thin stdio MCP mirroring ingest verbs. Source MCPs (Granola, Gmail, Notion, custom) stay user-configured outside fdeops.
-- **Skill + docs** — `@fde` routing for "make sure we're up to date" / pull-from-source; `references/ingest.md` method card; cross-links in debrief, USAGE, schema, PRIVACY, README.
+- **`fde ingest` CLI** - `stage`, `list`, `propose`, `apply` verbs. Raw pulls land in `<engagement>/.inbox/`; apply routes dated facts into `.fde/` (wraps debrief `--smart` / `--apply`). Optional `via:<source>` provenance.
+- **`mcp/fdeops-ingest`** - thin stdio MCP mirroring ingest verbs. Source MCPs (Granola, Gmail, Notion, custom) stay user-configured outside fdeops.
+- **Skill + docs** - `@fde` routing for "make sure we're up to date" / pull-from-source; `references/ingest.md` method card; cross-links in debrief, USAGE, schema, PRIVACY, README.
 
 ### Changed
 - Explicit non-goals restated: no bundled OAuth/connectors, no ambient sync, no unreviewed writes to `.fde/`.
 
-## 3.9.18 — 2026-07-29
+## 3.9.18 - 2026-07-29
 
-Failure-path + stakeholder identity hygiene — Veric-style depth without the platform.
+Failure-path + stakeholder identity hygiene - Veric-style depth without the platform.
 
 ### Added
 - **`fde doctor` operating map** - from `plan` onward, empty `terrain.md` ## Operating map (exception-led) is a hygiene fail (break → who notices → workaround). Discover may still be empty; land only seeds.
@@ -190,20 +194,20 @@ Failure-path + stakeholder identity hygiene — Veric-style depth without the pl
 ### Changed
 - Discover / stakeholder-radar / templates note doctor enforcement and one-name-per-person.
 
-## 3.9.17 — 2026-07-23
+## 3.9.17 - 2026-07-23
 
 Dogfood round: honest `--smart` contract + fix duplicate `## Next action` trap. Session digest: share thinking via `.fde/`, not transcript sync.
 
 ### Fixed
-- **Duplicate `## Next action`** — triage/status/dashboard read the last non-empty section (template empty + agent-appended second heading no longer reports `next: (none set)`). `fde doctor` flags duplicates. `next:` / `setNextAction` collapses to one section.
+- **Duplicate `## Next action`** - triage/status/dashboard read the last non-empty section (template empty + agent-appended second heading no longer reports `next: (none set)`). `fde doctor` flags duplicates. `next:` / `setNextAction` collapses to one section.
 
 ### Changed
-- **`--smart` honesty** — skill + debrief reference + USAGE state clearly: CLI is prefix/keyword gate + writer; the agent rewrites `.debrief-propose` with type prefixes. Editing the propose file means rewriting lines with prefixes, not annotating.
-- **Session digest (On exit / before PR)** — memory contract captures TL;DR, decisions & why, pivot, scope/verification, gotchas into existing `.fde/` files; review/build gates require it before merge. Explicitly not agent-transcript sync into the product repo.
+- **`--smart` honesty** - skill + debrief reference + USAGE state clearly: CLI is prefix/keyword gate + writer; the agent rewrites `.debrief-propose` with type prefixes. Editing the propose file means rewriting lines with prefixes, not annotating.
+- **Session digest (On exit / before PR)** - memory contract captures TL;DR, decisions & why, pivot, scope/verification, gotchas into existing `.fde/` files; review/build gates require it before merge. Explicitly not agent-transcript sync into the product repo.
 
-## 3.9.16 — 2026-07-21
+## 3.9.16 - 2026-07-21
 
-Intent vs diff gate — scope-creep detector fitted into ship/review (not a new skill).
+Intent vs diff gate - scope-creep detector fitted into ship/review (not a new skill).
 
 ### Added
 - **Intent vs diff** on ship (before pre-blast): KEEP / JUSTIFY / SPLIT / DROP every path against the stated slice; SPLIT/DROP still in tree = fix-first; receipt in `delivery.md`.
@@ -213,39 +217,39 @@ Intent vs diff gate — scope-creep detector fitted into ship/review (not a new 
 ### Changed
 - Build review gate names intent vs diff explicitly; skills-reference ship/review rows updated.
 
-## 3.9.15 — 2026-07-21
+## 3.9.15 - 2026-07-21
 
 Input hygiene from the ugly edge-case round.
 
 ### Fixed
-- **ANSI / control-char smuggling** — strip C0/C1 (except tab/LF/CR) on write and on readClean so triage/prep/status cannot paint fake trust colors.
-- **Binary debrief** — refuse mostly-nonprintable notes on file *and* stdin (null bytes or control/noise density).
-- **`.fde` as a file** — resolve refuses loudly (no fake green TRIAGE); ENOTDIR messages point at repair.
+- **ANSI / control-char smuggling** - strip C0/C1 (except tab/LF/CR) on write and on readClean so triage/prep/status cannot paint fake trust colors.
+- **Binary debrief** - refuse mostly-nonprintable notes on file *and* stdin (null bytes or control/noise density).
+- **`.fde` as a file** - resolve refuses loudly (no fake green TRIAGE); ENOTDIR messages point at repair.
 
-## 3.9.14 — 2026-07-21
+## 3.9.14 - 2026-07-21
 
 Field validation follow-ups: shout when the memory ledger dies silently; tighten receipts/debrief/garden.
 
 ### Fixed
-- **Silent ledger death** — corrupt `.fde/.git` is a loud `fde doctor` issue (UNVERSIONED + repair hint); `fde garden` stops claiming reversibility and refuses `--apply` while broken.
-- **Receipts dirty caveat** — ON RECORD hits in hand-edited files are marked dirty.
-- **Smart debrief** — preview lines capped; `Decided:` routes to decisions.md.
-- **Garden risk dedupe** — proposes and applies consolidating identical open-risk echoes into `## Retired`.
+- **Silent ledger death** - corrupt `.fde/.git` is a loud `fde doctor` issue (UNVERSIONED + repair hint); `fde garden` stops claiming reversibility and refuses `--apply` while broken.
+- **Receipts dirty caveat** - ON RECORD hits in hand-edited files are marked dirty.
+- **Smart debrief** - preview lines capped; `Decided:` routes to decisions.md.
+- **Garden risk dedupe** - proposes and applies consolidating identical open-risk echoes into `## Retired`.
 
-## 3.9.13 — 2026-07-21
+## 3.9.13 - 2026-07-21
 
 Audit → eval → deploy loop hardened in method + doctor (no schema break).
 
 ### Added
 - **Exception-led operating map** in `terrain.md` + land/discover method (exceptions, workarounds, who holds knowledge).
-- **Engagement eval pack** — optional `evals.md`, `references/eval-pack.md`, AI overlay + ship gate (non-AI stays `n/a`).
-- **Value + receipts gates** on ship/close — cost-save / risk-mitigation / revenue-uplift + audit/eval receipts.
+- **Engagement eval pack** - optional `evals.md`, `references/eval-pack.md`, AI overlay + ship gate (non-AI stays `n/a`).
+- **Value + receipts gates** on ship/close - cost-save / risk-mitigation / revenue-uplift + audit/eval receipts.
 - **`fde doctor`** warns on ship/close missing value bucket; warns for missing eval receipt only when AI is in scope.
 
 ### Changed
 - `success.md` / `delivery.md` templates: primary value bucket + Ship receipts; ledger gains Bucket column.
 
-## 3.9.12 — 2026-07-21
+## 3.9.12 - 2026-07-21
 
 Honest privacy wording for `<private>` tags.
 
@@ -253,7 +257,7 @@ Honest privacy wording for `<private>` tags.
 - Document `<private>` as CLI/dashboard/hook redaction plus an operational rule: do not open raw private blocks with file tools or paste them into prompts.
 - Remove overclaims that tags never enter model context by themselves.
 
-## 3.9.11 — 2026-07-20
+## 3.9.11 - 2026-07-20
 
 Minimal field hardening for integrity and privacy without schema or workflow changes.
 
@@ -262,14 +266,14 @@ Minimal field hardening for integrity and privacy without schema or workflow cha
 - Secret detection now applies to `next:` debrief entries.
 - Dashboard output replaces the existing fieldbook atomically.
 - Hooks delegate capture and preserve through the explicitly resolved engagement.
-- Mutation hooks prefer PATH `fde`, then plugin copies — same discovery order as session-start.
+- Mutation hooks prefer PATH `fde`, then plugin copies - same discovery order as session-start.
 - Preserve keeps daily deduplication atomic and commits only local memory changes.
 - Session capture derives its date and time from one consistent local timestamp.
 
 ### Added
 - Focused regressions for privacy, locking, atomic replacement, hook delegation (including PATH fallback), upgrade-shaped fixtures, deduplication, and timestamps.
 
-## 3.9.10 — 2026-07-20
+## 3.9.10 - 2026-07-20
 
 Skill routing clarity + switch-tools docs + cheap skill eval pack.
 
@@ -282,7 +286,7 @@ Skill routing clarity + switch-tools docs + cheap skill eval pack.
 - **`fde redact`** documented in the skill CLI routing table.
 - **Trust signal** - if the human already named the color, that is the confirm.
 
-## 3.9.9 — 2026-07-19
+## 3.9.9 - 2026-07-19
 
 Proactive fieldbook hygiene at high-value moments only.
 
@@ -294,7 +298,7 @@ Proactive fieldbook hygiene at high-value moments only.
 ### Changed
 - **Doctor** skips day-1 empty-template nagging (phase unset / empty success / empty next action with no dated work).
 
-## 3.9.8 — 2026-07-17
+## 3.9.8 - 2026-07-17
 
 Launch funnel hardenings from the v3.9.7 field run.
 
@@ -305,7 +309,7 @@ Launch funnel hardenings from the v3.9.7 field run.
 - **`fde redact <term> [--apply]`** - preview/remove buried lines (secrets noticed hours later). Undo stays last-write-only; redact commits the scrub to the ledger.
 - **`fde doctor`** - warns when phase is `ship`/`close` with open risks, and when open risks look like duplicate echoes.
 
-## 3.9.7 — 2026-07-17
+## 3.9.7 - 2026-07-17
 
 Defensible memory: stop laundering manual edits into the next write's commit.
 
@@ -318,7 +322,7 @@ Defensible memory: stop laundering manual edits into the next write's commit.
 - **`bin/fde.js` split** - `bin/lib/memory.js` (scoped git commits), `bin/lib/trust.js` (signals / triage), `bin/lib/render.js` (dashboard). CLI entry stays command routing.
 - **`examples/fieldbook.html`** - untracked (generated; regenerate with `fde dashboard`).
 
-## 3.9.6 — 2026-07-17
+## 3.9.6 - 2026-07-17
 
 Adoption contract in code: human speaks natural language; agent runs the CLI.
 
@@ -328,7 +332,7 @@ Adoption contract in code: human speaks natural language; agent runs the CLI.
 - **Session-start pointer + Cursor adapter** - same contract.
 - **README** - week as what you say; CLI reframed as under-the-hood map.
 
-## 3.9.5 — 2026-07-17
+## 3.9.5 - 2026-07-17
 
 Token discipline: SessionStart matches progressive-disclosure L1.
 
@@ -336,90 +340,90 @@ Token discipline: SessionStart matches progressive-disclosure L1.
 - **`hooks/session-start`** no longer `cat`s the full `SKILL.md` (~24KB) into every session. Injects a one-line `@fde` pointer + TRIAGE + bounded `context.md` only. Skill body loads when `@fde` triggers.
 - check.js asserts the lean inject; CLI test covers the hook output.
 
-## 3.9.4 — 2026-07-17
+## 3.9.4 - 2026-07-17
 
 Revert packaging-only 3.9.3 (week-loop README / Next: line / skills-add elevate). Restore 3.9.2 docs and skill wording.
 
-## 3.9.3 — 2026-07-17
+## 3.9.3 - 2026-07-17
 
-Yanked from product surface — packaging clarity experiment; superseded by 3.9.4.
+Yanked from product surface - packaging clarity experiment; superseded by 3.9.4.
 
-## 3.9.2 — 2026-07-17
+## 3.9.2 - 2026-07-17
 
-Field judgment hardenings blended into existing methods — no new skills, no imported skill names.
+Field judgment hardenings blended into existing methods - no new skills, no imported skill names.
 
 ### Added
-- **Brief interrogation** in `land` / `discover` — one Q + GUESS + confidence when the brief is thin; never invent stakeholders to fill gaps.
-- **Anti-invention gates** in `@fde` — when not to invent, over-route, grill, or ship on vibes.
-- **Pre-blast challenge** in `ship` / `red-team` — CLAIM → CHALLENGE → VERDICT before irreversible client moves.
+- **Brief interrogation** in `land` / `discover` - one Q + GUESS + confidence when the brief is thin; never invent stakeholders to fill gaps.
+- **Anti-invention gates** in `@fde` - when not to invent, over-route, grill, or ship on vibes.
+- **Pre-blast challenge** in `ship` / `red-team` - CLAIM → CHALLENGE → VERDICT before irreversible client moves.
 
-## 3.9.1 — 2026-07-14
+## 3.9.1 - 2026-07-14
 
 Field-sim closeout: prep and smart debrief match how FDEs actually write memory (logs, not only tables).
 
 ### Fixed
-- **`fde prep` reads log-shaped memory** — stakeholders from Signal history / ledger when the table is empty; risks from dated bullets as well as the table.
-- **`fde debrief --smart`** — infers `[signal:amber|green|red]` from contact language; person lines like “Randy opened the sheet…” route as contacts; open questions → risks; `next:` / “Next action:” updates `## Next action`.
+- **`fde prep` reads log-shaped memory** - stakeholders from Signal history / ledger when the table is empty; risks from dated bullets as well as the table.
+- **`fde debrief --smart`** - infers `[signal:amber|green|red]` from contact language; person lines like “Randy opened the sheet…” route as contacts; open questions → risks; `next:` / “Next action:” updates `## Next action`.
 - Worst-of trust still holds when smart apply lands Denise amber + Randy green in one pass.
 
-## 3.9.0 — 2026-07-14
+## 3.9.0 - 2026-07-14
 
-Defensible memory + frictionless debrief loop. Still a field kit — not a coworker shell. Zero telemetry; CLI stays offline.
+Defensible memory + frictionless debrief loop. Still a field kit - not a coworker shell. Zero telemetry; CLI stays offline.
 
 ### Added
-- **Versioned `.fde/`** — `git init` inside engagement memory; every log/debrief/capture/phase/garden write auto-commits. Tamper-evident receipts (`@hash` on writes). No new dependencies.
-- **Owner attribution** — `.owner` + `[@author]` on dated entries; `fde owner` / `fde owner set`.
-- **`fde triage`** — same TRIAGE block as `fde resume`; session-start hook and Cursor adapter load it on entry.
-- **`fde doctor`** — deterministic lint (stale signals, unset phase, empty success, missing next action).
-- **`fde debrief --smart` / `--apply`** — heuristic propose from messy notes → review → confirm. Prefix router unchanged for air-gap.
-- **`fde prep [label]`** — grounded walk-in brief from existing `.fde/` only (no invention).
-- **`fde garden [--apply]`** — contract: no new facts, no deleted substance, git-reversible; mechanical archive of 60d+ session-end blocks.
-- **`docs/field-reports/`** — attack-our-own-tool notes shipped in-repo.
+- **Versioned `.fde/`** - `git init` inside engagement memory; every log/debrief/capture/phase/garden write auto-commits. Tamper-evident receipts (`@hash` on writes). No new dependencies.
+- **Owner attribution** - `.owner` + `[@author]` on dated entries; `fde owner` / `fde owner set`.
+- **`fde triage`** - same TRIAGE block as `fde resume`; session-start hook and Cursor adapter load it on entry.
+- **`fde doctor`** - deterministic lint (stale signals, unset phase, empty success, missing next action).
+- **`fde debrief --smart` / `--apply`** - heuristic propose from messy notes → review → confirm. Prefix router unchanged for air-gap.
+- **`fde prep [label]`** - grounded walk-in brief from existing `.fde/` only (no invention).
+- **`fde garden [--apply]`** - contract: no new facts, no deleted substance, git-reversible; mechanical archive of 60d+ session-end blocks.
+- **`docs/field-reports/`** - attack-our-own-tool notes shipped in-repo.
 
 ### Fixed
 - Session-start now injects TRIAGE (not only raw `context.md`), matching `fde resume`.
 
-## 3.8.3 — 2026-07-14
+## 3.8.3 - 2026-07-14
 
 Real field-use fixes: trust colors that cannot lie at 5pm, Monday resume that earns its keep, honest phase.
 
 ### Fixed
-- **Worst-of-stakeholder trust** — latest `[signal:x]` is kept per person, then the worst active color wins. A green about Randy no longer clears Denise’s sponsor amber/red.
-- **`fde resume` leads with TRIAGE** — trust, phase, open risks, next action, then engagement memory.
-- **Phase is honest** — template defaults to `unset` (not fake `land`); `fde log phase <land|discover|plan|build|ship|close>` advances it.
+- **Worst-of-stakeholder trust** - latest `[signal:x]` is kept per person, then the worst active color wins. A green about Randy no longer clears Denise’s sponsor amber/red.
+- **`fde resume` leads with TRIAGE** - trust, phase, open risks, next action, then engagement memory.
+- **Phase is honest** - template defaults to `unset` (not fake `land`); `fde log phase <land|discover|plan|build|ship|close>` advances it.
 
-## 3.8.2 — 2026-07-14
+## 3.8.2 - 2026-07-14
 
 Filesystem last-mile hardenings from brutal edge-case report v2.
 
 ### Fixed
-- **Human fs errors** — permission denied / disk full / lock failures print one line and exit 1; no Node stack dumps on the field path.
-- **Atomic `resume --init`** — new engagements build in a staging dir and rename into place; partial failures clean up instead of leaving a half-built tree.
-- **Symlink write guard** — `lstat` refuses appends/writes when a memory file is a symlink (would escape the engagement tree).
+- **Human fs errors** - permission denied / disk full / lock failures print one line and exit 1; no Node stack dumps on the field path.
+- **Atomic `resume --init`** - new engagements build in a staging dir and rename into place; partial failures clean up instead of leaving a half-built tree.
+- **Symlink write guard** - `lstat` refuses appends/writes when a memory file is a symlink (would escape the engagement tree).
 
-## 3.8.1 — 2026-07-14
+## 3.8.1 - 2026-07-14
 
 Field edge-case follow-ups from live multi-client / hostile-handoff review.
 
 ### Fixed
-- **Secret hygiene** — `fde log` / routed `fde debrief` lines that look like credentials (AKIA…, `ghp_…`, PEM keys, etc.) are refused; pass `--force` only if intentional. `fde log --undo` removes the last CLI write.
-- **Corrupt memory ≠ green** — binary or unparseable `stakeholders.md` (or invalid `**Trust:**` value) surfaces as amber with `memory unreadable - verify`, not a healthy green.
-- **Status reason** — non-green rows prefer the triggering signal / memory warning over a random latest risk line.
+- **Secret hygiene** - `fde log` / routed `fde debrief` lines that look like credentials (AKIA…, `ghp_…`, PEM keys, etc.) are refused; pass `--force` only if intentional. `fde log --undo` removes the last CLI write.
+- **Corrupt memory ≠ green** - binary or unparseable `stakeholders.md` (or invalid `**Trust:**` value) surfaces as amber with `memory unreadable - verify`, not a healthy green.
+- **Status reason** - non-green rows prefer the triggering signal / memory warning over a random latest risk line.
 
-## 3.8.0 — 2026-07-14
+## 3.8.0 - 2026-07-14
 
 Trust + hygiene cut for the field kit (second brain), not an OS.
 
 ### Fixed
-- **Unknown commands exit 1** — typos in scripts/hooks no longer look like success (`fde help` still exits 0).
-- **Basename match is read-only** — `log` / `debrief` / `capture` require a workspace bind, `FDEOPS_ENGAGEMENT`, pointer, or in-repo `.fde/`. A folder that merely shares a client name cannot write into that client's memory.
-- **Memory write locking** — exclusive `.lock` + atomic rename on append/rewrite paths so parallel agent sessions (or hook + CLI) do not interleave the same markdown file.
-- **Signal ledger** — CLI `[signal:x]` lines also append to `.signal-ledger` so trust colors survive an agent rewrite that drops `## Signal history`.
+- **Unknown commands exit 1** - typos in scripts/hooks no longer look like success (`fde help` still exits 0).
+- **Basename match is read-only** - `log` / `debrief` / `capture` require a workspace bind, `FDEOPS_ENGAGEMENT`, pointer, or in-repo `.fde/`. A folder that merely shares a client name cannot write into that client's memory.
+- **Memory write locking** - exclusive `.lock` + atomic rename on append/rewrite paths so parallel agent sessions (or hook + CLI) do not interleave the same markdown file.
+- **Signal ledger** - CLI `[signal:x]` lines also append to `.signal-ledger` so trust colors survive an agent rewrite that drops `## Signal history`.
 
 ### Docs
 - Dropped leftover “writes itself” / “never cross-contaminated” claims; clarified bind-before-write and Windows Git Bash need for bash hooks.
 
-## 3.7.8 — 2026-07-13
+## 3.7.8 - 2026-07-13
 
 - Adapters install places the skill pointer files reference.
 - Stakeholder signal tokens land under `## Signal history` regardless of writer/token position.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -68,7 +68,7 @@ promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
-Security vulnerabilities are a different channel — see [SECURITY.md](SECURITY.md).
+Security vulnerabilities are a different channel - see [SECURITY.md](SECURITY.md).
 
 ## Enforcement Guidelines
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Skill and doc changes are **reviewed and merged by the maintainer only**. If you
 
 Skills should be **specific** (actionable steps), **verifiable** (an artifact in `.fde/`), and **minimal**. The `fde` CLI stays local-only.
 
-Adversarial CLI notes (resolution, hooks, `<private>`, non-regular files) live in [`evals/testing-fieldbook.md`](evals/testing-fieldbook.md). That file is not a skill — do not add a second `SKILL.md`.
+Adversarial CLI notes (resolution, hooks, `<private>`, non-regular files) live in [`evals/testing-fieldbook.md`](evals/testing-fieldbook.md). That file is not a skill - do not add a second `SKILL.md`.
 
 **What we won't build:** SaaS sync; Slack/Notion/Granola **push** inside the CLI; CRM as core; hardware capture; generic code-craft packs. You may **pull** via *your* MCP.
 

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -17,11 +17,11 @@ fdeops is local tooling. No fdeops-operated backend, telemetry, or accounts.
 
 ## Ingest (optional MCP sink)
 
-The optional ingest MCP (`mcp/fdeops-ingest`) and `fde ingest` CLI verbs **stage local files only** — raw pulls land in `<engagement>/.inbox/` beside the fieldbook. Third-party **source** MCPs (Gmail, Granola, Notion, custom) are **user-configured** in your AI tool; they are outside fdeops and carry their own credentials and privacy terms. fdeops never stores those credentials and does not call those services from the core CLI.
+The optional ingest MCP (`mcp/fdeops-ingest`) and `fde ingest` CLI verbs **stage local files only** - raw pulls land in `<engagement>/.inbox/` beside the fieldbook. Third-party **source** MCPs (Gmail, Granola, Notion, custom) are **user-configured** in your AI tool; they are outside fdeops and carry their own credentials and privacy terms. fdeops never stores those credentials and does not call those services from the core CLI.
 
 Nothing enters `.fde/` without your confirm step (`fde ingest apply`). There is no ambient sync: pulls happen when you (or your agent on your instruction) fetch and stage.
 
-**`.inbox/` is NDA surface** — same home tree as `~/fde-engagements/<name>/.fde/`. Cloud sync, backup, and permissions guidance above applies to staged raw artifacts too.
+**`.inbox/` is NDA surface** - same home tree as `~/fde-engagements/<name>/.fde/`. Cloud sync, backup, and permissions guidance above applies to staged raw artifacts too.
 
 ## Your data
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Forward deployed engineering skills for AI coding agents.**
 
-Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent follows them consistently — and writes a dated record you can defend. The host agent still writes the TypeScript.
+Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent follows them consistently, and writes a dated record you can defend. The host agent still writes the TypeScript.
 
 ```text
   LAND              DISCOVER           PLAN              SHIP               PROVE              CLOSE
@@ -10,7 +10,7 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
  │  Brief │ ───▶ │ Reality│ ───▶ │ Sequence│───▶ │  Live  │ ───▶ │ Signed │ ───▶ │  They  │
  │  Trust │      │ Terrain│      │  Align │      │  slice │      │   off  │      │   run  │
  └────────┘      └────────┘      └────────┘      └────────┘      └────────┘      └────────┘
-  /brief           /discover          /plan             /ship              /got              /close
+  /brief           /discover          /plan             /ship            /outcome           /close
 ```
 
 ---
@@ -25,12 +25,12 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
 | Find the real problem | `/discover` | Brief is a hypothesis |
 | Plan the sequence | `/plan` | Backwards from done |
 | Ship a slice | `/ship` | Pre-flight, then live |
-| Prove what they got | `/got` | Promised → measured → accepted |
+| Prove the outcome | `/outcome` | Promised → measured → accepted |
 | Close the embed | `/close` | They can run it without you |
 
 Also: `/debrief` (after a meeting) · `/prep` (walk-in) · `/quiet` (sponsor silent) · `/agreed` (scope dispute) · `/status` (Friday readout).
 
-Skills also activate automatically based on what you're doing — naming a client, debriefing a meeting, or asking what was agreed triggers `@fde`. Ordinary TypeScript, unit tests, and git commits stay in the host agent.
+Skills also activate automatically based on what you're doing: naming a client, debriefing a meeting, or asking what was agreed triggers `@fde`. Ordinary TypeScript, unit tests, and git commits stay in the host agent.
 
 ---
 
@@ -67,7 +67,7 @@ Hooks load where you left off. Slash commands match the map above.
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Or `npx fdeops adapters .` — [adapters/](adapters/README.md).
+Or `npx fdeops adapters .`. See [adapters/](adapters/README.md).
 
 </details>
 
@@ -86,7 +86,7 @@ Fallback if the agent cannot bind:
 npx fdeops resume --init acme   # ~/fde-engagements/acme + bind this checkout
 ```
 
-Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT` — [docs/install.md](docs/install.md). Try the loop: `npx fdeops demo`.
+Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](docs/install.md). Try the loop: `npx fdeops demo`.
 
 </details>
 
@@ -94,7 +94,7 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT` — [docs/install.md](docs
 
 ## All 31 Skills
 
-The commands above are the entry points. Under the hood, `@fde` activates these 31 skills — each a structured workflow with steps, an artifact, and a checkpoint. You never pick one by name. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
+The commands above are the entry points. Under the hood, `@fde` activates these 31 skills, each a structured workflow with steps, an artifact, and a checkpoint. You never pick one by name. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 
 ### Land - Brief and trust
 
@@ -128,14 +128,14 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 
 | Skill | What It Does | Use When |
 |--------|--------------|----------|
-| [incremental-build](skills/fde/references/incremental-build.md) | Vertical slices, visible every 2–3 days | Large feature on their codebase |
+| [incremental-build](skills/fde/references/incremental-build.md) | Vertical slices, visible every 2-3 days | Large feature on their codebase |
 | [blast-radius](skills/fde/references/blast-radius.md) | Impact from contained → irreversible | Touching shared infrastructure |
 | [rescue](skills/fde/references/rescue.md) | Production fire or trust fire | Down, or they went quiet |
 | [ship](skills/fde/references/ship.md) | Intent vs diff, pre-flight, rollback | Going live |
 | [review](skills/fde/references/review.md) | Did we only build what we agreed | Before merge, scope creep |
 | [rollback-drill](skills/fde/references/rollback-drill.md) | Test the escape route before 2am | "We can always revert" |
 
-### Prove - What they got
+### Prove - Outcome
 
 | Skill | What It Does | Use When |
 |--------|--------------|----------|
@@ -190,7 +190,7 @@ Every skill follows a consistent anatomy:
 - **Progressive disclosure.** The `SKILL.md` is the entry point. One `references/*.md` loads when routed.
 - **Local CLI.** Writes, status, dated agreements. Zero model tokens. The AI coding agent runs it.
 
-The record lives at `~/fde-engagements/<client>/.fde/` — not inside any vendor. Change hosts, install `@fde` on the new one, bind if needed, keep talking.
+The record lives at `~/fde-engagements/<client>/.fde/` - not inside any vendor. Change hosts, install `@fde` on the new one, bind if needed, keep talking.
 
 ---
 
@@ -203,7 +203,7 @@ fdeops/
 │   └── references/             #   31 skills + overlays
 ├── .claude/commands/           # slash commands (each loads @fde)
 ├── .claude-plugin/             # Claude Code marketplace
-├── bin/                        # local CLI — git + files, no network
+├── bin/                        # local CLI - git + files, no network
 ├── hooks/                      # session-start / session-stop / pre-compact
 ├── adapters/                   # Cursor, Gemini, Copilot, Codex pointers
 ├── templates/.fde/             # memory files created on bind
@@ -220,19 +220,19 @@ fdeops/
 
 ### 1. The brief is wrong
 
-The most common failure on an embed is building the portal they asked for. Ops has been running a spreadsheet for two years. `/brief` then `/discover` — who in their company would have to agree it worked?
+The most common failure on an embed is building the portal they asked for. Ops has been running a spreadsheet for two years. `/brief` then `/discover`. Who in their company would have to agree it worked?
 
 ### 2. They went quiet
 
-A sponsor who stops answering is not a Jira gap. It is a trust color. `/quiet` — process vs trust, then a dated signal in the record.
+A sponsor who stops answering is not a Jira gap. It is a trust color. `/quiet`. Process vs trust, then a dated signal in the record.
 
 ### 3. When did we agree?
 
 Arguments from memory lose. `/agreed` searches dated receipts. No hit is a gap, not proof.
 
-### 4. What did they get?
+### 4. What's the outcome?
 
-A number only you agree with is claimed, not delivered. `/got` reads promised → measured → accepted out loud.
+A number only you agree with is claimed, not delivered. `/outcome` reads promised → measured → accepted out loud.
 
 ---
 
@@ -260,14 +260,14 @@ Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
 | **Forward Deployed Engineer** | Client work that has to survive Monday morning |
 | **Consultant / contractor on site** | The engagement stops resetting every morning |
 | **Solutions architect** | Politics and architecture in the same record |
-| **Agency, 3–5 clients** | One `.fde/` each — they stop blurring |
+| **Agency, 3-5 clients** | One `.fde/` each - they stop blurring |
 | **Fractional CTO on client work** | System of record for the embed, and the billable trail |
 
 ---
 
 ## Your data stays yours
 
-Local only — `git` + files, no network, no telemetry. Plain markdown. The model sees client code only when you point the AI coding agent at it. `<private>` is redacted from CLI, dashboard, and hooks. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
+Local only - `git` + files, no network, no telemetry. Plain markdown. The model sees client code only when you point the AI coding agent at it. `<private>` is redacted from CLI, dashboard, and hooks. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
 
 [PRIVACY.md](PRIVACY.md) · [SECURITY.md](SECURITY.md)
 
@@ -275,11 +275,11 @@ Local only — `git` + files, no network, no telemetry. Plain markdown. The mode
 
 ## Principles
 
-- **The artifact is the memory** — producing the work and recording it are one action
-- **Skills, not autonomy** — the kit says what to check; judgment stays yours
-- **Brief is a hypothesis** — discover before building the wrong thing
-- **Evidence on every claim** — these files get defended in the room
-- **One customer, one folder** — context never bleeds
+- **The artifact is the memory** - producing the work and recording it are one action
+- **Skills, not autonomy** - the kit says what to check; judgment stays yours
+- **Brief is a hypothesis** - discover before building the wrong thing
+- **Evidence on every claim** - these files get defended in the room
+- **One customer, one folder** - context never bleeds
 
 ---
 
@@ -291,4 +291,4 @@ Skills should be **specific** (actionable steps), **verifiable** (an artifact in
 
 ## License
 
-MIT — use these skills on client work.
+MIT - use these skills on client work.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,13 +22,13 @@ Skills guide **AI coding agent** behavior. What you send to an AI vendor is gove
 
 **Email `suboss87@gmail.com` with `[fdeops security]` in the subject.** This channel works today and is the one to use if anything else fails.
 
-If the repository's private reporting is enabled, [GitHub Security Advisories](https://github.com/suboss87/fdeops/security/advisories/new) is equally fine — it keeps the thread and the fix in one place. That page 403s when private reporting is off, so it is a second option, never the only one.
+If the repository's private reporting is enabled, [GitHub Security Advisories](https://github.com/suboss87/fdeops/security/advisories/new) is equally fine - it keeps the thread and the fix in one place. That page 403s when private reporting is off, so it is a second option, never the only one.
 
 Please include: affected version (the `version` in `package.json`, or the commit), the exact commands, what you expected versus what happened, and the impact. Reduced test cases help more than write-ups.
 
-**Never include real client material** — no client names, credentials, or `<private>` content. Redact, or describe the shape of the data instead.
+**Never include real client material** - no client names, credentials, or `<private>` content. Redact, or describe the shape of the data instead.
 
-What to expect: acknowledgement within 5 days, an assessment with a fix or a reasoned decline within 30, credit in the release notes unless you prefer otherwise. This is a solo-maintained MIT project, not a funded program — there is no bounty, and those are targets rather than guarantees.
+What to expect: acknowledgement within 5 days, an assessment with a fix or a reasoned decline within 30, credit in the release notes unless you prefer otherwise. This is a solo-maintained MIT project, not a funded program - there is no bounty, and those are targets rather than guarantees.
 
 ### In scope
 

--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -4,7 +4,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 ## Entry
 
-When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) — load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
+When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
 Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
 

--- a/adapters/GEMINI.md
+++ b/adapters/GEMINI.md
@@ -4,7 +4,7 @@ Context for Gemini CLI when assisting a **Forward Deployed Engineer (FDE)** - th
 
 ## Entry
 
-When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) — load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
+When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
 Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
 

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -2,7 +2,7 @@
 
 **One brain, thin adapters.** fdeops has a single source of truth - the `@fde` skill at `skills/fde/SKILL.md` and the `fde` CLI. Each AI coding tool discovers it through a small pointer file in the place that tool already looks. No forked logic, no five copies to maintain - every adapter says the same thing: *route via `@fde`, read/write `.fde/` memory, talk like a peer, never touch what isn't yours.*
 
-**Switching tools:** the fieldbook does not live in the agent. It lives at `~/fde-engagements/<client>/.fde/`. Point a new tool at a bound workspace, drop adapters (or install the skill/plugin for that tool), and the same client record opens. Auto session hooks are Claude Code–first; elsewhere load via `@fde` / `fde resume`. See [README § How it works](../README.md#how-it-works).
+**Switching tools:** the fieldbook does not live in the agent. It lives at `~/fde-engagements/<client>/.fde/`. Point a new tool at a bound workspace, drop adapters (or install the skill/plugin for that tool), and the same client record opens. Auto session hooks are Claude Code-first; elsewhere load via `@fde` / `fde resume`. See [README § How it works](../README.md#how-it-works).
 
 ## What goes where
 

--- a/adapters/copilot-instructions.md
+++ b/adapters/copilot-instructions.md
@@ -4,7 +4,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 ## Entry
 
-When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) — load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
+When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
 Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
 

--- a/adapters/cursor.fde.mdc
+++ b/adapters/cursor.fde.mdc
@@ -9,7 +9,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 ## Entry
 
-When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) — load `@fde`. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
+When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load `@fde`. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
 Do **not** load `@fde` for ordinary code edits, unit tests, refactors, or git commits.
 
@@ -21,7 +21,7 @@ Do **not** load `@fde` for ordinary code edits, unit tests, refactors, or git co
 
 Read and write engagement files under the workspace's bound engagement: run `fde resume` to resolve it (binding created once with `fde resume --init <name>`; default `~/fde-engagements/<name>/.fde/`). `FDEOPS_ENGAGEMENT` (expand `~`) overrides when set. Use `./.fde/` only when the engagement approves it and it is gitignored.
 
-**On every session entry (before other work):** run `fde triage` (fallback `node ~/.claude/fdeops/fde.js triage`, then `fde resume`). Lead with that TRIAGE block — trust, phase, open risks, next action, record owner/hash. Do not invent stakeholders or status.
+**On every session entry (before other work):** run `fde triage` (fallback `node ~/.claude/fdeops/fde.js triage`, then `fde resume`). Lead with that TRIAGE block - trust, phase, open risks, next action, record owner/hash. Do not invent stakeholders or status.
 
 You run the CLI for deterministic work - `fde scan | log | debrief | prep | doctor | receipts | status | dashboard` - instead of improvising shell or handing commands to the human.
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -43,7 +43,7 @@ for (const f of requiredTemplates) {
 
 const deadMedia = ['demo.gif', 'demo.sh', 'demo.tape', 'terminal-demo.svg', 'fieldbook-dashboard.png', 'fieldbook-detail.png', 'fieldbook-walkthrough.gif']
 for (const name of deadMedia) {
-  if (fs.existsSync(path.join(root, 'media', name))) fail(`dead media/${name} must not ship — the recorded session is session.gif`)
+  if (fs.existsSync(path.join(root, 'media', name))) fail(`dead media/${name} must not ship - the recorded session is session.gif`)
 }
 ok('no staged mock media')
 
@@ -57,7 +57,7 @@ for (const dir of fs.readdirSync(path.join(root, 'skills'))) {
 ok('skills structure')
 
 if (fs.existsSync(path.join(root, 'skills', 'fde', 'archive'))) {
-  fail('skills/fde/archive must not exist — unrouted methods are dead code')
+  fail('skills/fde/archive must not exist - unrouted methods are dead code')
 } else ok('no archived skill dump')
 
 // v3: one skill + phase references (progressive disclosure)
@@ -201,7 +201,7 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
 
   const refDir = path.join(root, 'skills', 'fde', 'references')
   const extra = fs.readdirSync(refDir).filter(f => f.endsWith('.md') && !mentioned.includes(f))
-  if (extra.length) fail(`unrouted reference file(s) — dead method: ${extra.join(', ')}`)
+  if (extra.length) fail(`unrouted reference file(s) - dead method: ${extra.join(', ')}`)
   else ok('no unrouted reference files')
 }
 
@@ -222,7 +222,7 @@ if (read('package.json').includes('postinstall')) {
 
 const readme = read('README.md')
 if (/session\.gif|demo\.gif|<img /i.test(readme)) {
-  fail('README must not embed images — front door is text; the recording lives in docs/USAGE.md')
+  fail('README must not embed images - front door is text; the recording lives in docs/USAGE.md')
 } else ok('README is text (no gif)')
 
 const usage = read('docs/USAGE.md')
@@ -262,9 +262,10 @@ if (!readme.includes('AI coding agent')) {
 }
 ok('README clarity sections')
 
-for (const cmd of ['/brief', '/discover', '/plan', '/ship', '/got', '/close', '/debrief', '/prep', '/quiet', '/agreed', '/status']) {
+for (const cmd of ['/brief', '/discover', '/plan', '/ship', '/outcome', '/close', '/debrief', '/prep', '/quiet', '/agreed', '/status']) {
   if (!readme.includes(cmd)) fail(`README must document slash command ${cmd}`)
 }
+if (/(^|[^\w/])\/got\b/.test(readme)) fail('README must use /outcome, not /got')
 ok('README slash commands documented')
 
 // Front-door map is the embed left-to-right (LAND → CLOSE), not a pile of situations.
@@ -535,7 +536,7 @@ if (pkg.version !== plugin.version) {
 if (plugin.commands !== './.claude/commands' || plugin.skills !== './skills') {
   fail('.claude-plugin/plugin.json must declare skills and commands')
 } else {
-  for (const cmd of ['brief', 'discover', 'plan', 'ship', 'got', 'close', 'debrief', 'prep', 'quiet', 'agreed', 'status']) {
+  for (const cmd of ['brief', 'discover', 'plan', 'ship', 'outcome', 'close', 'debrief', 'prep', 'quiet', 'agreed', 'status']) {
     const rel = `.claude/commands/${cmd}.md`
     if (!fs.existsSync(path.join(root, rel))) fail(`${rel} missing`)
     else if (!read(rel).includes('@fde')) fail(`${rel} must load @fde`)
@@ -647,16 +648,36 @@ if (!fs.existsSync(path.join(root, '.github', 'ISSUE_TEMPLATE', 'bug_report.yml'
   fail('GitHub issue template missing')
 } else ok('issue templates')
 
+function findUnicodeDashes(dir, acc = []) {
+  for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (e.name === '.git' || e.name === 'node_modules' || e.name === '.agents') continue
+    const p = path.join(dir, e.name)
+    if (e.isDirectory()) findUnicodeDashes(p, acc)
+    else if (e.name === 'session.cast' || e.name === 'session.gif') continue
+    else {
+      let t
+      try { t = fs.readFileSync(p, 'utf8') } catch { continue }
+      if (t.includes('\u2014') || t.includes('\u2013')) acc.push(path.relative(root, p))
+    }
+  }
+  return acc
+}
+{
+  const dashed = findUnicodeDashes(root)
+  if (dashed.length) fail(`em/en dashes must be ASCII hyphen: ${dashed.join(', ')}`)
+  else ok('no em/en dashes')
+}
+
 if (!fs.existsSync(path.join(root, 'CODE_OF_CONDUCT.md'))) {
-  fail('CODE_OF_CONDUCT.md missing — GitHub community profile needs it')
+  fail('CODE_OF_CONDUCT.md missing - GitHub community profile needs it')
 } else ok('CODE_OF_CONDUCT.md')
 
 if (!fs.existsSync(path.join(root, '.github', 'PULL_REQUEST_TEMPLATE.md'))) {
-  fail('.github/PULL_REQUEST_TEMPLATE.md missing — GitHub community profile needs it')
+  fail('.github/PULL_REQUEST_TEMPLATE.md missing - GitHub community profile needs it')
 } else ok('pull request template')
 
 if (!fs.existsSync(path.join(root, '.github', 'ISSUE_TEMPLATE', 'question.md'))) {
-  fail('.github/ISSUE_TEMPLATE/question.md missing — community profile needs a markdown template with name/about')
+  fail('.github/ISSUE_TEMPLATE/question.md missing - community profile needs a markdown template with name/about')
 } else {
   const q = read('.github/ISSUE_TEMPLATE/question.md')
   if (!/^---[\s\S]*\nname:/m.test(q) || !/^---[\s\S]*\nabout:/m.test(q)) {
@@ -666,7 +687,7 @@ if (!fs.existsSync(path.join(root, '.github', 'ISSUE_TEMPLATE', 'question.md')))
 
 {
   const mktPath = path.join(root, '.claude-plugin', 'marketplace.json')
-  if (!fs.existsSync(mktPath)) fail('.claude-plugin/marketplace.json missing — /plugin marketplace add needs it')
+  if (!fs.existsSync(mktPath)) fail('.claude-plugin/marketplace.json missing - /plugin marketplace add needs it')
   else {
     const mkt = JSON.parse(read('.claude-plugin/marketplace.json'))
     const plug = (mkt.plugins || [])[0]

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1134,7 +1134,7 @@ function cmdResume(args) {
     const fdeDir = path.join(engRoot, '.fde')
     const existed = fs.existsSync(fdeDir)
 
-    // Optional stubs (AI eval pack, …) stay in templates/ for copy-on-use — not day-1 scaffold.
+    // Optional stubs (AI eval pack, …) stay in templates/ for copy-on-use - not day-1 scaffold.
     const SKIP_INIT_TEMPLATES = new Set(['evals.md'])
     const fillTemplates = (destFde) => {
       for (const f of fs.readdirSync(tpl)) {
@@ -1381,7 +1381,7 @@ function setContextPhase(eng, phase) {
 // as one dated debrief block. contact: lines may carry an inline [signal:x]
 // token anywhere in the text - preserved verbatim so computeSignals can trust it.
 // --smart: thin heuristic propose (existing prefixes + light keywords). Not a
-// brain — the agent rewrites .debrief-propose with prefixes; --apply commits.
+// brain - the agent rewrites .debrief-propose with prefixes; --apply commits.
 // --dry-run prints the routing without writing anything.
 function inferContactSignal(text) {
   const t = String(text)
@@ -1392,7 +1392,7 @@ function inferContactSignal(text) {
 }
 
 function looksLikePersonLine(text) {
-  // "Denise …" / "Randy opened…" — capitalized subject + field verb.
+  // "Denise …" / "Randy opened…" - capitalized subject + field verb.
   return /^[A-Z][a-z]{1,20}\b/.test(text) &&
     /\b(helping|quiet|skipped|said|will|opened|resistant|champion|warm|cold|unresponsive|demo|sheet|slack)\b/i.test(text)
 }
@@ -1688,7 +1688,7 @@ function cmdDebrief(args) {
 
 // Pull sink: stage raw artifacts outside the memory ledger, then reuse debrief
 // propose/apply. Never writes .fde/ until the FDE confirms apply. Source SaaS
-// (Granola/Gmail/…) is not here — only staging + the existing confirm gate.
+// (Granola/Gmail/…) is not here - only staging + the existing confirm gate.
 function inboxDir(eng) {
   return path.join(path.dirname(eng), '.inbox')
 }
@@ -1863,7 +1863,7 @@ function cmdIngest(args) {
   console.log(`staged → ${dest}`)
   console.log(`id: ${id}`)
   console.log('next:   fde ingest propose ' + id)
-  console.log('(does not write .fde/ — confirm via propose → apply)')
+  console.log('(does not write .fde/ - confirm via propose → apply)')
 }
 
 function cmdReceipts(args) {
@@ -2157,7 +2157,7 @@ function collectDoctorIssues(eng) {
     }
     if (engagementTouchesAI(eng) && !hasEvalReceipt(eng)) {
       issues.push(
-        `phase is ${s.phase} with AI in scope but no eval receipt (evals.md Verdict or delivery Eval / Ship receipts) — required before green ship/close`
+        `phase is ${s.phase} with AI in scope but no eval receipt (evals.md Verdict or delivery Eval / Ship receipts) - required before green ship/close`
       )
     }
   }
@@ -2302,7 +2302,7 @@ function hasValueBucket(eng) {
 // "pending review", "TBD.", "n/a (blocked)" and "..." are all the same thing an
 // FDE means by an empty cell - nagging about them teaches people to ignore doctor.
 const PENDING_CELL_RE =
-  /^(?:pending|tbd|to ?be ?(?:measured|confirmed|determined)|n\s*\/\s*a|na|none|unknown|not measured|\?+|\.{2,}|…|-+|—+|–+)(?:[^\w].*)?$/i
+  /^(?:pending|tbd|to ?be ?(?:measured|confirmed|determined)|n\s*\/\s*a|na|none|unknown|not measured|\?+|\.{2,}|…|-+|-+|-+)(?:[^\w].*)?$/i
 
 function parseValueLedger(eng) {
   const ledger = stripTemplateNoise(sectionBody(readClean(eng, 'delivery.md'), 'Value ledger') || '')
@@ -2359,7 +2359,7 @@ function valueLedgerStatusLines(eng, opts = {}) {
   return lines
 }
 
-// AI in scope for ship/close hygiene — delivery/decisions/trust evidence only.
+// AI in scope for ship/close hygiene - delivery/decisions/trust evidence only.
 // Do not scan terrain.md: its template headers mention LLM and would false-positive every ship.
 function engagementTouchesAI(eng) {
   const trust = readClean(eng, 'trust-profile.md')
@@ -2376,7 +2376,7 @@ function hasEvalReceipt(eng) {
   const evalsPath = path.join(eng, 'evals.md')
   if (fs.existsSync(evalsPath)) {
     const e = stripTemplateNoise(readClean(eng, 'evals.md'))
-    // Empty G1 stub + "Pass / fail" heading is not a receipt — need a real verdict/run/result.
+    // Empty G1 stub + "Pass / fail" heading is not a receipt - need a real verdict/run/result.
     if (/\*\*Verdict:\*\*\s*SHIP\b/i.test(e) || /(?:^|\n)\s*-\s*\*\*Verdict:\*\*\s*SHIP\b/i.test(e)) return true
     if (/\bLast run:\s*\d{4}-\d{2}-\d{2}/i.test(e)) return true
     if (/\|\s*G\d+\s*\|[^|\n]+\|[^|\n]+\|[^|\n]+\|[^|\n]+\|\s*pass\s*\|/i.test(e)) return true
@@ -2397,7 +2397,7 @@ function hygieneTriageLines(eng) {
   if (!issues.length) return []
   const top = issues[0].replace(/\s+/g, ' ').trim().slice(0, 72)
   return [
-    `  hygiene: ${issues.length} issue(s) — ${top}${issues[0].length > 72 ? '…' : ''}`,
+    `  hygiene: ${issues.length} issue(s) - ${top}${issues[0].length > 72 ? '…' : ''}`,
     '    → say "@fde clean up the fieldbook" when ready (agent runs fde doctor; nothing auto-rewrites)',
   ]
 }
@@ -2494,7 +2494,7 @@ function cmdPrep(args) {
   if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exit(2) }
   const label = args.join(' ').trim() || 'next meeting'
   // Grounded brief: only text already in .fde/. No invention (Rowboat meeting-prep rule).
-  console.log(`MEETING PREP — ${label}`)
+  console.log(`MEETING PREP - ${label}`)
   console.log('(grounded in local .fde/ only - if a fact is missing, it is missing)\n')
   console.log(resumeTriage(eng))
   const owner = readOwner(eng)
@@ -2504,7 +2504,7 @@ function cmdPrep(args) {
   const people = extractStakeholders(eng).slice(0, 8)
   console.log('\nStakeholders (table + signal history)')
   if (!people.length) console.log('  (none yet - log contacts with --signal)')
-  else people.forEach(p => console.log(`  [${p.signal}] ${p.name}${p.role ? ` — ${p.role}` : ''}${p.note ? ` · ${p.note.slice(0, 60)}` : ''}`))
+  else people.forEach(p => console.log(`  [${p.signal}] ${p.name}${p.role ? ` - ${p.role}` : ''}${p.note ? ` · ${p.note.slice(0, 60)}` : ''}`))
 
   const risks = extractRisks(eng).slice(0, 5)
   console.log('\nOpen risks (table + dated bullets)')
@@ -2537,16 +2537,16 @@ function cmdGarden(args) {
   if (gitHealth.ok) {
     console.log('TIDY (contract: no new facts · no deleted substance · reversible via memory git)')
   } else if (gitHealth.reason === 'broken') {
-    console.log('TIDY (contract: no new facts · no deleted substance · ⚠ memory git BROKEN — NOT reversible until ledger is repaired)')
+    console.log('TIDY (contract: no new facts · no deleted substance · ⚠ memory git BROKEN - NOT reversible until ledger is repaired)')
   } else {
-    console.log('TIDY (contract: no new facts · no deleted substance · ⚠ memory not git-versioned — NOT reversible)')
+    console.log('TIDY (contract: no new facts · no deleted substance · ⚠ memory not git-versioned - NOT reversible)')
   }
   console.log(resumeTriage(eng))
   if (!gitHealth.ok) {
     console.log(
       gitHealth.reason === 'broken'
         ? '\n⚠ ledger is UNVERSIONED (corrupt .git). Repair before trusting tidy apply: mv .fde/.git .fde/.git.broken && run any fde write to re-init.'
-        : '\n⚠ no memory git — tidy apply cannot create a reversible commit until the ledger exists.'
+        : '\n⚠ no memory git - tidy apply cannot create a reversible commit until the ledger exists.'
     )
   }
   const proposals = []
@@ -2564,7 +2564,7 @@ function cmdGarden(args) {
     proposals.push({
       id: 'dedupe-risks',
       kind: 'apply',
-      text: `Consolidate ${dupes.length} duplicate open-risk cluster(s) (e.g. "${sample}${sample.length >= 50 ? '…' : ''}") — keep first, retire echoes`,
+      text: `Consolidate ${dupes.length} duplicate open-risk cluster(s) (e.g. "${sample}${sample.length >= 50 ? '…' : ''}") - keep first, retire echoes`,
       clusters: dupes,
     })
   }

--- a/bin/lib/memory.js
+++ b/bin/lib/memory.js
@@ -152,7 +152,7 @@ function createMemoryApi(deps) {
   }
 
   // True only when .git exists AND can resolve HEAD. A corrupt ledger (broken
-  // HEAD / missing objects) still has a .git directory — existsSync alone lied.
+  // HEAD / missing objects) still has a .git directory - existsSync alone lied.
   function memoryGitHealthy(eng) {
     if (!eng) return { ok: false, reason: 'missing' }
     if (!fs.existsSync(path.join(eng, '.git'))) return { ok: false, reason: 'missing' }

--- a/bin/lib/render.js
+++ b/bin/lib/render.js
@@ -438,7 +438,7 @@ function todayViewHtml({ today, total, attentionCount, highRiskTotal, todayQueue
 <h1 class="fb-h1">Today</h1>
 <div class="fb-meta-line">${escapeHtml(today)} &middot; ${total} engagement${total === 1 ? '' : 's'} &middot; ${attentionCount} need you &middot; ${highRiskTotal} high risk${highRiskTotal === 1 ? '' : 's'} open</div>
 <div class="fb-block">
-<div class="fb-sec">Queue — next action per client, worst first</div>
+<div class="fb-sec">Queue - next action per client, worst first</div>
 ${todayQueue}
 </div>
 ${flagsHtml ? `<div class="fb-block">

--- a/bin/lib/trust.js
+++ b/bin/lib/trust.js
@@ -95,7 +95,7 @@ function createTrustApi(deps) {
 
   function nextActionLine(ctx) {
     // lastNonEmpty: template ships an empty ## Next action; agents often append a
-    // second heading with the real bullet — first-match would report "(none set)".
+    // second heading with the real bullet - first-match would report "(none set)".
     const body = sectionBody(ctx, 'Next action', { lastNonEmpty: true })
     for (const raw of body.split('\n')) {
       const t = raw.trim().replace(/^[-*]\s+/, '')

--- a/docs/REPO_LAYOUT.md
+++ b/docs/REPO_LAYOUT.md
@@ -3,12 +3,12 @@
 | Path | Purpose |
 |------|---------|
 | `skills/fde/` | **The one skill** - router (`SKILL.md`) + 31 routed skills, 5 overlays, and AI companion `eval-pack` under `references/` |
-| `.claude/commands/` | Slash commands: `/brief` `/discover` `/plan` `/ship` `/got` `/close` plus `/debrief` `/prep` `/quiet` `/agreed` `/status` — each loads `@fde` |
+| `.claude/commands/` | Slash commands: `/brief` `/discover` `/plan` `/ship` `/outcome` `/close` plus `/debrief` `/prep` `/quiet` `/agreed` `/status`. Each loads `@fde` |
 | `adapters/` | Thin per-tool pointers (Codex/`AGENTS.md`, Gemini, Cursor, Copilot, local LLMs) - `node bin/install.js adapters <dir>` |
 | `templates/.fde/` | Core memory templates for `fde resume --init` (phase artifacts are created by phases on demand; `evals.md` is optional) |
 | `examples/` | Fictional walkthroughs with sample `.fde/` files |
 | `bin/fde.js` | Deterministic CLI - scan, resume, triage, log, debrief, ingest, prep, doctor, tidy, redact, receipts, capture, preserve, status, dashboard, vault |
-| `mcp/` | Optional MCP sink (`fdeops-ingest`) + source **recipes** (`mcp/recipes/` — file, granola, notion); source MCPs remain user-configured |
+| `mcp/` | Optional MCP sink (`fdeops-ingest`) + source **recipes** (`mcp/recipes/` - file, granola, notion); source MCPs remain user-configured |
 | `bin/lib/` | Shared memory / trust / render helpers used by the CLI |
 | `bin/check.js` | Structural + install smoke gate (`npm run check`) |
 | `bin/install.js` | `node bin/install.js` (skills + hooks on disk) |
@@ -18,6 +18,6 @@
 | `.claude-plugin/` | Claude Code marketplace metadata |
 | `docs/` | install, USAGE, schema, OPERATIONS, REPO_LAYOUT, skills, skills-reference, methodology |
 | `docs/methodology.md` | FDE principles the kit encodes (not loaded by hosts) |
-| `media/` | Recorded session (`session.gif`) — embed lives in USAGE.md, not the README |
+| `media/` | Recorded session (`session.gif`) - embed lives in USAGE.md, not the README |
 
 **Install:** [install.md](./install.md) - Claude plugin + git clone is the reliable path.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -16,11 +16,11 @@ Day-to-day reference below.
 
 ## New here? (5 minutes)
 
-1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme` — the AI coding agent binds. Terminal fallback: `fde resume --init <client-name>`
+1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme` - the AI coding agent binds. Terminal fallback: `fde resume --init <client-name>`
 2. Read **Commands** and **Who this is for** in the README
 3. Skim [examples/garvey-payments/](../examples/garvey-payments/) Day 1 → Day 10
 4. Optional recon, zero config: `npx fdeops scan` in a repo
-5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what they got)
+5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what's the outcome)
 
 You do not read the phase methods. **`@fde` routes the AI and loads the right one.**
 
@@ -76,7 +76,7 @@ When a transcript or email is too large to paste, or lives in Granola/Slack/Noti
 fde ingest stage --source granola --title "Sponsor sync 2026-07-29" transcript.txt
 fde ingest list
 fde ingest propose <id-or-filename>   # → .debrief-propose (same as debrief --smart)
-fde ingest apply                      # after you review — same as debrief --apply
+fde ingest apply                      # after you review - same as debrief --apply
 ```
 
 Raw stays in `~/fde-engagements/<client>/.inbox/`; dated facts land in `.fde/` with optional `via:<source>` provenance. Optional MCP wrapper: `mcp/fdeops-ingest` (stdio tools mirror the verbs). Method detail: [skills/fde/references/ingest.md](../skills/fde/references/ingest.md).
@@ -119,7 +119,7 @@ npx fdeops dashboard                # optional local HTML view of the fieldbook
 | When did we agree to drop that? | `fde receipts …` |
 | Draft the sponsor update | `fde status` (+ judgment in chat) |
 | Log that the sponsor went quiet | `fde log contact "…" --signal amber` |
-| Wrap the session / share the thinking / before the PR | Session digest into `.fde/` (TL;DR, decisions & why) — not transcript sync |
+| Wrap the session / share the thinking / before the PR | Session digest into `.fde/` (TL;DR, decisions & why) - not transcript sync |
 
 **Full command list** (power users / scripts):
 
@@ -130,7 +130,7 @@ fde debrief --smart notes.md      # heuristic propose (not AI); agent prefixes �
 fde ingest stage [--source NAME] [--title TEXT] [file|-]  # raw pull → .inbox/
 fde ingest list                   # staged items
 fde ingest propose <id>           # → .debrief-propose (same smart path)
-fde ingest apply                  # after confirm — same as debrief --apply
+fde ingest apply                  # after confirm - same as debrief --apply
 fde doctor                        # check the fieldbook for gaps
 fde prep "sponsor sync"           # walk-in brief from existing memory
 fde log decision "…"

--- a/docs/field-reports/2026-07-14-defensible-memory.md
+++ b/docs/field-reports/2026-07-14-defensible-memory.md
@@ -1,15 +1,15 @@
-# Field report — defensible memory (2026-07-14)
+# Field report - defensible memory (2026-07-14)
 
 We attacked our own tool (multi-client bind, secret paste, corrupt stakeholders, symlink escape, non-atomic init) and compared notes with a source read of Rowboat's knowledge layer.
 
 ## What broke before 3.9
-- Receipts were dated markdown, not tamper-evident — a dispute at a regulated client wants a commit hash, not "trust me, it was in the file."
-- Monday TRIAGE lived in `fde resume` but session-start hooks only injected `context.md` — the promise depended on model obedience.
-- `fde debrief` required prefixed lines — messy meeting notes became `context.md` sludge unless the human babysat formatting.
+- Receipts were dated markdown, not tamper-evident - a dispute at a regulated client wants a commit hash, not "trust me, it was in the file."
+- Monday TRIAGE lived in `fde resume` but session-start hooks only injected `context.md` - the promise depended on model obedience.
+- `fde debrief` required prefixed lines - messy meeting notes became `context.md` sludge unless the human babysat formatting.
 
 ## What we stole (and refused)
 - **Stole:** git-version the memory directory (Rowboat `version_history.ts` pattern), gardener *contract*, meeting-prep grounding, field-reports-as-repo-content.
-- **Refused:** Electron coworker shell, Gmail/Slack ambient sync, PostHog, background agents writing into the record. fdeops compounds as fast as the FDE debriefs — make debrief cheap, keep the NDA moat.
+- **Refused:** Electron coworker shell, Gmail/Slack ambient sync, PostHog, background agents writing into the record. fdeops compounds as fast as the FDE debriefs - make debrief cheap, keep the NDA moat.
 
 ## Verification bar
 - `fde log` / `debrief` print `@<hash>`; `cd ~/fde-engagements/<client>/.fde && git log` shows the trail.

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ fdeops installs on **your laptop** - where **your AI coding agent** runs. Not on
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Then one chat — name the client; the AI coding agent binds. You never type the CLI:
+Then one chat - name the client; the AI coding agent binds. You never type the CLI:
 
 ```text
 @fde this is Acme
@@ -97,7 +97,7 @@ No cloud required. Load `SKILL.md` as your model's system prompt. Full guide: [`
 
 ## Other AI tools (Cursor, Codex, Gemini CLI, Copilot)
 
-**Switching tools:** the fieldbook stays at `~/fde-engagements/<client>/.fde/`. Install `@fde` on the new tool, open a bound workspace (`fde resume --init <client>` once if needed), then `@fde` / `fde resume`. Same client record. Session start/stop hooks are Claude Code–first; other tools get the same brain and CLI, usually on demand.
+**Switching tools:** the fieldbook stays at `~/fde-engagements/<client>/.fde/`. Install `@fde` on the new tool, open a bound workspace (`fde resume --init <client>` once if needed), then `@fde` / `fde resume`. Same client record. Session start/stop hooks are Claude Code-first; other tools get the same brain and CLI, usually on demand.
 
 One skill file powers every tool. Drop the right adapter into the **client workspace** (the repo you open in the tool - not only the engagement folder):
 
@@ -140,7 +140,7 @@ The format covers packaging only - it defines no install mechanism, permissions,
 
 The hooks honor the workspace registry written by `fde resume --init` - bind a workspace once and the loop closes by itself: read side + write side. You still confirm judgment; the fieldbook is not self-maintaining without you.
 
-**Windows:** the CLI and `hooks/run-hook.cmd` work on Windows. The session hooks themselves are `#!/bin/bash` scripts — on Windows you need Git Bash (or another bash) available for Claude Code hooks to run. The `fde` CLI (Node) does not require bash.
+**Windows:** the CLI and `hooks/run-hook.cmd` work on Windows. The session hooks themselves are `#!/bin/bash` scripts - on Windows you need Git Bash (or another bash) available for Claude Code hooks to run. The `fde` CLI (Node) does not require bash.
 
 ---
 
@@ -171,7 +171,7 @@ When set, it takes precedence over the registry. If it points at nothing, every 
 
 The session hooks (`session-start`, `session-stop`, `pre-compact`) honor the same rule: with a value they cannot resolve they exit without reading or writing any engagement, so an automatic capture never lands in a client you did not name.
 
-**Writes** (`fde log`, `fde debrief`, `fde capture`) require env, registry bind, pointer, or in-repo `.fde/`. A folder-name match alone is not enough — that stops an unbound checkout named like a client from appending into the wrong memory.
+**Writes** (`fde log`, `fde debrief`, `fde capture`) require env, registry bind, pointer, or in-repo `.fde/`. A folder-name match alone is not enough - that stops an unbound checkout named like a client from appending into the wrong memory.
 
 ---
 

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -12,7 +12,7 @@ Beside each engagement folder, **`~/fde-engagements/<name>/.inbox/`** holds raw 
 |------|---------|------------|
 | `.inbox/<staged-files>` | Raw artifacts before review | `fde ingest stage` (agent fetches via user-configured source MCPs) |
 
-After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same routing as `fde debrief --apply`). Raw files remain in `.inbox/` for audit. Optional `via:<source>` provenance on applied lines. NDA surface — same home-tree privacy rules as `.fde/`.
+After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same routing as `fde debrief --apply`). Raw files remain in `.inbox/` for audit. Optional `via:<source>` provenance on applied lines. NDA surface - same home-tree privacy rules as `.fde/`.
 
 ## Core files (start here)
 

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -52,7 +52,7 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 | [rollback-drill](../skills/fde/references/rollback-drill.md) | Test the escape route on staging before you need it at 2am | "We can always revert" - need to actually test the escape route |
 
 ### Prove
-*Show what they got. Dated receipts, not memory.*
+*Show the outcome. Dated receipts, not memory.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
@@ -91,7 +91,7 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 
 ## Engagement phases (quick reference)
 
-The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above - see it for the full 31 skills. Generic SDLC (build, debug, tests, commits) stays in the host agent — not routed here.
+The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above - see it for the full 31 skills. Generic SDLC (build, debug, tests, commits) stays in the host agent - not routed here.
 
 | Phase | Enter when | Method highlights | Writes |
 |-------|-----------|-------------------|--------|
@@ -118,7 +118,7 @@ The 9 phases most engagements actually run through, with what gets written where
 1. On entry the agent reads a bounded view of `context.md` (via `fde resume`) - nothing else until the phase needs it.
 2. **Deliverable = memory:** every phase's output IS a `.fde/` file; nothing is maintained by hand.
 3. Every claim carries evidence: `(ops lead, Day 5)` · `(churn: 47/90d)` · `(stated, unverified)`.
-4. On exit (and before a PR) the agent runs a **session digest** — TL;DR, key decisions & why, scope/verification, gotchas, next action — into existing `.fde/` files (not chat transcripts into the product repo); the `session-stop` hook backstops a thin snapshot (hooks resolve the engagement via the workspace registry written by `fde resume --init`).
+4. On exit (and before a PR) the agent runs a **session digest** - TL;DR, key decisions & why, scope/verification, gotchas, next action - into existing `.fde/` files (not chat transcripts into the product repo); the `session-stop` hook backstops a thin snapshot (hooks resolve the engagement via the workspace registry written by `fde resume --init`).
 5. One customer, one folder. Never merged.
 
 v2's 16 standalone skills were consolidated into the single `@fde` router in v3.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -3,7 +3,7 @@
 One skill (`@fde`) routes by situation - you never pick a skill by name. Three layers:
 
 1. **Daily** - prep, debrief, receipts, status, triage / doctor
-2. **Engagement** - brief wrong, they went quiet, when did we agree, what they got — plus the skills below
+2. **Engagement** - brief wrong, they went quiet, when did we agree, what's the outcome - plus the skills below
 3. **Overlays** - ai / fintech / healthcare / gov / artifacts (plus eval-pack as an AI companion)
 
 The full map is below; per-skill details live in [skills-reference.md](./skills-reference.md).
@@ -15,8 +15,8 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 | **Land** | land, audit, stakeholder-radar, trust-engineering, scope-defense | First days: access, credibility, scope |
 | **Discover** | discover, assumption-audit, use-case-scoring, sketch | Finding the real problem behind the brief |
 | **Plan** | plan, business-case, options-analysis, initiative-triage | Sequencing work, getting sponsor alignment |
-| **Ship** | incremental-build, blast-radius, rescue, ship, review, rollback-drill | Visible slices, go-live, rollback — not generic debug/build |
-| **Prove** | status, demo-prep, debrief, exec-narrative, dashboard, ingest, ingest-connect | What they got; pulling from source MCPs |
+| **Ship** | incremental-build, blast-radius, rescue, ship, review, rollback-drill | Visible slices, go-live, rollback - not generic debug/build |
+| **Prove** | status, demo-prep, debrief, exec-narrative, dashboard, ingest, ingest-connect | The outcome; pulling from source MCPs |
 | **Close** | close, handoff-engineering, multi-customer-ops, pattern-extract, red-team | They can run it without you |
 
 Each skill is a workflow, not advice: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.

--- a/evals/skill-routing/README.md
+++ b/evals/skill-routing/README.md
@@ -19,11 +19,11 @@ npm run test:skill-routing                 # both
 
 Latest automated + agent trial notes: [RESULTS.md](RESULTS.md).
 
-## Live trial (15–20 min)
+## Live trial (15-20 min)
 
 1. Bind a throwaway engagement in a scratch repo.
-2. Paste each HAPPY prompt with `@fde` — agent should run the listed CLI (or equivalent), not hand you the command.
-3. Paste each NEG prompt **without** forcing `@fde` — agent should code, not load `land.md` / run `fde doctor`.
+2. Paste each HAPPY prompt with `@fde` - agent should run the listed CLI (or equivalent), not hand you the command.
+3. Paste each NEG prompt **without** forcing `@fde` - agent should code, not load `land.md` / run `fde doctor`.
 4. Note fails in an issue or beside the case id. Fix SKILL.md, re-run.
 
 Do **not** block merges on LLM-as-judge. Re-run the live pack when you change the routing table or CLI verbs.

--- a/evals/skill-routing/RESULTS.md
+++ b/evals/skill-routing/RESULTS.md
@@ -1,17 +1,17 @@
-# Skill routing — trial results (2026-07-20)
+# Skill routing - trial results (2026-07-20)
 
 ## Automated
 | Suite | Result |
 |-------|--------|
-| `node evals/skill-routing/check.js` | PASS — 10/10 happy CLI routes in SKILL.md; description has negative trigger |
-| `node evals/skill-routing/live-smoke.js` | PASS — all happy verbs + day-1 hygiene silent |
+| `node evals/skill-routing/check.js` | PASS - 10/10 happy CLI routes in SKILL.md; description has negative trigger |
+| `node evals/skill-routing/live-smoke.js` | PASS - all happy verbs + day-1 hygiene silent |
 
 ## Agent harness trials (same day)
 | Pack | Result |
 |------|--------|
-| Happy `@fde` ×10 | PASS — correct `fde` verb; never tell human to run CLI; doctor no auto-rewrite; signal writes when color named |
-| Negative coding ×5 | PASS — no skill / no fde / no phase refs |
-| Mixed (“fix payroll and update Denise”) | PASS — code first; memory only after confirm |
+| Happy `@fde` ×10 | PASS - correct `fde` verb; never tell human to run CLI; doctor no auto-rewrite; signal writes when color named |
+| Negative coding ×5 | PASS - no skill / no fde / no phase refs |
+| Mixed (“fix payroll and update Denise”) | PASS - code first; memory only after confirm |
 
 ## Skill fixes applied from this pack
 - Documented `fde redact` in routing table

--- a/evals/skill-routing/cases.json
+++ b/evals/skill-routing/cases.json
@@ -66,7 +66,7 @@
     {
       "id": "happy-intent-vs-diff",
       "kind": "happy",
-      "prompt": "@fde did this PR stay in scope — any scope creep in the diff?",
+      "prompt": "@fde did this PR stay in scope - any scope creep in the diff?",
       "expect": {
         "reference_hint": "review",
         "must_not_load_reference": ["land.md", "discover.md", "scope-defense.md"]
@@ -129,7 +129,7 @@
       "prompt": "Fix the flaky payroll job and update Denise that we slipped",
       "expect": {
         "must_not_cli": ["debrief", "doctor", "land", "discover"],
-        "note": "Code first; memory/log only after confirm — not an immediate fde dump"
+        "note": "Code first; memory/log only after confirm - not an immediate fde dump"
       }
     }
   ]

--- a/evals/skill-routing/check.js
+++ b/evals/skill-routing/check.js
@@ -29,7 +29,7 @@ function hasCliRoute(verb) {
   return re.test(skill)
 }
 
-console.log(`skill-routing contract — ${pack.cases.length} cases against skills/fde/SKILL.md\n`)
+console.log(`skill-routing contract - ${pack.cases.length} cases against skills/fde/SKILL.md\n`)
 
 for (const c of pack.cases) {
   if (c.kind === 'happy') {
@@ -38,7 +38,7 @@ for (const c of pack.cases) {
     if (missing.length) {
       if (c.expect.optional) {
         gaps.push(`${c.id}: optional CLI not documented yet: ${missing.join(', ')}`)
-        console.log(`⚠  ${c.id}  optional gap — skill has no \`fde ${missing.join('|')}\` route`)
+        console.log(`⚠  ${c.id}  optional gap - skill has no \`fde ${missing.join('|')}\` route`)
       } else {
         fail++
         console.log(`✖  ${c.id}  missing CLI route in SKILL.md: ${missing.map(v => 'fde ' + v).join(', ')}`)
@@ -67,8 +67,8 @@ for (const c of pack.cases) {
       }
     }
   } else if (c.kind === 'negative') {
-    // Negatives cannot be proven statically — skill must stay engagement-scoped in description.
-    console.log(`·  ${c.id}  live-only (negative) — ${c.prompt.slice(0, 56)}…`)
+    // Negatives cannot be proven statically - skill must stay engagement-scoped in description.
+    console.log(`·  ${c.id}  live-only (negative) - ${c.prompt.slice(0, 56)}…`)
   }
 }
 
@@ -78,7 +78,7 @@ if (descMatch) {
   const desc = descMatch[1]
   const words = desc.trim().split(/\s+/).length
   if (words > 100) {
-    gaps.push(`frontmatter description is long (${words} words) — trim when/why only`)
+    gaps.push(`frontmatter description is long (${words} words) - trim when/why only`)
     console.log(`\n⚠  description ~${words} words (prefer lean when/why)`)
   } else {
     console.log(`\n✔  description present (${words} words)`)
@@ -96,7 +96,7 @@ if (descMatch) {
 const lines = skill.split(/\n/).length
 if (lines > 500) {
   gaps.push(`SKILL.md is ${lines} lines (Philip: keep under ~500; lean on references)`)
-  console.log(`⚠  SKILL.md is ${lines} lines (over ~500 lean guideline — prefer references)`)
+  console.log(`⚠  SKILL.md is ${lines} lines (over ~500 lean guideline - prefer references)`)
 }
 
 if (printLive || fail === 0) {

--- a/evals/skill-routing/live-smoke.js
+++ b/evals/skill-routing/live-smoke.js
@@ -79,7 +79,7 @@ for (const c of happy) {
     r = fdeRun(['receipts', 'reporting'])
   } else if (verb === 'doctor') {
     r = fdeRun(['doctor'])
-    // doctor exits 1 when issues remain — still a successful invoke
+    // doctor exits 1 when issues remain - still a successful invoke
     assert(c.id, r.status === 0 || /FDE DOCTOR|issue/i.test(r.stdout + r.stderr), `fde doctor rc=${r.status}`)
     continue
   } else if (verb === 'scan') {

--- a/evals/testing-fieldbook.md
+++ b/evals/testing-fieldbook.md
@@ -27,7 +27,7 @@ Rules learned the hard way:
   repeatedly re-introduced blocking reads/writes; without `timeout` the whole matrix stalls instead
   of reporting exit 124, and a regression here is invisible.
 
-## Engagement resolution — the part most likely to be wrong
+## Engagement resolution - the part most likely to be wrong
 
 `resolveEngagement()` in `bin/fde.js` tries, in order: the env var
 (`FDEOPS_ENGAGEMENT`, then legacy `FDEOS_ENGAGEMENT`) → registry bind → project `CLAUDE.md` line →
@@ -39,39 +39,39 @@ When testing "an unhonorable env var must refuse rather than file under another 
 - Use a slug that genuinely cannot resolve (e.g. `client-zzz`). A *valid* bare slug like `client-a`
   resolves under `FDEOPS_ENGAGEMENTS_ROOT` by design and is not a fall-through.
 - Cover writes (`log …`, `debrief --apply`, `capture`, `preserve`, `owner set`) **and** reads
-  (`resume`, `triage`, `prep`, `receipts`, `status`, `dashboard`) — and assert the other client's
+  (`resume`, `triage`, `prep`, `receipts`, `status`, `dashboard`) - and assert the other client's
   text never appears in stdout, not just that exit is nonzero.
 - Since v3.10.4 the env value is **classified up front**: absolute → path forms only; bare slug →
   `<root>/<slug>/.fde` only; anything relative (contains a separator or starts with `.`) → refused
   with `must be an absolute path or a bare engagement slug`. Verify `..`, `../..`, `./x`, `a/b`, `.`
   all refuse in **both** the CLI and the hooks.
 - **Absolute out-of-root paths are still accepted by design** (the in-repo `.fde/` strategy needs
-  it). So judge *relative/traversal* escapes as bugs and absolute ones as documented — but note
+  it). So judge *relative/traversal* escapes as bugs and absolute ones as documented - but note
   `~/..` expands to an absolute path and therefore survives the relative check, and pointing it at
   any existing directory will **create a brand-new memory tree there** (`.git`, `.owner`,
   `context.md`, `decisions.md`). Worth flagging as traversal-in-disguise.
 - **`slugify()` in `bin/fde.js` ends `|| 'engagement'`**, so values that slugify to empty (`???`,
-  `---`, `!!!`, `@@@@`) once resolved the CLI onto an engagement literally slugged `engagement` — a
-  client nobody named — while the bash hooks refused via `[ -n "$slug" ]`. The resolver now refuses
+  `---`, `!!!`, `@@@@`) once resolved the CLI onto an engagement literally slugged `engagement` - a
+  client nobody named - while the bash hooks refused via `[ -n "$slug" ]`. The resolver now refuses
   any value with no `[a-z0-9]` (`"…" which is not an engagement name`, exit 2) *before* the default
   applies; `slugify()` itself is unchanged, so **any new caller that slugifies untrusted input can
   reopen this**. Always test these four values with a `<root>/engagement/` fixture created first, or
-  the bug is invisible — and assert both the write side and the read side (`resume` leaking that
+  the bug is invisible - and assert both the write side and the read side (`resume` leaking that
   engagement's content is the same bug).
 - `FDEOPS_ENGAGEMENTS_ROOT` is **not forced absolute** (`bin/fde.js` ~line 40), so a relative root is
   resolved against cwd. Test `FDEOPS_ENGAGEMENTS_ROOT=..` with a valid bare slug.
 - Empty/whitespace-only env values skip the env branch entirely and fall through to the registry.
-  That is unset-like behaviour, not a misroute — but confirm it each time.
+  That is unset-like behaviour, not a misroute - but confirm it each time.
 - `env.replace(/^~/, HOME)` runs **before** `.trim()`, so `" ~/path"` does not expand. Test both.
-- `resume --init` bypasses resolution and always creates at `<root>/slugify(name)/.fde` — this is
+- `resume --init` bypasses resolution and always creates at `<root>/slugify(name)/.fde` - this is
   what makes the "no memory outside `<root>/<slug>/.fde`" invariant checkable via `find`.
 
-### The hooks re-implement resolution in bash — test them separately
+### The hooks re-implement resolution in bash - test them separately
 
 `hooks/session-start`, `hooks/session-stop`, `hooks/pre-compact` each have their **own**
-`resolve_engagement_dir`. **A fix in `bin/fde.js` does not fix the hooks, and vice versa** — always
+`resolve_engagement_dir`. **A fix in `bin/fde.js` does not fix the hooks, and vice versa** - always
 run all three hooks with a bound workspace plus a hostile env value and sha-compare the bound
-client. `session-stop` runs `capture` + `dashboard` and `pre-compact` runs `preserve` — both are
+client. `session-stop` runs `capture` + `dashboard` and `pre-compact` runs `preserve` - both are
 writes, so a misroute there is silent and unattended.
 
 Since v3.10.4 each hook accepts only absolute paths (`<p>/.fde` then `<p>`) or bare slugs under
@@ -92,7 +92,7 @@ Format is `<absolute workspace path> <slug>`, split on the **last** space, so wo
 contain spaces. Worth attacking: CRLF, duplicate lines, slug containing a space, a line pointing at
 a deleted engagement, lines with no space, relative workspace paths, 40k-line files (~50 ms is
 normal), and `.registry` as a directory, symlink or **fifo**. Expect exactly **one** warning per
-process naming the file. `resume --init` rewrites the file (self-heal) — assert valid bindings for
+process naming the file. `resume --init` rewrites the file (self-heal) - assert valid bindings for
 *other* workspaces survive verbatim.
 
 `resume --init` bind-failure behaviour is **mode-dependent**, so test several modes:
@@ -100,13 +100,13 @@ process naming the file. `resume --init` rewrites the file (self-heal) — asser
 - The "could not bind" branch prints `ENGAGEMENT READY`, a stderr reason naming the registry, an
   `export FDEOPS_ENGAGEMENT=…` workaround, and exits 1. Registry symlink/dir/fifo now all reach it
   because the registry write runs `{ soft: true }` inside the lock (error codes `ESYMLINK` vs
-  `EIRREGULAR`) instead of `process.exit()`-ing from inside `withFileLock` — which used to skip the
+  `EIRREGULAR`) instead of `process.exit()`-ing from inside `withFileLock` - which used to skip the
   message *and* leave a stray lock. Regression checks per mode: exit 1, `ENGAGEMENT READY`, the
   registry named, the workaround offered, `find <root> -name '.registry.lock*'` empty, and for the
   symlink case that the **target file is sha-identical** (nothing written through the link).
 - A **workspace directory whose name contains a newline** serialises as two lines and can never read
-  back — the way to exercise the read-back verification itself rather than the write failure.
-- A **read-only `.registry` file** (chmod 444) still binds successfully and exits 0 — `atomicWriteFile`
+  back - the way to exercise the read-back verification itself rather than the write failure.
+- A **read-only `.registry` file** (chmod 444) still binds successfully and exits 0 - `atomicWriteFile`
   renames over it, and rename only needs the *directory* writable. Verify by grepping the registry
   content rather than trusting the exit code; chmod 555 the **root** to actually block it.
 
@@ -116,7 +116,7 @@ process naming the file. `resume --init` rewrites the file (self-heal) — asser
 early-return, and since v3.10.4 `readEng()` lstats before reading, so most shapes are reported as
 `<f> is not a regular file` / `<f> is a symlink` without printing the target body.
 
-**`readEng()` is not the only reader — always test all four shapes in all five slots, reads *and*
+**`readEng()` is not the only reader - always test all four shapes in all five slots, reads *and*
 writes, each under `timeout`.** Historically three separate unguarded call sites each hung on a fifo
 and each needed its own lstat; assume a fourth exists until proven otherwise:
 
@@ -127,9 +127,9 @@ and each needed its own lstat; assume a fourth exists until proven otherwise:
   now refuses *any* non-regular target: `refused: <f> is not a regular file - remove it and re-run;
   every write is refused while it is there.` (exit 1), with the distinct symlink message
   `refused: <f> is a symlink - write would leave the engagement tree.` Assert the symlink target is
-  sha-identical afterwards — refusal messages alone do not prove there was no write-through.
+  sha-identical afterwards - refusal messages alone do not prove there was no write-through.
 
-To find *which* call blocks, preload an `fs` tracer instead of guessing — the last line printed
+To find *which* call blocks, preload an `fs` tracer instead of guessing - the last line printed
 before the timeout is the culprit, and it needs no repo edits:
 
 ```js
@@ -145,7 +145,7 @@ for (const fn of ['readFileSync','appendFileSync','writeFileSync','openSync']) {
 timeout 12 node --require /tmp/trace-fs.js bin/fde.js doctor 2>&1 | tail
 ```
 
-To decide whether a hang is node or `git`, re-run with a curated PATH that omits `git` — but note a
+To decide whether a hang is node or `git`, re-run with a curated PATH that omits `git` - but note a
 missing `git` changes the code path entirely, so confirm by logging the git argv with a wrapper
 script on PATH rather than concluding from the exit code alone.
 
@@ -164,12 +164,12 @@ Seed a sealed block into `context.md`, `stakeholders.md`, and `decisions.md`, th
 (and shorter fragments of it) is absent from `resume`, `resume --full`, `triage`, `prep`, `receipts`,
 `status`, `status --all`, `doctor`, `capture`, and the `dashboard` HTML at
 `<root>/fieldbook-current.html`, while `(private - redacted)` appears where expected. Always grep the
-`.fde` files as a **control** to prove the needle really is on disk — otherwise the zeros are
+`.fde` files as a **control** to prove the needle really is on disk - otherwise the zeros are
 meaningless. Do not paste raw private blocks into model-facing output.
 
 ## Baseline contrast
 
-To prove a resolution fix actually closes a misroute, test the parent commit, not `Main` — `Main`
+To prove a resolution fix actually closes a misroute, test the parent commit, not `Main` - `Main`
 may already contain the merge:
 
 ```bash

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -9,7 +9,7 @@ FDEOps MCP servers follow a **pluggable source model**: core owns the **sink**, 
 | **Source** | FDE configures separately | Granola, Slack, Notion, Gmail, file |
 | **Sink** | FDEOps (`fdeops-ingest`) | stage → propose → apply into engagement memory |
 
-Source MCPs fetch raw text from SaaS APIs using credentials the FDE manages. The ingest MCP never stores OAuth tokens or calls external services — it only shells out to the local `fde` CLI.
+Source MCPs fetch raw text from SaaS APIs using credentials the FDE manages. The ingest MCP never stores OAuth tokens or calls external services - it only shells out to the local `fde` CLI.
 
 ## Ground loop
 
@@ -28,7 +28,7 @@ Source MCP(s)          fdeops-ingest MCP           fde CLI
 1. Agent pulls from whichever source MCPs are configured.
 2. Agent stages raw content via `ingest_stage` (with `source` provenance).
 3. Agent proposes routing via `ingest_propose`; FDE confirms.
-4. Agent applies via `ingest_apply` — nothing writes `.fde/` unreviewed.
+4. Agent applies via `ingest_apply` - nothing writes `.fde/` unreviewed.
 
 ## Packages
 

--- a/mcp/fdeops-ingest/README.md
+++ b/mcp/fdeops-ingest/README.md
@@ -2,9 +2,9 @@
 
 Thin stdio MCP server for the FDEOps **ingest sink** only: **stage → propose → apply**.
 
-This package shells out to the local `fde` CLI. It never calls SaaS APIs. Source MCPs (Granola, Slack, Notion, etc.) are **separate** — you add those in your own `mcp.json`.
+This package shells out to the local `fde` CLI. It never calls SaaS APIs. Source MCPs (Granola, Slack, Notion, etc.) are **separate** - you add those in your own `mcp.json`.
 
-**Prefer the CLI when this workspace is bound:** `fde ingest stage|list|propose|apply`. Use this MCP when the host did not start in a bound workspace — then pass `engagement` (path to `.fde/` from `fde resume --bind`) on every tool call.
+**Prefer the CLI when this workspace is bound:** `fde ingest stage|list|propose|apply`. Use this MCP when the host did not start in a bound workspace - then pass `engagement` (path to `.fde/` from `fde resume --bind`) on every tool call.
 
 ## Tools
 
@@ -70,12 +70,12 @@ Or after `npm link` in this directory:
 
 ## Daily loop (with separate source MCPs)
 
-1. **Fetch** — Use your source MCP (e.g. Granola, Gmail) to pull raw text. FDEOps does not bundle these.
-2. **Stage** — `ingest_stage` with `content`, `source` (e.g. `"granola"`), optional `title`.
-3. **List** — `ingest_list` to see staged items in `.inbox/`.
-4. **Propose** — `ingest_propose` with the staged `id`; agent reviews `.debrief-propose`.
-5. **Confirm** — FDE approves the proposal in chat.
-6. **Apply** — `ingest_apply` writes dated facts into `.fde/` with provenance.
+1. **Fetch** - Use your source MCP (e.g. Granola, Gmail) to pull raw text. FDEOps does not bundle these.
+2. **Stage** - `ingest_stage` with `content`, `source` (e.g. `"granola"`), optional `title`.
+3. **List** - `ingest_list` to see staged items in `.inbox/`.
+4. **Propose** - `ingest_propose` with the staged `id`; agent reviews `.debrief-propose`.
+5. **Confirm** - FDE approves the proposal in chat.
+6. **Apply** - `ingest_apply` writes dated facts into `.fde/` with provenance.
 
 Raw artifacts stay in `.inbox/`; the system of record (`.fde/`) stays thin and reviewed.
 

--- a/mcp/fdeops-ingest/server.js
+++ b/mcp/fdeops-ingest/server.js
@@ -2,7 +2,7 @@
 'use strict'
 
 /**
- * fdeops-ingest MCP — thin stdio sink for FDEOps ingest.
+ * fdeops-ingest MCP - thin stdio sink for FDEOps ingest.
  * Shells out to local `fde` CLI only. Never calls SaaS.
  * MCP stdio transport: newline-delimited JSON-RPC 2.0
  * (Content-Length frames are accepted on input).

--- a/mcp/recipes/README.md
+++ b/mcp/recipes/README.md
@@ -4,13 +4,13 @@ FDEOps does **not** bundle Granola / Slack / Notion OAuth and does **not** push 
 
 **Daily (no MCP):** paste notes to `@fde debrief`, or drop a file ([file.md](./file.md)).
 
-**Pull (optional):** you add a **source** MCP. The agent fetches text, then runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply). The `fdeops-ingest` MCP is optional — only if you are not using the CLI from a bound workspace.
+**Pull (optional):** you add a **source** MCP. The agent fetches text, then runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply). The `fdeops-ingest` MCP is optional - only if you are not using the CLI from a bound workspace.
 
 | Recipe | When |
 |--------|------|
 | [file.md](./file.md) | Transcript / export already on disk, or paste |
 | [granola.md](./granola.md) | Meeting transcripts via a notes MCP (or export) |
-| [slack.md](./slack.md) | Pull a thread/channel as text — never post |
+| [slack.md](./slack.md) | Pull a thread/channel as text - never post |
 | [notion.md](./notion.md) | Read a Notion page (or export markdown) |
 
 **Natural language:** `@fde I want to connect Granola` (or Slack / Notion) → `skills/fde/references/ingest-connect.md`.

--- a/mcp/recipes/file.md
+++ b/mcp/recipes/file.md
@@ -1,6 +1,6 @@
 # Recipe: local file / paste (no source MCP)
 
-**Use when:** you already have a transcript, `.eml`, or export on disk — or you paste into chat. This is the default FDE path.
+**Use when:** you already have a transcript, `.eml`, or export on disk - or you paste into chat. This is the default FDE path.
 
 ## Setup
 

--- a/mcp/recipes/granola.md
+++ b/mcp/recipes/granola.md
@@ -1,6 +1,6 @@
 # Recipe: Granola-shaped meeting transcripts
 
-**Use when:** meeting notes live in Granola (or a similar notes MCP). FDEOps does not ship a Granola server — you add whichever MCP/export path you trust.
+**Use when:** meeting notes live in Granola (or a similar notes MCP). FDEOps does not ship a Granola server - you add whichever MCP/export path you trust.
 
 Daily path if the notes are already in chat or on disk: paste to `@fde debrief` or [file.md](./file.md). This recipe is only for **pull**.
 
@@ -8,7 +8,7 @@ Daily path if the notes are already in chat or on disk: paste to `@fde debrief` 
 
 1. Enable a **Granola (or notes) MCP** in Cursor/Claude per that product’s docs.
 2. Reload MCP / restart the host.
-3. Test: `@fde what can you pull?` — notes-source tools should appear.
+3. Test: `@fde what can you pull?` - notes-source tools should appear.
 
 The sink is **`fde ingest` in this bound workspace.** You do not need `fdeops-ingest` MCP for daily pull.
 
@@ -40,15 +40,15 @@ Replace command/args with whatever the real Granola MCP documents. FDEOps only n
 
 ## Agent steps
 
-1. Capability check — notes-source tools present?
+1. Capability check - notes-source tools present?
 2. Fetch transcript text (ask which meeting if ambiguous).
 3. `fde ingest stage --source granola --title "<short>"` then propose → confirm → apply.
-4. Extract decisions/risks/next — do not dump the raw transcript into `.fde/`.
+4. Extract decisions/risks/next - do not dump the raw transcript into `.fde/`.
 
 ## Common fails
 
 | Symptom | Fix |
 |---------|-----|
-| No Granola tools | Source MCP not loaded — they save + reload |
+| No Granola tools | Source MCP not loaded - they save + reload |
 | Wrong meeting | One clarifying question, then fetch |
 | Wrong engagement | `fde resume` in this workspace before staging |

--- a/mcp/recipes/notion.md
+++ b/mcp/recipes/notion.md
@@ -1,6 +1,6 @@
 # Recipe: Notion docs / meeting notes
 
-**Use when:** useful engagement notes live in Notion. FDEOps does not ship a Notion server — use a Notion MCP (or export markdown). We do not write back to Notion.
+**Use when:** useful engagement notes live in Notion. FDEOps does not ship a Notion server - use a Notion MCP (or export markdown). We do not write back to Notion.
 
 ## Setup (once)
 
@@ -36,7 +36,7 @@ The sink is **`fde ingest` in this bound workspace.** `fdeops-ingest` MCP is opt
 
 ## Agent steps
 
-1. Capability check — Notion read tools present?
+1. Capability check - Notion read tools present?
 2. Fetch page/block text (ask which page if ambiguous).
 3. `fde ingest stage --source notion --title "<short>"` → propose → confirm → apply.
 

--- a/mcp/recipes/slack.md
+++ b/mcp/recipes/slack.md
@@ -8,7 +8,7 @@ You add whatever Slack MCP your host already supports. We only accept **text you
 
 1. Enable a **Slack MCP** (official or community) with read access to the threads you need.
 2. Reload MCP / restart the host.
-3. Test: `@fde what can you pull?` — Slack fetch tools should appear. The FDEOps **CLI** (`fde ingest`) is the sink if this workspace is bound; you do not need `fdeops-ingest` MCP for daily use.
+3. Test: `@fde what can you pull?` - Slack fetch tools should appear. The FDEOps **CLI** (`fde ingest`) is the sink if this workspace is bound; you do not need `fdeops-ingest` MCP for daily use.
 
 ### Example mcp.json shape (illustrative)
 
@@ -40,10 +40,10 @@ Optional sink MCP (only if you are not running `fde ingest` from this workspace)
 
 ## Agent steps
 
-1. Capability check — Slack **read** tools present? If not → this recipe, then stop.
+1. Capability check - Slack **read** tools present? If not → this recipe, then stop.
 2. Fetch the thread/channel as **text** (ask which channel/thread if ambiguous).
 3. `fde ingest stage --source slack --title "<short>"` (CLI in this bound workspace).
-4. Propose → FDE confirms → apply. Extract decisions/risks/asks — do not dump the thread into `.fde/`.
+4. Propose → FDE confirms → apply. Extract decisions/risks/asks - do not dump the thread into `.fde/`.
 
 ## Never
 
@@ -55,7 +55,7 @@ Optional sink MCP (only if you are not running `fde ingest` from this workspace)
 
 | Symptom | Fix |
 |---------|-----|
-| No Slack tools | Source MCP not loaded — they save + reload; we cannot silent-install |
-| Missing channel | Token/scopes cannot read that workspace — their Slack admin, not FDEOps |
+| No Slack tools | Source MCP not loaded - they save + reload; we cannot silent-install |
+| Missing channel | Token/scopes cannot read that workspace - their Slack admin, not FDEOps |
 | Huge dump | Stage full text in `.inbox/`; apply only short dated facts |
 | Wrong client | Bind this workspace (`fde resume`) before staging |

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -7,13 +7,13 @@ description: Keeps engagement memory for client work - sponsor, promise, what sh
 
 ## Purpose
 
-The **engagement record** for one client. One skill; six stages (land → close). You pick the method; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript; you log what they got. The artifact is the memory.
+The **engagement record** for one client. One skill; six stages (land → close). You pick the method; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript; you log the outcome. The artifact is the memory.
 
 ## When to use
 
 - They named a client, pasted notes, or asked what was agreed
 - The brief feels wrong, a sponsor went quiet, or Friday needs the ledger
-- Unbound — ask the name once, then **you** run `fde resume --init`
+- Unbound - ask the name once, then **you** run `fde resume --init`
 
 ## When NOT to use
 
@@ -25,14 +25,14 @@ TypeScript errors, unit tests, refactors, git commits, generic debug: **host age
 |---------|-----------------|---------|-----------|
 | **The brief is wrong** | "If this works, who in their company would have to agree that it worked?" | `fde resume` then discover | `references/discover.md` |
 | **They went quiet** | "Is this a process gap, or a trust problem?" | `fde log contact "…" --signal amber\|red\|green` | `references/rescue.md` |
-| **When did we agree?** | Don't argue from memory. Search the record. | `fde receipts <term>` | — |
-| **What did they get?** | A number nobody signed is claimed, not delivered. | `fde status` | `references/status.md` |
+| **When did we agree?** | Don't argue from memory. Search the record. | `fde receipts <term>` | - |
+| **What's the outcome?** | A number nobody signed is claimed, not delivered. | `fde status` | `references/status.md` |
 
 After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde prep`. Friday: `fde status`.
 
 ## Human surface vs agent plumbing
 
-**FDE (human):** `@fde` + English, or `/brief` `/discover` `/plan` `/ship` `/got` `/close` `/debrief` `/prep` `/quiet` `/agreed` `/status`. Never a skill catalog.
+**FDE (human):** `@fde` + English, or `/brief` `/discover` `/plan` `/ship` `/outcome` `/close` `/debrief` `/prep` `/quiet` `/agreed` `/status`. Never a skill catalog.
 
 **You (agent):** run the CLI. **Never tell the FDE to type** `fde …`. If unbound, you run `fde resume --init` after one question. Never ask them to run the CLI.
 
@@ -42,7 +42,7 @@ Fallbacks: `node ~/.claude/fdeops/fde.js …`, then `npx --yes fdeops …`. Skil
 
 1. `fde resume` (bounded `context.md`). `--full` only if you need the whole log.
 2. **NO ENGAGEMENT:** ask "What should we call this client?" then **you** init. Pasted notes → debrief after bind.
-3. Playback 2–3 lines. `hygiene:` → offer `fde doctor`; **never auto-rewrite**.
+3. Playback 2-3 lines. `hygiene:` → offer `fde doctor`; **never auto-rewrite**.
 4. Route. Read **one** `references/*.md`. Confirm, then write.
 
 Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on infrastructure they do not control.
@@ -54,10 +54,10 @@ Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on in
 | debrief / pasted notes | `fde debrief --smart` → you rewrite prefixes → confirm → `--apply`. `--smart` is a gate, not a brain. `references/debrief.md` |
 | prep me for … | `fde prep "<label>"` |
 | when did we agree | `fde receipts <term>` |
-| sponsor update / what they got | `fde status` |
+| sponsor update / the outcome | `fde status` |
 | they went quiet | `fde log contact "…" --signal amber\|green\|red` |
 | fieldbook page | `fde dashboard` |
-| clean up the fieldbook | `fde doctor` — never auto-rewrite |
+| clean up the fieldbook | `fde doctor` - never auto-rewrite |
 | scrub a secret | `fde redact <term>` then `--apply` after confirm |
 | pull Granola/Slack/transcript | capability check → `fde ingest stage` → confirm → apply. Never auto-apply. `references/ingest.md` |
 | connect an MCP | `references/ingest-connect.md` |
@@ -69,35 +69,35 @@ Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on in
 2. **Deliverable = memory.** The work *is* the `.fde/` file. The reference names which one.
 3. **Evidence.** Every claim has a source. Traceable beats plausible.
 4. **No invented facts.** People, quotes, meetings, numbers: they said it or the repo shows it. Else `unknown - ask: <question>`.
-5. **Session digest** (end of session and before a PR) — thinking, not the chat. Confirm, then write. Never a transcript dump.
+5. **Session digest** (end of session and before a PR) - thinking, not the chat. Confirm, then write. Never a transcript dump.
 
    | Digest beat | Lands in |
    |-------------|----------|
    | **TL;DR** | `context.md` |
-   | **Key decisions & why** | `decisions.md` — skip if none |
+   | **Key decisions & why** | `decisions.md` - skip if none |
    | **Pivot / aha** | `context.md` or `decisions.md` |
    | **Scope + verification** | `delivery.md` if code/PR; else skip |
    | **Gotchas** | `context.md` |
-   | **Next action** | existing `## Next action` — **replace**; never append a second heading |
+   | **Next action** | existing `## Next action` - **replace**; never append a second heading |
 
    Judgment ships in the fieldbook. Raw transcripts stay on the machine. The `session-stop` hook is a thin backstop; **you** write the digest.
 
 6. **One customer, one folder.**
 7. Never drop `## Signal history` or `## Retired` when rewriting those files.
 
-**Don't invent.** Don't tell them to run the CLI. Don't fill `success.md` / `terrain.md` with guesses. Don't ship on "probably fine" — intent vs diff, then pre-blast. Don't grill mid-flow. Don't sync transcripts into git.
+**Don't invent.** Don't tell them to run the CLI. Don't fill `success.md` / `terrain.md` with guesses. Don't ship on "probably fine" - intent vs diff, then pre-blast. Don't grill mid-flow. Don't sync transcripts into git.
 
 ## Data boundary
 
-CLI is local (`git` + files, no network). You see their code only when they point you at it. AI policy unknown → ask before loading code. `<private>` is redacted from CLI/dashboard/hooks — do not open raw private blocks with file tools.
+CLI is local (`git` + files, no network). You see their code only when they point you at it. AI policy unknown → ask before loading code. `<private>` is redacted from CLI/dashboard/hooks - do not open raw private blocks with file tools.
 
 ## Voice
 
-Direct. Their words. No "Certainly." Playback 2–4 lines, then act. One question only when a missing fact changes the next move.
+Direct. Their words. No "Certainly." Playback 2-4 lines, then act. One question only when a missing fact changes the next move.
 
 New embed: sprint / standard / programme changes depth, not which methods exist. Before first code: safe place to break things, plus AI-code policy. Before go-live: who needs to know, what's the rollback. Before a sponsor artifact: as-is or gut-check first.
 
-Muddy signal: name it ("discover or rescue — leaning X"). Never a phase-picker interview. Default: land if new, audit if takeover.
+Muddy signal: name it ("discover or rescue - leaning X"). Never a phase-picker interview. Default: land if new, audit if takeover.
 
 ## Routing - 6 stages
 
@@ -135,13 +135,13 @@ Read **one** reference and follow it. Do not improvise from memory.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Large feature, need visible progress every 2–3 days | incremental-build | `references/incremental-build.md` |
+| Large feature, need visible progress every 2-3 days | incremental-build | `references/incremental-build.md` |
 | What could go wrong, touching shared infrastructure, need to assess impact | blast-radius | `references/blast-radius.md` |
 | Production down, urgent - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
 | Ready to deploy, going live, pre-flight check | ship | `references/ship.md` |
 | Review this change, is it safe, does it match what we agreed | review | `references/review.md` |
 | Diff grew / scope creep in the PR / "did we only build what we said" / KEEP JUSTIFY SPLIT DROP | review (+ ship if going live) | `references/review.md` Stage 1 · `references/ship.md` Intent vs diff |
-| Wrap the session / share the thinking / catch teammates up / before I open the PR | (memory contract — session digest) | SKILL.md **On exit** — write TL;DR + decisions/why into `.fde/`; no transcript sync |
+| Wrap the session / share the thinking / catch teammates up / before I open the PR | (memory contract - session digest) | SKILL.md **On exit** - write TL;DR + decisions/why into `.fde/`; no transcript sync |
 | "We can always revert" - need to actually test the escape route | rollback-drill | `references/rollback-drill.md` |
 
 ### Prove
@@ -184,8 +184,8 @@ Ready to build with no `terrain.md` / plan: discover or plan first. Takeover wit
 ## Principles
 
 - Never ask the FDE to pick a phase. That's your job.
-- Read `context.md` before speaking. One sharp question — never a barrage.
-- Never invent people, meetings, or numbers — `unknown - ask:` beats a polished lie.
+- Read `context.md` before speaking. One sharp question - never a barrage.
+- Never invent people, meetings, or numbers - `unknown - ask:` beats a polished lie.
 - Every phase ends with its artifact written. No artifact, no "done."
 - Evidence on every claim. The FDE will be challenged on these files.
 - Overlays activate on signal, not on request.

--- a/skills/fde/references/ai.md
+++ b/skills/fde/references/ai.md
@@ -29,7 +29,7 @@ Never start with the most powerful model. Start with the cheapest that meets the
 4. **Does it need fine-tuning?** Only when: you have 500+ high-quality examples, the base model fails consistently on your domain, and the cost of inference at scale justifies the training cost.
 
 **Evaluation method (before choosing):**
-- Build a test set: 50–100 representative inputs with expected outputs.
+- Build a test set: 50-100 representative inputs with expected outputs.
 - Run every candidate model against the test set.
 - Score: accuracy, latency, cost per call, failure modes.
 - The cheapest model that scores above the quality threshold wins.
@@ -38,14 +38,14 @@ Write model selection rationale to `decisions.md`. Include: models tested, test 
 
 ## Engagement eval pack (before AI ships)
 
-When any slice touches a model, embeddings, RAG, or an agent: create or update `.fde/evals.md` **before** ship. Full method: `references/eval-pack.md`. This is the engagement-local test set — not unit tests.
+When any slice touches a model, embeddings, RAG, or an agent: create or update `.fde/evals.md` **before** ship. Full method: `references/eval-pack.md`. This is the engagement-local test set - not unit tests.
 
 **Minimum pack (do not grow until the minimum exists):**
-1. **Component + quality bar** — one sentence each; kill switch / fallback named.
-2. **Golden cases** — 5–20 representative inputs with expected outputs and a pass rule. Prefer real production-shaped data (sanitized).
-3. **Failure modes** — at least the silent ones: hallucination/ungrounded, retrieval miss (if RAG), drift, cost runaway.
-4. **Pass/fail** — dated run; Verdict **SHIP** or **NO-SHIP**; critical fails must be 0.
-5. **HITL gate** — which decisions need human review before action (align with `trust-profile.md`). Empty when policy requires review → NO-SHIP.
+1. **Component + quality bar** - one sentence each; kill switch / fallback named.
+2. **Golden cases** - 5-20 representative inputs with expected outputs and a pass rule. Prefer real production-shaped data (sanitized).
+3. **Failure modes** - at least the silent ones: hallucination/ungrounded, retrieval miss (if RAG), drift, cost runaway.
+4. **Pass/fail** - dated run; Verdict **SHIP** or **NO-SHIP**; critical fails must be 0.
+5. **HITL gate** - which decisions need human review before action (align with `trust-profile.md`). Empty when policy requires review → NO-SHIP.
 
 **When to write:** plan seeds the pack; sketch/build grows goldens; ship requires Verdict SHIP and a receipt in `delivery.md` → `## Ship receipts`. Non-AI work skips this file entirely.
 
@@ -59,7 +59,7 @@ When the AI needs to answer questions about the client's data:
 3. **Generate** - chunks + query → LLM → answer with citations
 
 **Common failure modes:**
-- **Chunk size wrong.** Too small = lost context. Too large = noise drowns signal. Start at 500–1000 tokens with 100-token overlap.
+- **Chunk size wrong.** Too small = lost context. Too large = noise drowns signal. Start at 500-1000 tokens with 100-token overlap.
 - **No citation/grounding.** If the model can't point to where it found the answer, you can't verify it. Always require source attribution.
 - **Stale index.** Documents update, embeddings don't. Define the refresh cadence. Real-time for critical data, daily for reference docs.
 - **Retrieval miss.** The right document exists but wasn't retrieved. Test with known-answer queries where the answer IS in the corpus - if retrieval misses these, the embedding model or chunking strategy needs work.

--- a/skills/fde/references/assumption-audit.md
+++ b/skills/fde/references/assumption-audit.md
@@ -76,11 +76,11 @@ Tell the FDE: how many assumptions extracted, how many critical, which ones were
 
 Acme's brief reads cleanly, which is the signal.
 
-Extracted assumptions include one nobody said aloud: *finance would act on an alert*. The whole plan rests on it, and the evidence behind it is a sentence in a kickoff. Blast radius CRITICAL — if false, alerting changes nothing and the engagement delivers a page nobody answers.
+Extracted assumptions include one nobody said aloud: *finance would act on an alert*. The whole plan rests on it, and the evidence behind it is a sentence in a kickoff. Blast radius CRITICAL - if false, alerting changes nothing and the engagement delivers a page nobody answers.
 
 Validation is a test, not a discussion, and it is cheap: send one real failure notification to the finance channel and watch what happens. It goes first because highest blast radius × cheapest test is the killer test.
 
-Result: acked in 40 minutes, by Marco, not finance. Assumption DISPROVED, and the plan changes before six weeks are spent on it — the alert needs a rota with an owner, which is a different piece of work than the one that was funded. `assumptions.md` records the status, the evidence, and the date; the finding is presented to the FDE as a fact base, not as "the brief was wrong".
+Result: acked in 40 minutes, by Marco, not finance. Assumption DISPROVED, and the plan changes before six weeks are spent on it - the alert needs a rota with an owner, which is a different piece of work than the one that was funded. `assumptions.md` records the status, the evidence, and the date; the finding is presented to the FDE as a fact base, not as "the brief was wrong".
 
 ## Principles
 

--- a/skills/fde/references/blast-radius.md
+++ b/skills/fde/references/blast-radius.md
@@ -26,7 +26,7 @@ CONTAINED  → Only the module you're changing is affected
              Rollback: revert the PR
              Example: changing a utility function with no external callers
 
-ADJACENT   → 2–5 callers or one downstream system affected
+ADJACENT   → 2-5 callers or one downstream system affected
              Rollback: revert the PR + verify downstream
              Example: changing an API response format used by the frontend
 

--- a/skills/fde/references/business-case.md
+++ b/skills/fde/references/business-case.md
@@ -30,7 +30,7 @@ Keep the drivers explicit. "We estimate $200K savings" means nothing. "3 people 
 
 **3. Sensitivity check - name the two drivers that swing the result:**
 
-Every business case has 1–2 variables where a small change flips the outcome. Name them explicitly:
+Every business case has 1-2 variables where a small change flips the outcome. Name them explicitly:
 
 > "This case holds if the team actually reclaims 6+ hours/week per person. If it's only 3 hours, the payback extends from 5 months to 14 months. The validation: measure time-spent before and after pilot with 2 team members."
 
@@ -75,9 +75,9 @@ Acme phase 2 needs funding. The case starts with the cost of doing nothing, not 
 
 Anchor: two silent failures since March, each one day of finance reconciliation by hand plus a late close (`reality.md`, Marco's sheet). That is the number the sponsor already believes because her own team reported it.
 
-Driver model the sponsor can trace: incidents/quarter × hours of manual reconciliation × loaded cost, plus the tail risk of a late regulatory close — stated separately, because mixing a certain small number with an uncertain large one is how a case loses credibility.
+Driver model the sponsor can trace: incidents/quarter × hours of manual reconciliation × loaded cost, plus the tail risk of a late regulatory close - stated separately, because mixing a certain small number with an uncertain large one is how a case loses credibility.
 
-Sensitivity names the two drivers that swing it: incident frequency (2/quarter → 1/quarter and the case halves) and whether the manual re-run continues in parallel (if Marco keeps re-running every morning, the saving is theoretical). The second one is the honest weakness, so it is in the case rather than waiting to be found in the room — with the condition that makes it hold: the morning re-run stops after two clean cycles, agreed with Marco.
+Sensitivity names the two drivers that swing it: incident frequency (2/quarter → 1/quarter and the case halves) and whether the manual re-run continues in parallel (if Marco keeps re-running every morning, the saving is theoretical). The second one is the honest weakness, so it is in the case rather than waiting to be found in the room - with the condition that makes it hold: the morning re-run stops after two clean cycles, agreed with Marco.
 
 ## Principles
 

--- a/skills/fde/references/close.md
+++ b/skills/fde/references/close.md
@@ -18,7 +18,7 @@ The engagement doesn't end at ship. It ends when the customer can maintain what 
 - AI components: did they behave in production? What failure modes did the prototype hide? Is the team equipped to maintain them?
 
 **1b. Value + receipts close gate (refuse green close if any fail):**
-- Primary value bucket in `success.md` matches what the sponsor funded; at least one ledger row has **Measured** (not forever-`pending`) with evidence **and a named customer-side owner in Accepted by** for that bucket — or the retrospective explicitly records “not measured; sponsor accepted pending.” A measured-but-unaccepted number closes as `claimed`; say so in the retrospective rather than closing green on arithmetic nobody signed.
+- Primary value bucket in `success.md` matches what the sponsor funded; at least one ledger row has **Measured** (not forever-`pending`) with evidence **and a named customer-side owner in Accepted by** for that bucket - or the retrospective explicitly records “not measured; sponsor accepted pending.” A measured-but-unaccepted number closes as `claimed`; say so in the retrospective rather than closing green on arithmetic nobody signed.
 - Audit receipt exists for the final shipped path (exceptions/operating map walked; cite file).
 - Eval receipt: **n/a if no AI**, else final golden/eval result + HITL owner recorded; kill switch / fallback named in `handoff.md`.
 - One line in the retrospective: which bucket moved, by how much, vs baseline.
@@ -39,17 +39,17 @@ The engagement doesn't end at ship. It ends when the customer can maintain what 
 
 ## Checkpoint
 
-Direct assessment to the FDE: did the engagement achieve `success.md` · 2–3 lessons that matter · is the pattern worth encoding · is the handoff complete or where are the gaps. Also: value bucket + audit receipt green; eval **n/a or green**. Pending Measured without sponsor acceptance = gap, not green close. Honest - a gap named now is cheaper than a callback in six weeks.
+Direct assessment to the FDE: did the engagement achieve `success.md` · 2-3 lessons that matter · is the pattern worth encoding · is the handoff complete or where are the gaps. Also: value bucket + audit receipt green; eval **n/a or green**. Pending Measured without sponsor acceptance = gap, not green close. Honest - a gap named now is cheaper than a callback in six weeks.
 
 ## Worked example
 
 Acme, twelve weeks in, the FDE is rolling off.
 
-Retrospective against the receipts: `brief.md` asked for monitoring, `reality.md` proved it was ownership — and the delta is the most useful paragraph in the file, because it is exactly the argument the next engagement will need.
+Retrospective against the receipts: `brief.md` asked for monitoring, `reality.md` proved it was ownership - and the delta is the most useful paragraph in the file, because it is exactly the argument the next engagement will need.
 
-The close gate bites in a useful way. The ledger shows detection at 12 minutes measured across two real incidents, but **Accepted by** is empty — Marco confirmed it in Slack, Denise (finance) never did, and Denise is whose escalation started the engagement. So it closes as `claimed` with a one-line retrospective note and a named next step, rather than a green close on a number nobody with budget agreed to.
+The close gate bites in a useful way. The ledger shows detection at 12 minutes measured across two real incidents, but **Accepted by** is empty - Marco confirmed it in Slack, Denise (finance) never did, and Denise is whose escalation started the engagement. So it closes as `claimed` with a one-line retrospective note and a named next step, rather than a green close on a number nobody with budget agreed to.
 
-`handoff.md` is written for the person woken at 2am: the three things that break, what the page means, how to re-run manually the way Marco does, and who holds the tribal knowledge (Raj, who built the original job — credited, because he protects it now). `patterns.md` gets *"unowned job" presents as "unmonitored job"* — it has now happened twice.
+`handoff.md` is written for the person woken at 2am: the three things that break, what the page means, how to re-run manually the way Marco does, and who holds the tribal knowledge (Raj, who built the original job - credited, because he protects it now). `patterns.md` gets *"unowned job" presents as "unmonitored job"* - it has now happened twice.
 
 ## Principles
 

--- a/skills/fde/references/debrief.md
+++ b/skills/fde/references/debrief.md
@@ -12,7 +12,7 @@
 
 - The `fde` CLI is **local, deterministic, no AI**. `--smart` is a **gate + writer**, not a brain.
 - It keeps lines that already have `decision:` / `risk:` / `delivery:` / `contact:` / `next:` prefixes, plus a thin keyword pass (e.g. "we agreed", person+verb lines, "open question").
-- Real messy notes without prefixes often route **0 useful lines** — everything else lands as a context dump. That is expected. **You are the router:** rewrite `.debrief-propose` with type prefixes, then `--apply`.
+- Real messy notes without prefixes often route **0 useful lines** - everything else lands as a context dump. That is expected. **You are the router:** rewrite `.debrief-propose` with type prefixes, then `--apply`.
 - `.debrief-propose` is raw lines only (no routing annotations). "Edit if mis-routed" means **rewrite the line with the right prefix**, not leave a comment in the file.
 
 ## Method (you do this work)
@@ -22,7 +22,7 @@
 1. Save the FDE's notes to a temp `.md` file in the workspace (or pipe stdin).
 2. Run `fde debrief --smart <notes.md>` (or `npx fdeops debrief --smart …`).
 3. Open `.debrief-propose`. If lines lack type prefixes, **rewrite them** before showing the FDE, e.g.:
-   - `decision: agreed chargebacks stay phase 2 — Priya`
+   - `decision: agreed chargebacks stay phase 2 - Priya`
    - `risk: legal may reopen scope if we slip the SOW date`
    - `contact: Priya pushed hard on Friday deck [signal:amber]`
    - `next: send one-pager before Thursday 9am`

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -22,16 +22,16 @@ State your read, let the FDE correct, then discover.
 
 Use when the "problem" is unfalsifiable, success is undefined, or you cannot name the decision discovery informs. Skip when `reality.md` / `terrain.md` already pin a testable claim and the FDE is ready to dig.
 
-Same format as land — one Q + GUESS, no checklist:
+Same format as land - one Q + GUESS, no checklist:
 
 ```
 READ: <the real problem you think exists, in one sentence>
-CONFIDENCE: ~NN% — missing: <what would falsify or confirm it>
+CONFIDENCE: ~NN% - missing: <what would falsify or confirm it>
 Q: <one question that changes where you dig>
 GUESS: <your answer, so they can correct it>
 ```
 
-Stop when you can write the decision sentence under **Frame the decision first**. If a name, quote, or metric is still missing, write `unknown - ask:` — never invent ops folklore to make the map look complete.
+Stop when you can write the decision sentence under **Frame the decision first**. If a name, quote, or metric is still missing, write `unknown - ask:` - never invent ops folklore to make the map look complete.
 
 ## Frame the decision first
 
@@ -92,7 +92,7 @@ The real spec is what people **do** when the system fails - not what the slide d
 - **The hesitation.** When someone says "well, there's also this other thing we do…" - stop them, ask them to finish. The main story is what they're comfortable explaining; the hesitation is the real problem.
 - **"Which part of the codebase do you least want to touch?"** The answer is unanimous and it's the load-bearing wall. Check it against your churn scan - when the human answer and the churn data agree, that's your first map landmark.
 - **Shadow AI.** Someone pasting data into ChatGPT to cope = a real unmet need + an uncontrolled data risk. Note both.
-- **Exception-led operating map.** For each real break (not the slide-deck process): what fails, who notices first, what they do today, and which artifact is trusted in that moment. Prefer exceptions over happy-path swimlanes — the workaround is the operating system. Write rows under `terrain.md` → `## Operating map (exception-led)`. If the section is missing on an older engagement, add it; never regenerate the rest of terrain. When AI is in play, also fill `## Intelligence placement` (deterministic vs LLM judgement vs human approve). **`fde doctor` requires at least one filled exception row before plan/build/ship/close** — empty map after discover is a hygiene fail, not optional polish.
+- **Exception-led operating map.** For each real break (not the slide-deck process): what fails, who notices first, what they do today, and which artifact is trusted in that moment. Prefer exceptions over happy-path swimlanes - the workaround is the operating system. Write rows under `terrain.md` → `## Operating map (exception-led)`. If the section is missing on an older engagement, add it; never regenerate the rest of terrain. When AI is in play, also fill `## Intelligence placement` (deterministic vs LLM judgement vs human approve). **`fde doctor` requires at least one filled exception row before plan/build/ship/close** - empty map after discover is a hygiene fail, not optional polish.
 
 ## Method - part 3: workshop facilitation
 
@@ -137,7 +137,7 @@ A use case that depends on a "Blocker" source doesn't get scored - it gets a dat
 
 Score every candidate use case before anything gets prototyped:
 
-| Dimension | Question | 1–5 |
+| Dimension | Question | 1-5 |
 |---|---|---|
 | Business value | What does it cost them unsolved? | |
 | Complexity | How hard to build safely? (5 = hardest) | |
@@ -196,9 +196,9 @@ Stop. Don't form a fourth hypothesis. Three disproven reads means the brief is a
 
 Acme's brief blamed missing monitoring. Discovery goes to the workaround first.
 
-`git log` shows the reconciliation module at 47 commits/90d with no tests, all from one author who left in February. Marco (ops lead) turns out to keep a spreadsheet: every morning he re-runs the job manually and eyeballs the totals — a habit nobody mentioned because to him it is just the job. That spreadsheet is the system of record when the job fails, which is the actual finding.
+`git log` shows the reconciliation module at 47 commits/90d with no tests, all from one author who left in February. Marco (ops lead) turns out to keep a spreadsheet: every morning he re-runs the job manually and eyeballs the totals - a habit nobody mentioned because to him it is just the job. That spreadsheet is the system of record when the job fails, which is the actual finding.
 
-`reality.md`: **Confirmed:** the job has no owner, and the manual re-run masks failures for a day (evidence: Marco's sheet, Day 5; two silent failures since March, finance escalation Mar 14). **Stated brief was wrong because:** alerting existed last year and was disabled — adding it again without an owner reproduces the same outcome. `terrain.md` gets the hotspot row and an operating-map row: `job fails silently → Marco notices next morning → re-runs by hand → spreadsheet is truth → LOAD-BEARING (Marco, Day 5)`.
+`reality.md`: **Confirmed:** the job has no owner, and the manual re-run masks failures for a day (evidence: Marco's sheet, Day 5; two silent failures since March, finance escalation Mar 14). **Stated brief was wrong because:** alerting existed last year and was disabled - adding it again without an owner reproduces the same outcome. `terrain.md` gets the hotspot row and an operating-map row: `job fails silently → Marco notices next morning → re-runs by hand → spreadsheet is truth → LOAD-BEARING (Marco, Day 5)`.
 
 Checkpoint to the FDE names the sponsor decision this creates: fund ownership, or fund alerting and accept the same failure in six months.
 

--- a/skills/fde/references/eval-pack.md
+++ b/skills/fde/references/eval-pack.md
@@ -1,6 +1,6 @@
 # eval-pack - prove the system before it acts
 
-**Enter when:** the work touches AI/LLM/agents/RAG, or ship/close is blocked because there is no evidence the non-deterministic path is safe. Activate alongside `ai.md`, `sketch`, `build`, or `ship` — not instead of them.
+**Enter when:** the work touches AI/LLM/agents/RAG, or ship/close is blocked because there is no evidence the non-deterministic path is safe. Activate alongside `ai.md`, `sketch`, `build`, or `ship` - not instead of them.
 
 **Read first:** `trust-profile.md` (AI policy + HITL), `terrain.md` (operating map), `delivery.md`. Create or extend `evals.md`.
 
@@ -14,19 +14,19 @@ Intelligence without evidence is token-maxing with a nicer name. An FDE earns tr
 
 **1. Scope the judgement surface.** One sentence: which step uses model judgement, and what must never be autonomous.
 
-**2. Build a golden set (minimum 5–20 for a slice; prefer 50–100 before broad scale).** For each case:
-- input (sanitized — no `<private>` raw values)
+**2. Build a golden set (minimum 5-20 for a slice; prefer 50-100 before broad scale).** For each case:
+- input (sanitized - no `<private>` raw values)
 - expected outcome or expert-approved acceptance note
 - pass rule (exact / contains / short rubric)
 - source: real historical example / expert label / staged fixture
 
 **3. Score pass/fail, not vibes.** Run the suite. Record count pass / fail. Failures get a failure-mode tag (missing data, wrong record, format drift, hallucination, retrieval miss, unsafe action, other).
 
-**4. Human-in-the-loop gate.** Name which outcomes require human approve before side effects. If none, write why that is allowed under `trust-profile.md` AI policy — do not invent permission.
+**4. Human-in-the-loop gate.** Name which outcomes require human approve before side effects. If none, write why that is allowed under `trust-profile.md` AI policy - do not invent permission.
 
 **5. Ship rule.** Until `evals.md` shows Verdict **SHIP** with a dated run (critical fails = 0) and HITL filled when policy requires it, AI-touching ship stays **fix-first**. Log a one-line eval receipt in `delivery.md` → `## Ship receipts`.
 
-## Artifact — `evals.md`
+## Artifact - `evals.md`
 
 Create on first AI-touching slice (not at `resume --init`). Use the stub in `templates/.fde/evals.md`. Every claim needs a source. Missing evidence → leave the cell `unknown - ask:`, never invent scores.
 
@@ -38,6 +38,6 @@ Present to the FDE: suite size, pass rate, top failure mode, HITL gate, Verdict 
 
 - No golden set, no AI ship.
 - Pass/fail beats “looks good.”
-- Failure modes are the product — the happy path is table stakes.
+- Failure modes are the product - the happy path is table stakes.
 - HITL is a gate, not a slide.
 - Non-AI work does not need this file.

--- a/skills/fde/references/handoff-engineering.md
+++ b/skills/fde/references/handoff-engineering.md
@@ -58,13 +58,13 @@ Rollback: <exact command and expected time>
 
 | Session | Focus | Attendees | Duration | Output |
 |---------|-------|-----------|----------|--------|
-| **Architecture walkthrough** | Why, not what. The decisions, the trade-offs, the things that almost went wrong. | Full team | 60–90 min | Recording + Q&A log |
+| **Architecture walkthrough** | Why, not what. The decisions, the trade-offs, the things that almost went wrong. | Full team | 60-90 min | Recording + Q&A log |
 | **Operational drill** | Deploy, rollback, incident response. They do it, you watch. | On-call team | 60 min | Drill report with confidence level |
 | **Edge-case handover** | The things that aren't in any document. The workarounds, the fragile spots, the "ask Sarah because she's the only one who knows." | Team lead + 1 | 30 min | Additions to `handoff.md` |
 
 **4. The confidence check.** After the knowledge transfer, score the team's readiness:
 
-| Area | Confidence (1–5) | Evidence |
+| Area | Confidence (1-5) | Evidence |
 |------|------------------|----------|
 | Daily operations | | Can they deploy and rollback without help? |
 | Incident response | | Did they complete the drill within acceptable time? |

--- a/skills/fde/references/incremental-build.md
+++ b/skills/fde/references/incremental-build.md
@@ -1,6 +1,6 @@
 # incremental-build - thin slices on someone else's codebase
 
-**Enter when:** the build task is larger than a single PR, multiple files or systems are involved, or the FDE needs to show visible progress to a stakeholder every 2–3 days.
+**Enter when:** the build task is larger than a single PR, multiple files or systems are involved, or the FDE needs to show visible progress to a stakeholder every 2-3 days.
 
 **Read first:** `decisions.md` (the plan), `terrain.md` (the danger zones), `context.md`. This skill works *inside* the build phase - it's the execution discipline that makes large features safe on codebases you don't own.
 
@@ -50,14 +50,14 @@ Read existing code in the area (search before creating)
 
 | Metric | Target | Why |
 |--------|--------|-----|
-| Lines changed | 100–300 | Reviewable in one sitting |
-| Time to implement | 30–90 minutes | Testable before context decays |
-| Files touched | 1–5 | Blast radius stays containable |
+| Lines changed | 100-300 | Reviewable in one sitting |
+| Time to implement | 30-90 minutes | Testable before context decays |
+| Files touched | 1-5 | Blast radius stays containable |
 | Tests added | ≥1 per new behaviour | Proves the slice works; guards against regression |
 
 A slice larger than 300 lines → split before implementing. "It's all connected" means the design needs work, not the slice limit.
 
-**5. Stakeholder visibility rhythm.** Every 2–3 slices, something the customer can see:
+**5. Stakeholder visibility rhythm.** Every 2-3 slices, something the customer can see:
 
 - A working endpoint they can hit
 - A UI change they can click
@@ -80,12 +80,12 @@ Technical progress invisible to stakeholders is trust decay. `delivery.md` gets 
 
 ## Checkpoint
 
-After each slice: tests pass (state the command and result), acceptance criteria met, blast radius as declared. After every 2–3 slices: stakeholder visibility confirmed - what did they see, and what's their signal?
+After each slice: tests pass (state the command and result), acceptance criteria met, blast radius as declared. After every 2-3 slices: stakeholder visibility confirmed - what did they see, and what's their signal?
 
 ## Principles
 
 - Vertical slices, always. Horizontal layers are untestable until assembled.
-- 100–300 lines per slice. Larger means split first.
+- 100-300 lines per slice. Larger means split first.
 - Every slice is independently revertible. If it isn't, the design is coupled.
-- Visible progress every 2–3 slices. Technical progress alone is trust decay.
+- Visible progress every 2-3 slices. Technical progress alone is trust decay.
 - The ugly code outside your slice stays ugly. That's discipline, not laziness.

--- a/skills/fde/references/ingest-connect.md
+++ b/skills/fde/references/ingest-connect.md
@@ -15,15 +15,15 @@
 
 ## Method
 
-1. **Ask one question** — which source? (`file` / `granola` / `slack` / `notion` / other). If "other", ask for the MCP they intend to use. If they just want paste → send them to debrief and stop.
-2. **Capability check (current session)** — list MCP tools you can actually call:
+1. **Ask one question** - which source? (`file` / `granola` / `slack` / `notion` / other). If "other", ask for the MCP they intend to use. If they just want paste → send them to debrief and stop.
+2. **Capability check (current session)** - list MCP tools you can actually call:
    - Sink: `fde ingest` CLI (preferred) and/or `ingest_stage`
    - Source: anything that can **fetch** that system's content (not post)
    - Say clearly: *available now* vs *needs config*.
-3. **Emit config for the source only** — open `mcp/recipes/<source>.md`. Fill placeholders from *that product's* docs. Tell them to paste secrets into host env — never into `.fde/`.
-4. **Tell them where to paste** — Cursor MCP settings / `mcp.json`. Claude Code: their MCP config. Save → reload MCP / restart session.
-5. **Verify** — after reload: re-run capability check. If source tools appear, offer a **test pull** staged to `.inbox/` only. Stop before apply unless they ask to propose.
-6. **Handoff phrase** — e.g. `@fde pull today's Acme Granola into the fieldbook`.
+3. **Emit config for the source only** - open `mcp/recipes/<source>.md`. Fill placeholders from *that product's* docs. Tell them to paste secrets into host env - never into `.fde/`.
+4. **Tell them where to paste** - Cursor MCP settings / `mcp.json`. Claude Code: their MCP config. Save → reload MCP / restart session.
+5. **Verify** - after reload: re-run capability check. If source tools appear, offer a **test pull** staged to `.inbox/` only. Stop before apply unless they ask to propose.
+6. **Handoff phrase** - e.g. `@fde pull today's Acme Granola into the fieldbook`.
 
 ## If they only want paste / files
 

--- a/skills/fde/references/ingest.md
+++ b/skills/fde/references/ingest.md
@@ -1,6 +1,6 @@
 # ingest - pull large artifacts into the fieldbook loop
 
-**Enter when:** the FDE wants to catch the engagement up from external sources — "make sure Acme is up to date," "pull what's relevant," "grab today's Granola and Denise's last email." Raw transcripts and long emails that are too big to paste usefully.
+**Enter when:** the FDE wants to catch the engagement up from external sources - "make sure Acme is up to date," "pull what's relevant," "grab today's Granola and Denise's last email." Raw transcripts and long emails that are too big to paste usefully.
 
 **Connect / capability (different entry):** "connect a new MCP", "connect Granola/Slack/Notion", "what can you pull?" → `references/ingest-connect.md` first. Recipes: `mcp/recipes/` (file, granola, slack, notion).
 
@@ -11,7 +11,7 @@
 ## Honest contract (read once)
 
 - FDEOps owns the **sink only**: stage raw pulls → propose → confirm → apply. Nothing writes `.fde/` unreviewed.
-- **Source MCPs are the FDE's.** Granola, Slack, Notion, Gmail, custom — whatever they configured in Cursor/Claude. fdeops does not bundle OAuth, connectors, or ambient sync, and **does not push** to those tools.
+- **Source MCPs are the FDE's.** Granola, Slack, Notion, Gmail, custom - whatever they configured in Cursor/Claude. fdeops does not bundle OAuth, connectors, or ambient sync, and **does not push** to those tools.
 - Prefer **`fde ingest` in this bound workspace.** Optional `fdeops-ingest` MCP: pass `engagement` (path to `.fde/` from `fde resume --bind`) because MCP cwd often is not the client workspace.
 - The core `fde` CLI stays local (git + file reads). Source credentials live with that MCP; fdeops never stores them.
 - After apply, raw stays in `.inbox/`; the system of record (`.fde/`) stays thin dated facts.
@@ -20,20 +20,20 @@
 
 List what you can actually call **this session**:
 
-1. **Sink** — `ingest_stage` / `fde ingest` available?
-2. **Sources** — which fetch tools exist (Granola-shaped, Slack, Notion, Drive, file-only)?
+1. **Sink** - `ingest_stage` / `fde ingest` available?
+2. **Sources** - which fetch tools exist (Granola-shaped, Slack, Notion, Drive, file-only)?
 3. Tell the FDE in one line: *I can pull from X; Y is not connected.* If they asked to pull Y and it is missing → switch to `ingest-connect.md`. Never pretend a source exists.
 
 ## Ground loop (you do this work)
 
-1. **Bind** the engagement (`fde resume` / registry). If multiple meetings or threads could apply, ask **one** clarifying question — which meeting, which thread, which date range.
+1. **Bind** the engagement (`fde resume` / registry). If multiple meetings or threads could apply, ask **one** clarifying question - which meeting, which thread, which date range.
 2. **Capability check** (above). Then **fetch** via available source MCP(s). You pull; the CLI does not reach the network.
-3. **Stage** — `fde ingest stage [--source NAME] [--title TEXT] [file|-]` writes raw text into `<engagement>/.inbox/` (outside the memory git ledger).
-4. **List** (optional) — `fde ingest list` shows staged items when you need an id or filename.
-5. **Propose** — `fde ingest propose <id-or-filename>` runs the debrief `--smart` path on the staged body (+ provenance line). Opens `.debrief-propose`.
-6. **Rewrite prefixes** — same as debrief: lines without `decision:` / `risk:` / `delivery:` / `contact:` / `next:` need **you** to rewrite before showing the FDE. `--smart` is a gate, not a brain.
+3. **Stage** - `fde ingest stage [--source NAME] [--title TEXT] [file|-]` writes raw text into `<engagement>/.inbox/` (outside the memory git ledger).
+4. **List** (optional) - `fde ingest list` shows staged items when you need an id or filename.
+5. **Propose** - `fde ingest propose <id-or-filename>` runs the debrief `--smart` path on the staged body (+ provenance line). Opens `.debrief-propose`.
+6. **Rewrite prefixes** - same as debrief: lines without `decision:` / `risk:` / `delivery:` / `contact:` / `next:` need **you** to rewrite before showing the FDE. `--smart` is a gate, not a brain.
 7. **Show** the proposed routing in plain language. Wait for confirm.
-8. **Apply** — on FDE confirm only → `fde ingest apply` (= `fde debrief --apply`). On reject → stop; ask what to change.
+8. **Apply** - on FDE confirm only → `fde ingest apply` (= `fde debrief --apply`). On reject → stop; ask what to change.
 
 No invented names, meetings, or quotes. If the propose looks wrong, fix prefixes with judgment, then re-show before apply.
 
@@ -41,7 +41,7 @@ No invented names, meetings, or quotes. If the propose looks wrong, fix prefixes
 
 | Path | Role |
 |------|------|
-| `~/fde-engagements/<slug>/.inbox/` | Staging for raw pulls. Not the memory ledger. NDA surface — same home tree as `.fde/`. |
+| `~/fde-engagements/<slug>/.inbox/` | Staging for raw pulls. Not the memory ledger. NDA surface - same home tree as `.fde/`. |
 | `~/fde-engagements/<slug>/.fde/` | System of record (unchanged contract). |
 | `.fde/.debrief-propose` | Propose file (shared with debrief). |
 
@@ -56,15 +56,15 @@ fde ingest apply
 
 ## Provenance
 
-When a staged fact came from a named source, carry `via:<source>` on the applied line where useful (e.g. `via:granola`, `via:gmail`). Helps receipts and sponsor disputes later — not mandatory on every context line.
+When a staged fact came from a named source, carry `via:<source>` on the applied line where useful (e.g. `via:granola`, `via:gmail`). Helps receipts and sponsor disputes later - not mandatory on every context line.
 
 ## MCP sink + recipes
 
-Optional `mcp/fdeops-ingest` wraps the same verbs over stdio. Source MCPs remain separate — the FDE adds whichever fetch tools they trust. Setup coach: `ingest-connect.md`. Copy-paste recipes: `mcp/recipes/`.
+Optional `mcp/fdeops-ingest` wraps the same verbs over stdio. Source MCPs remain separate - the FDE adds whichever fetch tools they trust. Setup coach: `ingest-connect.md`. Copy-paste recipes: `mcp/recipes/`.
 
 ## Checkpoint
 
-Before apply, read back the 2–3 most consequential captures in one breath — same as debrief. Confirm which sources you staged and what would land in the record. Then stop.
+Before apply, read back the 2-3 most consequential captures in one breath - same as debrief. Confirm which sources you staged and what would land in the record. Then stop.
 
 ## Principles
 

--- a/skills/fde/references/initiative-triage.md
+++ b/skills/fde/references/initiative-triage.md
@@ -29,15 +29,15 @@ Notice: every stakeholder's initiative is P0 or P1. That's the problem this skil
 | **Dependency** | How many other initiatives are blocked waiting for this? | 0 (standalone) → 5 (critical path for 3+ others) |
 | **Cost of delay** | What happens each week this doesn't ship? | 1 (nothing) → 5 (measurable loss or regulatory exposure) |
 
-**Triage score = Impact + Dependency + Cost of delay** (simple sum, 3–15 range).
+**Triage score = Impact + Dependency + Cost of delay** (simple sum, 3-15 range).
 
 **3. Sort into three lanes:**
 
 | Lane | Score | Action |
 |------|-------|--------|
-| **Now** (max 3) | 11–15 | Active work this phase. FDE and team capacity allocated. |
-| **Next** (max 5) | 7–10 | Sequenced for the following phase. Dependencies tracked but not started. |
-| **Later** (unlimited) | 3–6 | Captured, not committed. Revisit at next triage. |
+| **Now** (max 3) | 11-15 | Active work this phase. FDE and team capacity allocated. |
+| **Next** (max 5) | 7-10 | Sequenced for the following phase. Dependencies tracked but not started. |
+| **Later** (unlimited) | 3-6 | Captured, not committed. Revisit at next triage. |
 
 **The cap matters.** "Now" has exactly 3 slots. Not 4, not "3 plus this small one." Discipline is the product.
 
@@ -51,8 +51,8 @@ Notice: every stakeholder's initiative is P0 or P1. That's the problem this skil
 
 | Engagement type | Triage frequency | Trigger for emergency re-triage |
 |----------------|-----------------|-------------------------------|
-| Sprint (1–2 weeks) | Once, at plan | Crisis or sponsor change |
-| Standard (1–4 weeks) | Weekly | New P0 from sponsor |
+| Sprint (1-2 weeks) | Once, at plan | Crisis or sponsor change |
+| Standard (1-4 weeks) | Weekly | New P0 from sponsor |
 | Programme (months) | Bi-weekly | Quarterly review, team change, market shift |
 
 **6. Communicate the triage result.** The output is not just a priority list - it's a commitment:

--- a/skills/fde/references/land.md
+++ b/skills/fde/references/land.md
@@ -20,18 +20,18 @@ State your read, let the FDE correct, then land.
 
 ## Brief interrogation (only when the brief is thin)
 
-Use this when the ask is conventional or underspecified — missing who decides, why now, what success looks like, or the binding constraint. **Do not** run it when the FDE already gave a clear brief, is mid-flow, or asked for speed over verification.
+Use this when the ask is conventional or underspecified - missing who decides, why now, what success looks like, or the binding constraint. **Do not** run it when the FDE already gave a clear brief, is mid-flow, or asked for speed over verification.
 
-Format — one question at a time, with a guess the FDE can correct:
+Format - one question at a time, with a guess the FDE can correct:
 
 ```
-READ: <one sentence — what you think they actually need>
-CONFIDENCE: ~NN% — missing: <what still blocks a safe start>
+READ: <one sentence - what you think they actually need>
+CONFIDENCE: ~NN% - missing: <what still blocks a safe start>
 Q: <one focused question>
 GUESS: <your best answer, so they can push back fast>
 ```
 
-Wait for the reaction before the next question. Stop when confidence is high enough to write `success.md` without inventing names, or when the FDE says move on. Every answer that is still unknown stays `unknown - ask:` in the artifact — never fill the gap with a plausible stakeholder.
+Wait for the reaction before the next question. Stop when confidence is high enough to write `success.md` without inventing names, or when the FDE says move on. Every answer that is still unknown stays `unknown - ask:` in the artifact - never fill the gap with a plausible stakeholder.
 
 ## Method - part 1: interrogate the brief (you do this work)
 
@@ -65,7 +65,7 @@ Let silence sit. If their fear doesn't match the written brief, the brief is wro
 - **The previous attempt** - "we tried something similar last year" is the most important sentence in the first meeting. Who was involved? Still there and protective, or gone because of it?
 - **The passed-over internal team** - they know exactly what's wrong, and they resent the FDE's presence. Find them before the first standup, ask what they tried, use their language in every meeting. Make them look right and they protect you; ignore them and they wait for the mistake.
 - **The sacred thing** - "Is there anything in this environment I should treat as untouchable?" The hesitation before the answer is the answer.
-- **Exception path (operating map seed)** - "When the happy path breaks this week, what do people actually do — who do they call, what spreadsheet opens, what do they skip?" Capture the break → workaround → who owns it. Do not build a full map on day 1; seed rows later in `terrain.md` → `## Operating map (exception-led)` during discover. Unknowns stay `unknown - ask:`.
+- **Exception path (operating map seed)** - "When the happy path breaks this week, what do people actually do - who do they call, what spreadsheet opens, what do they skip?" Capture the break → workaround → who owns it. Do not build a full map on day 1; seed rows later in `terrain.md` → `## Operating map (exception-led)` during discover. Unknowns stay `unknown - ask:`.
 - **AI posture and policy** - tools already in use (sanctioned or shadow), and: "Does your organisation have a policy on AI-generated code? Are there decisions where you would not be comfortable with AI involvement?"
 - **Boundaries in multi-vendor rooms** - who owns what surface, who signs off before a change crosses it.
 
@@ -119,9 +119,9 @@ If remote: trust-building takes ~40% longer - push for a short video call before
 
 Kickoff at Acme payments. Priya (VP Eng) sponsors; the brief says "add monitoring to the reconciliation service."
 
-Asking what happens the week after a perfect delivery gets: "I stop hearing about it from finance." That is the real success statement — not monitoring. The previous attempt surfaces too: the platform team built alerting last year, it was turned off. Raj, who built it, is still there and was not in the kickoff — the passed-over team, found on day 1 rather than at the first standup.
+Asking what happens the week after a perfect delivery gets: "I stop hearing about it from finance." That is the real success statement - not monitoring. The previous attempt surfaces too: the platform team built alerting last year, it was turned off. Raj, who built it, is still there and was not in the kickoff - the passed-over team, found on day 1 rather than at the first standup.
 
-What gets written: `success.md` with bucket `risk-mitigation`, `reconciliation failures reach a named owner within 15 min (baseline: 4h, found by finance)`, gaming check `alerting on everything so nobody reads them` → guard `≤2 alerts/week, acked by name`, sign-off Priya. `brief.md` carries the gap list and the hypothesis: *the job is not unmonitored, it is unowned*. `assumptions.md` seeds `"finance would act on an alert" — CRITICAL — OPEN — (stated, unverified)`. `trust-profile.md` records the sacred thing Priya hesitated before naming.
+What gets written: `success.md` with bucket `risk-mitigation`, `reconciliation failures reach a named owner within 15 min (baseline: 4h, found by finance)`, gaming check `alerting on everything so nobody reads them` → guard `≤2 alerts/week, acked by name`, sign-off Priya. `brief.md` carries the gap list and the hypothesis: *the job is not unmonitored, it is unowned*. `assumptions.md` seeds `"finance would act on an alert" - CRITICAL - OPEN - (stated, unverified)`. `trust-profile.md` records the sacred thing Priya hesitated before naming.
 
 Day-1 deliverable: fix the log line that swallows the job's exit code. Small, visible, in their environment.
 

--- a/skills/fde/references/multi-customer-ops.md
+++ b/skills/fde/references/multi-customer-ops.md
@@ -70,7 +70,7 @@ The 3-line context update is the bridge. Without it, the next session starts wit
 | Engagement intensity | Status cadence | Touchpoint type |
 |---------------------|---------------|-----------------|
 | Active build (daily work) | Weekly written + ad-hoc Slack | Status update + visible progress |
-| Light touch (2–3 days/week) | Weekly written | Status update + next week's plan |
+| Light touch (2-3 days/week) | Weekly written | Status update + next week's plan |
 | Monitoring only | Bi-weekly written | Health check + any emerging risks |
 
 **The golden rule: no customer should have to chase you for an update.** Proactive status updates are cheaper than reactive ones - and they protect trust across all engagements.

--- a/skills/fde/references/options-analysis.md
+++ b/skills/fde/references/options-analysis.md
@@ -76,11 +76,11 @@ Present the three options and the recommendation. One question to the FDE: "Whic
 
 Acme: the reconciliation job needs to survive the FDE leaving. Priya asks "so what should we do?"
 
-Three real paths, not a strawman set. **Safe:** keep the job, add the rota and runbook — two weeks, no new failure modes, does nothing about the 47-commits/90d hotspot. **Pragmatic:** extract the settlement-matching step behind a tested interface — six weeks, retires the untested hotspot, needs Raj's time and he currently opposes it. **Aggressive:** rewrite the service — a quarter, fixes everything, and the same team already abandoned this once.
+Three real paths, not a strawman set. **Safe:** keep the job, add the rota and runbook - two weeks, no new failure modes, does nothing about the 47-commits/90d hotspot. **Pragmatic:** extract the settlement-matching step behind a tested interface - six weeks, retires the untested hotspot, needs Raj's time and he currently opposes it. **Aggressive:** rewrite the service - a quarter, fixes everything, and the same team already abandoned this once.
 
 Same dimensions on each, so comparison is instant, and every cost carries a source: the six-week figure is churn-based, not felt.
 
-Recommendation: pragmatic, conditional — *if* Raj is on the design, otherwise safe, because the aggressive path failed here before for exactly the reason it would fail again. `decisions.md` records the decision, who chose it, and the condition, so week 10's "why aren't we rewriting it" has an answer with a date on it.
+Recommendation: pragmatic, conditional - *if* Raj is on the design, otherwise safe, because the aggressive path failed here before for exactly the reason it would fail again. `decisions.md` records the decision, who chose it, and the condition, so week 10's "why aren't we rewriting it" has an answer with a date on it.
 
 ## Principles
 

--- a/skills/fde/references/plan.md
+++ b/skills/fde/references/plan.md
@@ -30,11 +30,11 @@ An FDE plan is not a sprint backlog. The technical sequence is the easy part. Th
 
 **3. Slice vertically.** Each task delivers something visible and testable end to end ("user submits form, sees it saved"), never a horizontal layer ("build the database layer").
 
-**4. Size to 30–90 minutes, PR-sized.** Longer = two tasks. Each task implementable, testable, reviewable without a thousand-line diff.
+**4. Size to 30-90 minutes, PR-sized.** Longer = two tasks. Each task implementable, testable, reviewable without a thousand-line diff.
 
 **5. AI components get explicit eval tasks.** "Output validated on 50 real production examples," "fallback tested under model unavailability," "inputs/outputs logging to <destination>" - these are pre-conditions of shipping, in the plan before build starts.
 
-**6. Stakeholder touchpoints every 2–3 tasks.** "Show progress to <name from stakeholders.md>." Not ceremony: a customer who sees small wins stays bought in; silence gets filled with doubt.
+**6. Stakeholder touchpoints every 2-3 tasks.** "Show progress to <name from stakeholders.md>." Not ceremony: a customer who sees small wins stays bought in; silence gets filled with doubt.
 
 **7. End with a kill list.** Every plan names what you will **not** do this phase. If everything is "later," you have no plan - you have a wish list. Cap **Now** at 3 slices (same discipline as initiative-triage).
 
@@ -83,7 +83,7 @@ Every FDE gets asked this in week one. The honest answer is a range, not a numbe
 2. **Expected case** - normal friction: one discovery changes the plan, one integration takes longer, one approval cycle stalls. This is what to plan against.
 3. **Worst case** - a major unknown surfaces, a dependency fails, a key person is unavailable. This is what to protect against.
 
-**Present as:** "2–4 weeks expected, could stretch to 6 if [named risk]." Never give one number.
+**Present as:** "2-4 weeks expected, could stretch to 6 if [named risk]." Never give one number.
 
 **The sizing table:**
 
@@ -135,9 +135,9 @@ Never quietly update tasks. Name the reset: update `reality.md` and `success.md`
 
 Acme, after discover: the reconciliation job is unowned, Marco's spreadsheet is the real fallback.
 
-**Now** is three tasks, not eight. Task 1 is *failures reach a named human* — delivers a page to a rota, accepts "kill the job mid-run → the on-call is paged within 15 min", touches the job wrapper and the alert config, rollback is re-disable the route, verify by killing it in staging. Value promised: `risk-mitigation — a silent failure becomes a 15-minute one`.
+**Now** is three tasks, not eight. Task 1 is *failures reach a named human* - delivers a page to a rota, accepts "kill the job mid-run → the on-call is paged within 15 min", touches the job wrapper and the alert config, rollback is re-disable the route, verify by killing it in staging. Value promised: `risk-mitigation - a silent failure becomes a 15-minute one`.
 
-The kill list in `decisions.md` is where the plan earns its keep: the rewrite of the reconciliation service that Tom keeps proposing goes there — *deferred, the failure mode is ownership not architecture (Priya accepted, Jun 12)* — along with the finance dashboard finance asked for directly. Both stay visible so the same argument is not re-litigated in week 4 without a receipt.
+The kill list in `decisions.md` is where the plan earns its keep: the rewrite of the reconciliation service that Tom keeps proposing goes there - *deferred, the failure mode is ownership not architecture (Priya accepted, Jun 12)* - along with the finance dashboard finance asked for directly. Both stay visible so the same argument is not re-litigated in week 4 without a receipt.
 
 First visible slice goes to Marco, not Priya: he is the one whose morning changes, and his confirmation is what makes the sponsor update true.
 
@@ -145,7 +145,7 @@ First visible slice goes to Marco, not Priya: he is the one whose morning change
 
 - Plan from success backwards, not from today forwards.
 - Fragile zones early. Fail fast.
-- Every 2–3 tasks, a stakeholder touchpoint. Trust decays without visibility.
+- Every 2-3 tasks, a stakeholder touchpoint. Trust decays without visibility.
 - No written acceptance criteria, no build.
 - No kill list, no finished plan.
 - Estimates are ranges, not promises. Name the assumptions.

--- a/skills/fde/references/red-team.md
+++ b/skills/fde/references/red-team.md
@@ -28,10 +28,10 @@ You are not a helpful peer right now. You are the skeptical senior who has seen 
 ```
 CLAIM: <the position under test, one sentence>
 WHY IT MATTERS: <credibility / time / engagement risk if wrong>
-CHALLENGE: <your strongest counter — specific names/dates from .fde/ only>
+CHALLENGE: <your strongest counter - specific names/dates from .fde/ only>
 ```
 
-Wait for their defense. Score it SOLID / THIN / EXPOSED (same scale as step 5). Only then widen into the five angles. If the claim collapses here, stop — the kill list is already clear.
+Wait for their defense. Score it SOLID / THIN / EXPOSED (same scale as step 5). Only then widen into the five angles. If the claim collapses here, stop - the kill list is already clear.
 
 **3. Attack from five angles.** Every plan has five failure surfaces. Hit each one:
 

--- a/skills/fde/references/review.md
+++ b/skills/fde/references/review.md
@@ -12,7 +12,7 @@ Thousands of lines or dozens of unrelated files → **stop**, recommend the spli
 
 ## Stage 1 - did we build what we agreed? (you do this work)
 
-Check the diff against the **one-line intent** in `decisions.md` / acceptance criteria — what was *explicitly decided*, not what seems right:
+Check the diff against the **one-line intent** in `decisions.md` / acceptance criteria - what was *explicitly decided*, not what seems right:
 
 ```bash
 git diff <base>...HEAD --stat
@@ -23,9 +23,9 @@ For each touched path (or logical hunk), assign one verdict:
 | Verdict | Meaning |
 |---------|---------|
 | **KEEP** | Required for the stated intent |
-| **JUSTIFY** | Adjacent but must ship now — write one sentence why, or SPLIT |
-| **SPLIT** | Real work for another PR / Next / kill list — do not merge with this slice |
-| **DROP** | Noise / drive-by — revert before Pass |
+| **JUSTIFY** | Adjacent but must ship now - write one sentence why, or SPLIT |
+| **SPLIT** | Real work for another PR / Next / kill list - do not merge with this slice |
+| **DROP** | Noise / drive-by - revert before Pass |
 
 Also check:
 - Any sacred system from `trust-profile.md` touched?
@@ -34,7 +34,7 @@ Also check:
 
 **Stage 1 fails → stop** if any SPLIT/DROP remains, or JUSTIFY lacks a written sentence. Quality review on out-of-scope code is wasted work. Record the mismatch (and the KEEP/JUSTIFY/SPLIT/DROP tally) in `decisions.md`.
 
-Stakeholder "also can you…" mid-build is `scope-defense` — different axis. This stage is **code vs claim**.
+Stakeholder "also can you…" mid-build is `scope-defense` - different axis. This stage is **code vs claim**.
 
 ## Stage 2 - is it safe to live with?
 
@@ -59,7 +59,7 @@ Five dimensions, line-specific ("line 47 fails under concurrent writes - no lock
 
 ## Before the PR - thinking for the next reader
 
-Code alone loses the "why." Before you call the change reviewable, run the **session digest** from the memory contract (SKILL.md On exit): TL;DR, key decisions & rationale, scope + how you verified, gotchas. Confirm with the FDE, then write into `.fde/` — `decisions.md` / `delivery.md` / `context.md`. Reviewers (or Monday-you) should answer "why this approach?" from the fieldbook, not from a chat transcript. Do **not** dump agent logs into the product repo.
+Code alone loses the "why." Before you call the change reviewable, run the **session digest** from the memory contract (SKILL.md On exit): TL;DR, key decisions & rationale, scope + how you verified, gotchas. Confirm with the FDE, then write into `.fde/` - `decisions.md` / `delivery.md` / `context.md`. Reviewers (or Monday-you) should answer "why this approach?" from the fieldbook, not from a chat transcript. Do **not** dump agent logs into the product repo.
 
 ## Artifact
 
@@ -70,7 +70,7 @@ Code alone loses the "why." Before you call the change reviewable, run the **ses
 ## Principles
 
 - Stage 1 before Stage 2. Wrong scope reviewed well is still wrong scope.
-- KEEP / JUSTIFY / SPLIT / DROP — every path gets a verdict; silent extras fail Stage 1.
+- KEEP / JUSTIFY / SPLIT / DROP - every path gets a verdict; silent extras fail Stage 1.
 - Specific or silent - vague concerns waste everyone's time.
 - No rollback path = first finding.
 - A clean review proves this diff is safe as agreed - not that the feature was right.

--- a/skills/fde/references/scope-defense.md
+++ b/skills/fde/references/scope-defense.md
@@ -38,7 +38,7 @@ Log via `fde log decision "scope change: <summary> - requested by <who>, impact:
 
 **The key phrase: "Let me place it."** Not "that's out of scope" (adversarial) or "sure" (absorbed). "Let me place it" signals you're taking it seriously while buying time to assess the real cost.
 
-**4. The accumulation conversation.** When the scope receipts show a pattern - typically 3–5 absorbed changes - the FDE needs a conversation with the sponsor:
+**4. The accumulation conversation.** When the scope receipts show a pattern - typically 3-5 absorbed changes - the FDE needs a conversation with the sponsor:
 
 Frame it as **protection, not complaint:**
 > "We've absorbed five changes since the original agreement. Each one made sense individually. Together, they've added roughly two weeks. I want to make sure the timeline expectation still matches - should we adjust the delivery date, or reprioritise to keep the original date?"
@@ -67,9 +67,9 @@ Acme, week 5. Nothing has been formally added, and the slice is a week late.
 
 The pattern shows in three receipts, not one argument: a "quick" finance CSV export (Jun 20, half a day, from Denise directly), retry-logic cleanup asked for mid-build (Jun 24, one day, Tom), and a dashboard tile "while you're in there" (Jun 27, half a day). Each was individually reasonable; together they are the slip.
 
-Three-bucket response, applied at the moment of the third ask rather than in a retrospective: the CSV export goes to Next with an accepted trade (it displaces the runbook polish), the retry cleanup goes to the kill list in `decisions.md` with the blast-radius reason, and the tile is absorbed because it is genuinely twenty minutes — logged anyway, since an unlogged absorption is the one that gets forgotten in the accumulation conversation.
+Three-bucket response, applied at the moment of the third ask rather than in a retrospective: the CSV export goes to Next with an accepted trade (it displaces the runbook polish), the retry cleanup goes to the kill list in `decisions.md` with the blast-radius reason, and the tile is absorbed because it is genuinely twenty minutes - logged anyway, since an unlogged absorption is the one that gets forgotten in the accumulation conversation.
 
-That conversation happens with Priya at three receipts, with the dates on screen: "these are the four asks, here is the two days, here is what moved." Not a complaint — a decision she gets to make, with evidence, before the deadline makes it for her.
+That conversation happens with Priya at three receipts, with the dates on screen: "these are the four asks, here is the two days, here is what moved." Not a complaint - a decision she gets to make, with evidence, before the deadline makes it for her.
 
 ## Principles
 

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -47,7 +47,7 @@ Score each dimension green/amber/red. This is the gate, not a suggestion:
 | Dimension | Green | Amber | Red |
 |-----------|-------|-------|-----|
 | **Value bucket** | `success.md` names primary bucket (`cost-save` \| `risk-mitigation` \| `revenue-uplift`) and a baseline→target metric; this slice’s value-ledger row has **Bucket** + **Promised** | Bucket named; **Measured** still `pending` with a pulse date | No bucket, or Promised empty / ticket-theater only |
-| **Audit receipt** | Dated line in `delivery.md` (`## Ship receipts` or ledger Evidence) proving exceptions/operating path were walked — cite `terrain.md` / `reality.md` / `audit.md` | Path described, not verified this ship | No audit receipt for this slice |
+| **Audit receipt** | Dated line in `delivery.md` (`## Ship receipts` or ledger Evidence) proving exceptions/operating path were walked - cite `terrain.md` / `reality.md` / `audit.md` | Path described, not verified this ship | No audit receipt for this slice |
 | **Eval receipt** | **n/a** (no AI on this slice) **or** `evals.md` Verdict SHIP with dated golden run + HITL gate named | Eval pack exists; known fails open with owner + date | AI in scope and no eval receipt |
 | **AI eval pack** | `.fde/evals.md` Verdict SHIP; goldens run this change; critical fails 0; HITL filled if policy requires | Pack exists; run stale vs change log | AI-touching deploy and pack missing / NO-SHIP / HITL required but empty |
 
@@ -59,13 +59,13 @@ Score each dimension green/amber/red. This is the gate, not a suggestion:
 2. If Verdict is not **SHIP**, or Last run is older than the latest change-log row → **RED.**
 3. If `trust-profile.md` requires human-in-the-loop and the HITL gate has no reviewer → **RED.**
 4. Log in `delivery.md` → `## Ship receipts` before deploy: audit cite + eval receipt.
-5. Non-AI deploys: Eval = **n/a** — do not invent an empty pack.
+5. Non-AI deploys: Eval = **n/a** - do not invent an empty pack.
 
 Write the readiness score (including value + receipts) to `delivery.md` before deploying. The score is the evidence if anything goes wrong.
 
 ## Intent vs diff (before pre-blast)
 
-Ship the change you intended — not the drift that snuck in. Run this on the deploy branch against the **one-line intent** from `decisions.md` / `success.md` (the slice you said you were building).
+Ship the change you intended - not the drift that snuck in. Run this on the deploy branch against the **one-line intent** from `decisions.md` / `success.md` (the slice you said you were building).
 
 ```bash
 git diff <base>...HEAD --stat
@@ -77,22 +77,22 @@ Score every touched path (or logical hunk):
 | Path / change | Verdict | Rule |
 |---------------|---------|------|
 | | **KEEP** | Directly required for the stated intent |
-| | **JUSTIFY** | Adjacent but load-bearing — one sentence why it must ship *now*, or split |
-| | **SPLIT** | Real work, wrong PR — park in `decisions.md` kill/Next; do not deploy with this slice |
-| | **DROP** | Noise (format-only, drive-by rename, unrelated tidy) — revert before ship |
+| | **JUSTIFY** | Adjacent but load-bearing - one sentence why it must ship *now*, or split |
+| | **SPLIT** | Real work, wrong PR - park in `decisions.md` kill/Next; do not deploy with this slice |
+| | **DROP** | Noise (format-only, drive-by rename, unrelated tidy) - revert before ship |
 
-**Any SPLIT or DROP still in the tree = fix-first.** JUSTIFY without a written sentence = treat as SPLIT. Log a one-line receipt in `delivery.md`: `intent vs diff: KEEP n · JUSTIFY n · SPLIT n · DROP n — <intent>`.
+**Any SPLIT or DROP still in the tree = fix-first.** JUSTIFY without a written sentence = treat as SPLIT. Log a one-line receipt in `delivery.md`: `intent vs diff: KEEP n · JUSTIFY n · SPLIT n · DROP n - <intent>`.
 
-This is **code drift**, not stakeholder "also can you…" (that is `scope-defense`). Same family as review Stage 1 — ship refuses green when the diff outgrew the claim.
+This is **code drift**, not stakeholder "also can you…" (that is `scope-defense`). Same family as review Stage 1 - ship refuses green when the diff outgrew the claim.
 
 ## Pre-blast challenge (before the deploy button)
 
-For any non-trivial go-live (shared infra, regulated data, irreversible migration, or first prod touch), run this once before canary — not as theater, as a stop-the-line check:
+For any non-trivial go-live (shared infra, regulated data, irreversible migration, or first prod touch), run this once before canary - not as theater, as a stop-the-line check:
 
 ```
 CLAIM: <what you are about to ship, in one sentence>
 WHY IT MATTERS: <blast radius / who feels pain if wrong>
-CHALLENGE: <the strongest argument this is not ready — grounded in delivery.md / risks.md / trust-profile.md>
+CHALLENGE: <the strongest argument this is not ready - grounded in delivery.md / risks.md / trust-profile.md>
 VERDICT: proceed | fix-first | sponsor conversation
 ```
 
@@ -116,11 +116,11 @@ grep -rnE "(api[_-]?key|secret|password|token)\s*[:=]\s*['\"][^'\"]{8,}" \
 
 ## Method - the deploy
 
-**Canary:** 1–5% of traffic, ≥10 minutes. Watch error rate, latency, and **the business metric this change affects**. Anything looks wrong → roll back immediately; investigate safely; redeploy when confident. Never investigate during the canary. Then stage up: 5% → 25% → 100%, each confirmed stable.
+**Canary:** 1-5% of traffic, ≥10 minutes. Watch error rate, latency, and **the business metric this change affects**. Anything looks wrong → roll back immediately; investigate safely; redeploy when confident. Never investigate during the canary. Then stage up: 5% → 25% → 100%, each confirmed stable.
 
 **Programme-scale rollout (transformations)** - different problem from one service:
 1. **Pilot** - one team, one use case; success metrics defined *before* it starts (after = fitting metrics to results).
-2. **Limited release** - 3–5 teams, real load; this is where the failure modes the pilot hid show up.
+2. **Limited release** - 3-5 teams, real load; this is where the failure modes the pilot hid show up.
 3. **Broad release** - self-serve onboarding; if teams still need the FDE to start, onboarding isn't finished.
 4. **Enterprise standard** - the FDE is no longer needed for this use case. That's the end state.
 Straight from pilot to standard = a high-profile failure at scale.
@@ -156,7 +156,7 @@ AI components: also define what *normal output* looks like and check a weekly sa
 
 **The scale sequence:**
 1. **Pilot** (1 team, controlled) → prove value, find failure modes
-2. **Limited** (3–5 teams, real load) → prove operability, find scale bugs
+2. **Limited** (3-5 teams, real load) → prove operability, find scale bugs
 3. **Broad** (self-serve onboarding) → prove the team doesn't need the FDE
 4. **Standard** (enterprise default) → the FDE exits this workstream
 
@@ -172,7 +172,7 @@ Adoption isn't a handoff-stage problem - it starts during build. Software that l
 - **Resistance signals.** Watch for: workaround creation (they built a spreadsheet instead of using the tool), drop-off after day 3 (onboarding fails), vocal detractors (one influential skeptic can kill adoption). Address these DURING build, not after launch.
 
 **At launch:**
-- **Champion network.** Identify 2–3 power users per team who adopt early. Support them intensely - they become your multiplier.
+- **Champion network.** Identify 2-3 power users per team who adopt early. Support them intensely - they become your multiplier.
 - **30-60-90 adoption targets.** Week 1: 20% of target users try it. Week 4: 50% use it weekly. Week 12: 80% can't imagine working without it. If week 1 misses → the onboarding is broken. If week 4 misses → the value proposition is wrong.
 - **The "switching cost" test.** If users can still do it the old way, they will. Adoption requires either: the old way is removed, the new way is dramatically better, or management mandates the switch. Know which lever applies.
 
@@ -190,9 +190,9 @@ Before 100%: canary clean, business metric verified, pulse written into `deliver
 
 Acme, shipping the failure-routing slice into a payments environment on a Thursday.
 
-Readiness scoring catches two things the diff does not. The audit receipt is missing: the operating map says Marco's manual re-run is the fallback, and nobody has checked whether the new page fires *before* his morning run or after — if after, the alert changes nothing. That gets walked and cited before deploy. Second, the intent-vs-diff read shows the PR also touches the settlement retry that was deferred in build; it comes out.
+Readiness scoring catches two things the diff does not. The audit receipt is missing: the operating map says Marco's manual re-run is the fallback, and nobody has checked whether the new page fires *before* his morning run or after - if after, the alert changes nothing. That gets walked and cited before deploy. Second, the intent-vs-diff read shows the PR also touches the settlement retry that was deferred in build; it comes out.
 
-Pre-blast challenge: "what does this break if it fires at 3am and nobody acks?" Answer: nothing breaks, but the rota is not yet agreed — so the deploy waits on a name, not on code. That is a one-day slip that prevents a fake green.
+Pre-blast challenge: "what does this break if it fires at 3am and nobody acks?" Answer: nothing breaks, but the rota is not yet agreed - so the deploy waits on a name, not on code. That is a one-day slip that prevents a fake green.
 
 After deploy: `delivery.md` ship receipt with the audit cite, the kill test evidence, and the rollback line. Eval receipt: n/a, no AI in this path.
 

--- a/skills/fde/references/sketch.md
+++ b/skills/fde/references/sketch.md
@@ -20,7 +20,7 @@
 
 **4. Kill it immediately if:** the assumption is disproven · the customer ignores it (indifference is a signal, not neutrality) · 3 iterations and feedback isn't converging · it works but the customer can't explain or trust the output (unexplainable AI in a high-stakes context is not a solution). When killed: write down what was *learned*, not what was built. The learning is the asset.
 
-**5. Translate to business language** once validated: problem solved, cost of inaction, success in numbers, 2–3 trade-offs. Three sentences max for the stakeholder - can't say it in three, don't understand it yet.
+**5. Translate to business language** once validated: problem solved, cost of inaction, success in numbers, 2-3 trade-offs. Three sentences max for the stakeholder - can't say it in three, don't understand it yet.
 
 ## Artifact
 

--- a/skills/fde/references/stakeholder-radar.md
+++ b/skills/fde/references/stakeholder-radar.md
@@ -28,7 +28,7 @@ The org chart tells you who reports to whom. The stakeholder radar tells you who
 
 **3. The 48-hour rule.** A stakeholder who goes amber has roughly 48 hours before they go red. A stakeholder who goes red is already escalating above you. Respond same-day to amber signals - not with more delivery, with a conversation.
 
-**3b. One name per person.** If the table says "Denise Chen" and Signal history says "Denise" or "D. Chen", trust keys fork and prep lies. Consolidate to one spelling. `fde doctor` flags these identity clusters — treat that as a fix, not a nit.
+**3b. One name per person.** If the table says "Denise Chen" and Signal history says "Denise" or "D. Chen", trust keys fork and prep lies. Consolidate to one spelling. `fde doctor` flags these identity clusters - treat that as a fix, not a nit.
 
 **4. Detect the invisible escalation.** Three markers:
 - Questions shift from "what are you building" to "when will it be done" - someone above is asking.
@@ -76,11 +76,11 @@ One line per stakeholder who changed signal this week. If nobody changed: "Map s
 
 Acme, week 6. Priya's replies have gone from same-day to two days, and a phase-2 go/no-go is scheduled for Thursday.
 
-Two signals, not one feeling: response time doubled *and* a finance analyst nobody introduced started asking when the work completes. That combination is an invisible escalation — someone above Priya is asking, and the meeting is already happening without the FDE.
+Two signals, not one feeling: response time doubled *and* a finance analyst nobody introduced started asking when the work completes. That combination is an invisible escalation - someone above Priya is asking, and the meeting is already happening without the FDE.
 
-Positions: Priya is a supporter under pressure. Marco is a supporter who does not vote. Denise (finance) is the swing, and what she is protecting is not the budget line she cites — it is that her team's escalation started this and she has nothing to show her own director. Raj is a firm opponent on the rewrite question, and no amount of the same argument moves him.
+Positions: Priya is a supporter under pressure. Marco is a supporter who does not vote. Denise (finance) is the swing, and what she is protecting is not the budget line she cites - it is that her team's escalation started this and she has nothing to show her own director. Raj is a firm opponent on the rewrite question, and no amount of the same argument moves him.
 
-Sequence: Denise one-on-one Tuesday with the incident numbers in her units, then Priya Wednesday, so Priya walks in already knowing finance is not going to object. Pre-mortem sentence: *"Denise says 'we still don't know if this actually caught anything'"* — which is precisely why Tuesday exists. `stakeholders.md` records `Priya | sponsor | green→amber | reply latency 1d → 2d, unintroduced analyst (Jul 3)`; `context.md` carries the sequence.
+Sequence: Denise one-on-one Tuesday with the incident numbers in her units, then Priya Wednesday, so Priya walks in already knowing finance is not going to object. Pre-mortem sentence: *"Denise says 'we still don't know if this actually caught anything'"* - which is precisely why Tuesday exists. `stakeholders.md` records `Priya | sponsor | green→amber | reply latency 1d → 2d, unintroduced analyst (Jul 3)`; `context.md` carries the sequence.
 
 ## Principles
 

--- a/skills/fde/references/status.md
+++ b/skills/fde/references/status.md
@@ -6,16 +6,16 @@
 
 ## Method (you do this work)
 
-**First:** run `fde status`. It prints the value ledger before trust — promised → measured → accepted by, or `claimed, not yet accepted`. Those lines are the Situation. Do not invent a number the CLI did not print.
+**First:** run `fde status`. It prints the value ledger before trust - promised → measured → accepted by, or `claimed, not yet accepted`. Those lines are the Situation. Do not invent a number the CLI did not print.
 
 **Always draft in SCQA.** One page maximum. No other shape.
 
 | Block | What to write | Source |
 |-------|---------------|--------|
-| **S — Situation** | Where we are against `success.md`, in their words | success.md, delivery value ledger |
-| **C — Complication** | What changed, what is at risk, or what we learned (bad news first) | risks.md, assumptions DISPROVED/OPEN, stakeholders signal |
-| **Q — Question / Ask** | The one decision or help you need from them | decisions.md, access/sign-off needs |
-| **A — Answer** | What you recommend / what happens next week (≤3 bullets) | plan Now lane, delivery promised→measured |
+| **S - Situation** | Where we are against `success.md`, in their words | success.md, delivery value ledger |
+| **C - Complication** | What changed, what is at risk, or what we learned (bad news first) | risks.md, assumptions DISPROVED/OPEN, stakeholders signal |
+| **Q - Question / Ask** | The one decision or help you need from them | decisions.md, access/sign-off needs |
+| **A - Answer** | What you recommend / what happens next week (≤3 bullets) | plan Now lane, delivery promised→measured |
 
 Then add, still on the same page:
 1. **Value this week** - from the value ledger: promised → measured (or "pending") → **accepted by whom**, with evidence citation. A measured number nobody on the customer side has agreed to is written as `claimed`, and the Ask never rests on it - if the whole case for the next phase is a claimed number, the real ask this week is "who signs off that this is real?".
@@ -36,7 +36,7 @@ Append the draft to `delivery.md` under `## Status - <date>` using the SCQA head
 **C:** ...
 **Q:** ...
 **A:** ...
-**Value ledger:** promised … / measured … / accepted by … (evidence) — or `claimed, unaccepted`
+**Value ledger:** promised … / measured … / accepted by … (evidence) - or `claimed, unaccepted`
 **Kill list reminder:** …
 **Hostile Qs:** 1) … 2) … 3) …
 ```
@@ -49,9 +49,9 @@ Walk the FDE through the Complication and the Ask - confirm the framing matches 
 
 Acme, week 3, Priya's Friday update.
 
-**S:** failure routing is live; detection is 12 min against the 4h baseline in `success.md`. **C** leads with the bad news, not the win: the second incident was acked 40 minutes late because the rota has one name on it, and that name was on leave. **Q:** one ask — a second name on the rota by Wednesday. **A:** three bullets, top of the Now lane.
+**S:** failure routing is live; detection is 12 min against the 4h baseline in `success.md`. **C** leads with the bad news, not the win: the second incident was acked 40 minutes late because the rota has one name on it, and that name was on leave. **Q:** one ask - a second name on the rota by Wednesday. **A:** three bullets, top of the Now lane.
 
-Value ledger line: `promised 4h → 15min / measured 12min over 2 incidents / accepted by — (Marco confirmed operationally, finance not yet)` → written as `claimed, unaccepted`, which is what makes the Ask honest rather than a victory lap.
+Value ledger line: `promised 4h → 15min / measured 12min over 2 incidents / accepted by - (Marco confirmed operationally, finance not yet)` → written as `claimed, unaccepted`, which is what makes the Ask honest rather than a victory lap.
 
 Hostile Q prep, from memory not imagination: "why did we pay for alerting we already had?" → the receipt from `decisions.md` and the disabled-alerting finding in `reality.md`. Kill list reminder: the service rewrite is still deferred, accepted by Priya on Jun 12.
 

--- a/skills/fde/references/trust-engineering.md
+++ b/skills/fde/references/trust-engineering.md
@@ -66,7 +66,7 @@ Mistakes happen. What matters is speed and honesty:
 **`trust-profile.md`** - updated sections:
 ```markdown
 ## Trust level
-Current: <level 0–5> as of <date>
+Current: <level 0-5> as of <date>
 Evidence: <what earned this level>
 Next target: <level> - requires: <specific action>
 

--- a/skills/fde/references/use-case-scoring.md
+++ b/skills/fde/references/use-case-scoring.md
@@ -10,7 +10,7 @@ The most dangerous moment in a multi-use-case engagement is when the technically
 
 **1. List every candidate.** From the brief, from discovery conversations, from the FDE's own observations. Include the ones the customer hasn't said aloud but the codebase implies - a high-churn module with no tests is a candidate even if nobody named it.
 
-**2. Score on five dimensions.** Each 1–5, with the scoring rubric below:
+**2. Score on five dimensions.** Each 1-5, with the scoring rubric below:
 
 | Dimension | 1 | 3 | 5 |
 |-----------|---|---|---|

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -2111,7 +2111,7 @@ test('ingest stage → propose → apply never writes .fde until confirm', () =>
   fs.writeFileSync(
     notes,
     [
-      'decision: agreed to descope reporting until audit — Denise',
+      'decision: agreed to descope reporting until audit - Denise',
       'Denise went quiet after the board review',
       'next: send one-pager before Thursday',
     ].join('\n')
@@ -2142,7 +2142,7 @@ test('ingest stage → propose → apply never writes .fde until confirm', () =>
     path.join(eng, '.debrief-propose'),
     [
       'via:granola board prep',
-      'decision: agreed to descope reporting until audit — Denise',
+      'decision: agreed to descope reporting until audit - Denise',
       'contact: Denise went quiet after the board review [signal:amber]',
       'next: send one-pager before Thursday',
       '',


### PR DESCRIPTION
## Summary
- Rename `/got` to `/outcome` so the prove step reads as promised, measured, accepted.
- Replace em/en dashes with ASCII hyphens (or commas/periods on the README) so public copy does not use special dashes.

## Test plan
- [ ] README map and Commands table show `/outcome`
- [ ] Claude slash command file is `.claude/commands/outcome.md`
- [ ] `npm run check` (CI validate) passes
- [ ] No `/got` on the README


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/65" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->