### PR TITLE
feat: 3.15.2 — ground loop, /outcome, sharper front door

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/agreed.md
+++ b/.claude/commands/agreed.md
@@ -1,5 +1,5 @@
 ---
-description: When did we agree? - dated receipts, not memory
+description: When did we agree? Dated receipts, or a gap.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`. Do not invent names or quotes.
 
 Done when: the brief and who decides are on the record, and the human agrees the next move.
 
-Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: Land the embed - brief and trust before code
+description: Land the embed. Who signs done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,5 +1,5 @@
 ---
-description: Close the embed - they can run it without you
+description: Close the embed. They run it without you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -12,4 +12,4 @@ Confirm before any write to `.fde/`. Do not invent a clean ending the record doe
 
 Done when: handoff is on the record and the human agrees they are replaceable.
 
-Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -1,5 +1,5 @@
 ---
-description: After a meeting - notes into the record, human confirms
+description: After a meeting. Notes into the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **after a meeting**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Find the real problem - brief is a hypothesis
+description: Find the real problem. Brief is a hypothesis.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`. Do not invent stakeholders or quotes.
 
 Done when: reality vs brief is named, and the human agrees the next move.
 
-Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -18,4 +18,4 @@ Do not invent metrics or sign-off. Numbers without a source in `.fde/` stay `unk
 
 Done when: the human hears the three-beat ledger and agrees what is actually delivered vs still claimed.
 
-Not for TypeScript errors, unit tests, refactors, or git commits. Those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Plan the sequence - backwards from done
+description: Plan the sequence. Backwards from done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`.
 
 Done when: order, slices, and “done” are on the record and the human agrees.
 
-Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,5 +1,5 @@
 ---
-description: Walk-in prep - plain-language readout from the record
+description: Walk-in prep. One page from the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.

--- a/.claude/commands/quiet.md
+++ b/.claude/commands/quiet.md
@@ -1,5 +1,5 @@
 ---
-description: They went quiet - process gap or trust problem
+description: They went quiet. Process gap or trust problem.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -14,4 +14,4 @@ Confirm before any write to `.fde/`. Do not ship on “probably fine.”
 
 Done when: go-live checks are on the record, or the human has named what still blocks live.
 
-Not for TypeScript errors, unit tests, refactors, or git commits - those stay in the host agent.
+Not for a one-line typo in an unbound file. A client slice, POC, eval, or go-live stays on `@fde`.

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship a slice - pre-flight, then live
+description: Ship a slice. Live with a rollback.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.

--- a/.claude/commands/status.md
+++ b/.claude/commands/status.md
@@ -1,5 +1,5 @@
 ---
-description: Friday sponsor update - value ledger first
+description: Friday sponsor update. Value ledger first.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+Front door: Why is the product reason (agents forget the client), not four anecdotes. Commands carry the tells. How Skills Work is the router, not a fake 24-skill anatomy. Project Structure lists every reference and slash command.
+
 `/got` is now `/outcome` (promised, measured, accepted). Em dashes removed from copy.
 
 ## 3.15.1 - 2026-08-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,10 @@
 # Changelog
 
-## Unreleased
+## 3.15.2 - 2026-08-28
 
-Front door: Why is the product reason (agents forget the client), not four anecdotes. Commands carry the tells. How Skills Work is the router, not a fake 24-skill anatomy. Project Structure lists every reference and slash command.
+`/got` is now `/outcome`. Why is the product reason: agents forget the client; this is the record you take on site. Commands carry the tells. How Skills Work is the router. Project Structure lists every reference and slash command. Em dashes removed from copy.
 
-**Ground loop.** `@fde` stays on from discovery to signed outcome: POC (sketch), slice and on-site proof (incremental-build), eval when a model judges (eval-pack), promised → measured → accepted. No extra skill pack. Throwaway typos in an unbound repo can skip; a client slice cannot.
-
-`/got` is now `/outcome` (promised, measured, accepted). Em dashes removed from copy.
+**Ground loop.** `@fde` stays from discovery to signed outcome: POC, slice, on-site proof, eval when a model judges, promised → measured → accepted. A throwaway typo in an unbound repo can skip; a client slice cannot.
 
 ## 3.15.1 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Front door: Why is the product reason (agents forget the client), not four anecdotes. Commands carry the tells. How Skills Work is the router, not a fake 24-skill anatomy. Project Structure lists every reference and slash command.
 
+**Ground loop.** `@fde` stays on from discovery to signed outcome: POC (sketch), slice and on-site proof (incremental-build), eval when a model judges (eval-pack), promised → measured → accepted. No extra skill pack. Throwaway typos in an unbound repo can skip; a client slice cannot.
+
 `/got` is now `/outcome` (promised, measured, accepted). Em dashes removed from copy.
 
 ## 3.15.1 - 2026-08-28

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Forward deployed engineering skills for AI coding agents.**
 
-Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent follows them, and writes a dated client record you can defend. The host agent still writes the TypeScript. The kit is everything around the code that makes an embed defensible.
+Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent can run the embed end-to-end: discovery, POC, slice, on-site proof, eval, signed outcome. The workspace still compiles and commits. `@fde` does not leave.
 
 ```text
   LAND              DISCOVER           PLAN              SHIP               PROVE              CLOSE
@@ -37,7 +37,7 @@ Four tells the map does not cover:
 | After a meeting | `/debrief` | Notes into the record |
 | Walk-in / Friday | `/prep` `/status` | One page, then the ledger |
 
-Skills also activate on English: naming a client, debriefing a meeting, or asking what was agreed. Ordinary TypeScript, unit tests, and git commits stay in the host agent.
+Skills also activate on English: naming a client, running a POC, slicing a feature, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. A client slice cannot.
 
 ---
 
@@ -120,7 +120,7 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 | [discover](skills/fde/references/discover.md) | Repo + workaround + the real problem | Brief feels wrong, shadow processes |
 | [assumption-audit](skills/fde/references/assumption-audit.md) | Untested assumptions by blast radius | Brief feels too neat |
 | [use-case-scoring](skills/fde/references/use-case-scoring.md) | Value × urgency × alignment / complexity | Everything is P0 |
-| [sketch](skills/fde/references/sketch.md) | Kill the killer assumption in a day | Need to de-risk a direction |
+| [sketch](skills/fde/references/sketch.md) | Kill the killer assumption in a day | POC, spike, need to de-risk |
 
 ### Plan - Sequence the work
 
@@ -135,7 +135,7 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 
 | Skill | What It Does | Use When |
 |--------|--------------|----------|
-| [incremental-build](skills/fde/references/incremental-build.md) | Vertical slices, visible every 2-3 days | Large feature on their codebase |
+| [incremental-build](skills/fde/references/incremental-build.md) | Vertical slices, on-site proof | Building on their codebase |
 | [blast-radius](skills/fde/references/blast-radius.md) | Impact from contained → irreversible | Touching shared infrastructure |
 | [rescue](skills/fde/references/rescue.md) | Production fire or trust fire | Down, or they went quiet |
 | [ship](skills/fde/references/ship.md) | Intent vs diff, pre-flight, rollback | Going live |
@@ -191,6 +191,7 @@ One skill. One reference file per situation. One folder per client.
 ```
 
 - **Process, not prose.** Each reference is a workflow with an artifact and a checkpoint, not a tip sheet.
+- **Ground loop.** Name → characterise → prove where they live → log. The workspace compiles; `@fde` stays.
 - **You confirm.** Nothing is written until you say so.
 - **Progressive disclosure.** `SKILL.md` is the entry point. One `references/*.md` loads when routed.
 - **Local CLI.** Writes and status cost zero model tokens. The AI coding agent runs it.
@@ -272,7 +273,7 @@ fdeops/
 
 AI coding agents are built for a repo, not for a client. They forget the sponsor, the promise, who can say yes, and whether anyone accepted the number. Monday morning they start from the ticket again.
 
-FDEOps is the engagement record those agents load first. One `@fde` skill routes the work. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record. Coding skill packs cover specs, tests, and review. This kit covers the embed around that code.
+FDEOps is what you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, slice, on-site proof, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
 
 ---
 
@@ -295,9 +296,9 @@ Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
 
 ## Who this is for
 
-You embed with a customer and an AI coding agent. The record has to survive Monday, a sponsor change, and the readout. One `.fde/` per client so they do not blur.
+You embed with a customer and an AI coding agent. Take this on the ground. Discovery through signed outcome lives in `@fde`. One `.fde/` per client so they do not blur.
 
-If you only write code in your own repo, this is the wrong pack. Use a coding skill pack for specs, tests, and review. Use this when the work is on someone else's site.
+If you only write code in your own repo with no client record to defend, you do not need this kit.
 
 ---
 
@@ -312,6 +313,7 @@ Local only - `git` + files, no network, no telemetry. Plain markdown. The model 
 ## Principles
 
 - **The artifact is the memory** - producing the work and recording it are one action
+- **Ground loop** - name the slice, characterise their code, prove it where they live, log the outcome
 - **Skills, not autonomy** - the kit says what to check; judgment stays yours
 - **Brief is a hypothesis** - discover before building the wrong thing
 - **Evidence on every claim** - these files get defended in the room

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Forward deployed engineering skills for AI coding agents.**
 
-Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent follows them consistently, and writes a dated record you can defend. The host agent still writes the TypeScript.
+Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent follows them, and writes a dated client record you can defend. The host agent still writes the TypeScript. The kit is everything around the code that makes an embed defensible.
 
 ```text
   LAND              DISCOVER           PLAN              SHIP               PROVE              CLOSE
@@ -17,20 +17,27 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
 
 ## Commands
 
-6 slash commands that map to the engagement. Each one activates `@fde`.
+Each command loads the same `@fde` skill. You never pick from 31 names.
 
 | What you're doing | Command | Key principle |
 |-------------------|---------|-----------|
-| Land the embed | `/brief` | Brief and trust before code |
+| Land the embed | `/brief` | Who signs done |
 | Find the real problem | `/discover` | Brief is a hypothesis |
 | Plan the sequence | `/plan` | Backwards from done |
-| Ship a slice | `/ship` | Pre-flight, then live |
-| Prove the outcome | `/outcome` | Promised → measured → accepted |
-| Close the embed | `/close` | They can run it without you |
+| Ship a slice | `/ship` | Live with a rollback |
+| Prove the outcome | `/outcome` | Promised, measured, accepted |
+| Close the embed | `/close` | They run it without you |
 
-Also: `/debrief` (after a meeting) · `/prep` (walk-in) · `/quiet` (sponsor silent) · `/agreed` (scope dispute) · `/status` (Friday readout).
+Four tells the map does not cover:
 
-Skills also activate automatically based on what you're doing: naming a client, debriefing a meeting, or asking what was agreed triggers `@fde`. Ordinary TypeScript, unit tests, and git commits stay in the host agent.
+| What you're doing | Command | Key principle |
+|-------------------|---------|-----------|
+| Sponsor went silent | `/quiet` | Process or trust |
+| Scope dispute | `/agreed` | Dated receipts, or a gap |
+| After a meeting | `/debrief` | Notes into the record |
+| Walk-in / Friday | `/prep` `/status` | One page, then the ledger |
+
+Skills also activate on English: naming a client, debriefing a meeting, or asking what was agreed. Ordinary TypeScript, unit tests, and git commits stay in the host agent.
 
 ---
 
@@ -165,32 +172,30 @@ Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mc
 
 ## How Skills Work
 
-Every skill follows a consistent anatomy:
+One skill. One reference file per situation. One folder per client.
 
 ```
-┌─────────────────────────────────────────────┐
-│  @fde  (one skill)                          │
-│                                             │
-│  ┌─ Frontmatter ─────────────────────────┐  │
-│  │ name: fde                             │  │
-│  │ description: Use when [client work]   │  │
-│  └───────────────────────────────────────┘  │
-│                                             │
-│  Commands load it. English loads it.        │
-│  You confirm. Then .fde/ is written.        │
-└─────────────────────────────────────────────┘
-         │
-         ▼
-  references/<skill>.md      fde CLI (local)
-  one file, then stop        dating, gates, redaction
+  /brief   or   "@fde this is Acme"
+           │
+           ▼
+  skills/fde/SKILL.md          hosts load this one file
+           │  routes. you never pick a skill by name
+           ▼
+  references/land.md           one workflow, then stop
+           │
+           ▼
+  fde CLI (local)              dates, gates, redacts. no network
+           │  after you confirm
+           ▼
+  ~/fde-engagements/<client>/.fde/
 ```
 
-- **Process, not prose.** Skills are workflows with an artifact and a checkpoint, not tip sheets.
+- **Process, not prose.** Each reference is a workflow with an artifact and a checkpoint, not a tip sheet.
 - **You confirm.** Nothing is written until you say so.
-- **Progressive disclosure.** The `SKILL.md` is the entry point. One `references/*.md` loads when routed.
-- **Local CLI.** Writes, status, dated agreements. Zero model tokens. The AI coding agent runs it.
+- **Progressive disclosure.** `SKILL.md` is the entry point. One `references/*.md` loads when routed.
+- **Local CLI.** Writes and status cost zero model tokens. The AI coding agent runs it.
 
-The record lives at `~/fde-engagements/<client>/.fde/` - not inside any vendor. Change hosts, install `@fde` on the new one, bind if needed, keep talking.
+Change hosts, install `@fde` on the new one, bind if needed, keep talking. The record is not inside any vendor.
 
 ---
 
@@ -198,41 +203,76 @@ The record lives at `~/fde-engagements/<client>/.fde/` - not inside any vendor. 
 
 ```
 fdeops/
-├── skills/fde/                 # the one skill
-│   ├── SKILL.md                #   router
-│   └── references/             #   31 skills + overlays
-├── .claude/commands/           # slash commands (each loads @fde)
-├── .claude-plugin/             # Claude Code marketplace
-├── bin/                        # local CLI - git + files, no network
-├── hooks/                      # session-start / session-stop / pre-compact
-├── adapters/                   # Cursor, Gemini, Copilot, Codex pointers
-├── templates/.fde/             # memory files created on bind
-├── examples/                   # fictional walkthroughs
-├── mcp/                        # optional ingest + source recipes
-├── evals/                      # routing checks + CLI attack notes
-├── media/                      # recorded session (docs/USAGE.md)
-└── docs/                       # usage, schema, install, methodology
+├── skills/fde/                            # the one skill hosts load
+│   ├── SKILL.md                           #   router
+│   └── references/                        #   31 skills + overlays (you never pick)
+│       ├── land.md                        #   Land
+│       ├── audit.md
+│       ├── stakeholder-radar.md
+│       ├── trust-engineering.md
+│       ├── scope-defense.md
+│       ├── discover.md                    #   Discover
+│       ├── assumption-audit.md
+│       ├── use-case-scoring.md
+│       ├── sketch.md
+│       ├── plan.md                        #   Plan
+│       ├── business-case.md
+│       ├── options-analysis.md
+│       ├── initiative-triage.md
+│       ├── incremental-build.md           #   Ship
+│       ├── blast-radius.md
+│       ├── rescue.md
+│       ├── ship.md
+│       ├── review.md
+│       ├── rollback-drill.md
+│       ├── status.md                      #   Prove
+│       ├── demo-prep.md
+│       ├── debrief.md
+│       ├── exec-narrative.md
+│       ├── dashboard.md
+│       ├── ingest.md
+│       ├── ingest-connect.md
+│       ├── close.md                       #   Close
+│       ├── handoff-engineering.md
+│       ├── multi-customer-ops.md
+│       ├── pattern-extract.md
+│       ├── red-team.md
+│       ├── ai.md                          #   overlays (on signal)
+│       ├── artifacts.md
+│       ├── eval-pack.md
+│       ├── fintech.md
+│       ├── healthcare.md
+│       └── gov.md
+├── .claude/commands/                      # slash commands (each loads @fde)
+│   ├── brief.md
+│   ├── discover.md
+│   ├── plan.md
+│   ├── ship.md
+│   ├── outcome.md
+│   ├── close.md
+│   ├── quiet.md
+│   ├── agreed.md
+│   ├── debrief.md
+│   ├── prep.md
+│   └── status.md
+├── .claude-plugin/                        # Claude Code marketplace
+├── bin/                                   # local CLI: git + files, no network
+├── hooks/                                 # session-start / session-stop / pre-compact
+├── adapters/                              # Cursor, Gemini, Copilot, Codex pointers
+├── templates/.fde/                        # memory files created on bind
+├── examples/                              # fictional walkthroughs
+├── mcp/                                   # optional ingest + source recipes
+├── evals/                                 # routing checks
+└── docs/                                  # usage, schema, install
 ```
 
 ---
 
 ## Why FDEOps?
 
-### 1. The brief is wrong
+AI coding agents are built for a repo, not for a client. They forget the sponsor, the promise, who can say yes, and whether anyone accepted the number. Monday morning they start from the ticket again.
 
-The most common failure on an embed is building the portal they asked for. Ops has been running a spreadsheet for two years. `/brief` then `/discover`. Who in their company would have to agree it worked?
-
-### 2. They went quiet
-
-A sponsor who stops answering is not a Jira gap. It is a trust color. `/quiet`. Process vs trust, then a dated signal in the record.
-
-### 3. When did we agree?
-
-Arguments from memory lose. `/agreed` searches dated receipts. No hit is a gap, not proof.
-
-### 4. What's the outcome?
-
-A number only you agree with is claimed, not delivered. `/outcome` reads promised → measured → accepted out loud.
+FDEOps is the engagement record those agents load first. One `@fde` skill routes the work. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record. Coding skill packs cover specs, tests, and review. This kit covers the embed around that code.
 
 ---
 
@@ -255,13 +295,9 @@ Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
 
 ## Who this is for
 
-| You are | What this is |
-|---------|----------------|
-| **Forward Deployed Engineer** | Client work that has to survive Monday morning |
-| **Consultant / contractor on site** | The engagement stops resetting every morning |
-| **Solutions architect** | Politics and architecture in the same record |
-| **Agency, 3-5 clients** | One `.fde/` each - they stop blurring |
-| **Fractional CTO on client work** | System of record for the embed, and the billable trail |
+You embed with a customer and an AI coding agent. The record has to survive Monday, a sponsor change, and the readout. One `.fde/` per client so they do not blur.
+
+If you only write code in your own repo, this is the wrong pack. Use a coding skill pack for specs, tests, and review. Use this when the work is on someone else's site.
 
 ---
 

--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -6,7 +6,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, slices, characterisation, on-site proof, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/GEMINI.md
+++ b/adapters/GEMINI.md
@@ -6,7 +6,7 @@ Context for Gemini CLI when assisting a **Forward Deployed Engineer (FDE)** - th
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, slices, characterisation, on-site proof, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/copilot-instructions.md
+++ b/adapters/copilot-instructions.md
@@ -6,7 +6,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for ordinary code edits, TypeScript, unit tests, refactors, or git commits.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, slices, characterisation, on-site proof, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/cursor.fde.mdc
+++ b/adapters/cursor.fde.mdc
@@ -11,7 +11,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load `@fde`. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for ordinary code edits, unit tests, refactors, or git commits.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, slices, characterisation, on-site proof, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md` (or the copy this install placed)
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -91,7 +91,7 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 
 ## Engagement phases (quick reference)
 
-The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above - see it for the full 31 skills. Generic SDLC (build, debug, tests, commits) stays in the host agent - not routed here.
+The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above. POC, slice, on-site proof, and eval stay on `@fde` - they are not a side pack.
 
 | Phase | Enter when | Method highlights | Writes |
 |-------|-----------|-------------------|--------|

--- a/evals/skill-routing/cases.json
+++ b/evals/skill-routing/cases.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "purpose": "Cheap @fde routing pack (Philip-style): happy vs negative. CLI unit tests stay the product bar; this grades the skill contract.",
+  "purpose": "Cheap @fde routing pack: happy vs negative. CLI unit tests stay the product bar; this grades the skill contract.",
   "cases": [
     {
       "id": "happy-debrief",

--- a/evals/skill-routing/check.js
+++ b/evals/skill-routing/check.js
@@ -95,8 +95,8 @@ if (descMatch) {
 
 const lines = skill.split(/\n/).length
 if (lines > 500) {
-  gaps.push(`SKILL.md is ${lines} lines (Philip: keep under ~500; lean on references)`)
-  console.log(`⚠  SKILL.md is ${lines} lines (over ~500 lean guideline - prefer references)`)
+  gaps.push(`SKILL.md is ${lines} lines (keep under ~500; lean on references)`)
+    console.log(`⚠  SKILL.md is ${lines} lines (over ~500 lean guideline - prefer references)`)
 }
 
 if (printLive || fail === 0) {

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.15.1",
+  "version": "3.15.2",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: fde
-description: Keeps engagement memory for client work - sponsor, promise, what shipped, who accepted it. Use when the human names a client, customer or stakeholder. Use when they debrief a meeting or paste notes from one. Use when they ask what was agreed, or want dates and receipts. Use when they prep a client meeting or readout, when scope or trust shifts, or when they say @fde. Route the phase and run the local fde CLI (or npx --yes fdeops if it is not installed); never ask them to type commands. Not for ordinary code edits, unit tests, refactors or commits.
+description: Keeps the engagement record for client work. Use when they name a client or stakeholder. Use when they debrief a meeting or paste notes. Use when they ask what was agreed. Use when they run a POC, slice a feature on the client's codebase, prove it on their staging, or need evals before a model acts. Use when they prep a readout, when trust shifts, or they say @fde. Route and run the local fde CLI (or npx --yes fdeops). Never ask them to type commands. Not for ordinary code edits in an unbound repo.
 ---
 
 # @fde
 
 ## Purpose
 
-The **engagement record** for one client. One skill; six stages (land → close). You route; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript. This skill is the embed around that code.
+The **engagement record** for one client, from first meeting to signed outcome. One skill; six stages (land → close). You route; they never pick a skill. Confirm, then write `.fde/`. The workspace still compiles and commits. `@fde` does not leave.
 
 ## When to use
 
@@ -17,7 +17,7 @@ The **engagement record** for one client. One skill; six stages (land → close)
 
 ## When NOT to use
 
-TypeScript errors, unit tests, refactors, git commits, generic debug: **host agent**. Agreed slice + code: implement in the host, then `fde log delivery`.
+A one-line typo or compile error in a file that will not ship. On a bound client: stay here for POC, slice, characterisation, eval, go-live, rollback, and acceptance.
 
 ## Use these first
 
@@ -29,6 +29,18 @@ TypeScript errors, unit tests, refactors, git commits, generic debug: **host age
 | **What's the outcome?** | A number nobody signed is claimed, not delivered. | `fde status` | `references/status.md` |
 
 After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde prep`. Friday: `fde status`.
+
+## Ground loop
+
+On someone else's site the work is not "write code, remember later." Every slice stays on `@fde`:
+
+1. **Name it** in `decisions.md` (plan) or kill it in a day (sketch).
+2. **Characterise their code** before you change it (incremental-build). Their tests, their runner.
+3. **Prove it where they live.** Staging they operate, a screen the signer in `success.md` can reject.
+4. **If a model judges:** `evals.md` Verdict SHIP before the slice is done (eval-pack).
+5. **Log delivery.** Outcome is promised → measured → accepted, not a green CI.
+
+A throwaway file can skip the loop. A client slice cannot.
 
 ## Human surface vs agent plumbing
 
@@ -120,7 +132,7 @@ Read **one** reference and follow it. Do not improvise from memory.
 | Don't know the real problem, brief feels wrong, shadow processes | discover | `references/discover.md` |
 | The brief feels too neat, assumptions untested, "we just need…" | assumption-audit | `references/assumption-audit.md` |
 | Multiple use cases competing, "we want to do everything" | use-case-scoring | `references/use-case-scoring.md` |
-| Need to validate a direction, prototype, demo to de-risk | sketch | `references/sketch.md` |
+| Need to validate a direction, prototype, demo to de-risk, **POC**, spike, killer assumption | sketch | `references/sketch.md` |
 
 ### Plan
 
@@ -135,7 +147,7 @@ Read **one** reference and follow it. Do not improvise from memory.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Large feature, need visible progress every 2-3 days | incremental-build | `references/incremental-build.md` |
+| Large feature, need visible progress every 2-3 days, slice it, characterise their tests, POC follow-through | incremental-build | `references/incremental-build.md` |
 | What could go wrong, touching shared infrastructure, need to assess impact | blast-radius | `references/blast-radius.md` |
 | Production down, urgent - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
 | Ready to deploy, going live, pre-flight check | ship | `references/ship.md` |
@@ -173,7 +185,7 @@ Read **one** reference and follow it. Do not improvise from memory.
 | Signal | Overlay |
 |--------|---------|
 | AI, ML, LLM, model, embeddings, RAG, agents, fine-tuning, inference, drift | `references/ai.md` |
-| Golden set, eval suite, eval pack, pass/fail before AI ship, HITL gate for model | `references/eval-pack.md` (+ `ai.md`) |
+| Golden set, eval suite, eval pack, pass/fail before AI ship, HITL gate for model, POC the model | `references/eval-pack.md` (+ `ai.md`) |
 | Deck, slides, report, governance framework, compliance pack, ADR, PDF | `references/artifacts.md` |
 | Patient data, PHI, HIPAA, EHR, clinical | `references/healthcare.md` |
 | Payments, cardholder data, PCI-DSS, anything that moves money | `references/fintech.md` |
@@ -184,6 +196,7 @@ Ready to build with no `terrain.md` / plan: discover or plan first. Takeover wit
 ## Principles
 
 - Never ask the FDE to pick a phase. That's your job.
+- Ground loop on a bound client: name → characterise → prove where they live → log. Do not hand the slice to a generic coding pack.
 - Read `context.md` before speaking. One sharp question - never a barrage.
 - Never invent people, meetings, or numbers - `unknown - ask:` beats a polished lie.
 - Every phase ends with its artifact written. No artifact, no "done."

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -7,7 +7,7 @@ description: Keeps engagement memory for client work - sponsor, promise, what sh
 
 ## Purpose
 
-The **engagement record** for one client. One skill; six stages (land → close). You pick the method; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript; you log the outcome. The artifact is the memory.
+The **engagement record** for one client. One skill; six stages (land → close). You route; they never pick a skill. Confirm, then write `.fde/`. The host agent writes the TypeScript. This skill is the embed around that code.
 
 ## When to use
 

--- a/skills/fde/references/eval-pack.md
+++ b/skills/fde/references/eval-pack.md
@@ -1,6 +1,6 @@
 # eval-pack - prove the system before it acts
 
-**Enter when:** the work touches AI/LLM/agents/RAG, or ship/close is blocked because there is no evidence the non-deterministic path is safe. Activate alongside `ai.md`, `sketch`, `build`, or `ship` - not instead of them.
+**Enter when:** the work touches AI/LLM/agents/RAG, or they need to POC a model, or ship/close is blocked because there is no evidence the non-deterministic path is safe. Activate alongside `ai.md`, `sketch`, `incremental-build`, or `ship` - not instead of them.
 
 **Read first:** `trust-profile.md` (AI policy + HITL), `terrain.md` (operating map), `delivery.md`. Create or extend `evals.md`.
 

--- a/skills/fde/references/incremental-build.md
+++ b/skills/fde/references/incremental-build.md
@@ -37,14 +37,23 @@ Each vertical slice delivers working functionality the customer can see. Each sl
 
 ```
 Read existing code in the area (search before creating)
-  → Write characterisation tests for what's there (if legacy)
+  → Characterise what is already there (their tests, their runner)
     → Implement the minimal working path
-      → Verify with evidence (tests + typecheck + smallest proving run)
+      → On-site proof (below)
         → Cleanup pass (dedupe, simplify - behaviour unchanged)
           → Self-review against acceptance criteria
-            → Commit with descriptive message
+            → Commit with a message the client's team can read
               → Update decisions.md + delivery.md
 ```
+
+**On-site proof.** A green check on your laptop is not delivery. Before the slice is done:
+
+- Run **their** test command, typecheck, or smallest proving path. Write the command and the result in `delivery.md`.
+- If the signer in `success.md` cannot reject this slice on a screen they already use, it is not proven.
+- Staging they operate beats a local demo. If you have no staging: `unknown - ask:` who owns an environment, then stop pretending it shipped.
+- Model in the path: `eval-pack` until `evals.md` says SHIP. Do not skip because "it looked right in chat."
+
+Do not prove it with a textbook ritual. The proof is whatever this client already believes, plus one new receipt they can replay.
 
 **4. Size discipline.** Each slice targets:
 

--- a/skills/fde/references/sketch.md
+++ b/skills/fde/references/sketch.md
@@ -1,6 +1,6 @@
 # sketch - prototype to kill or confirm a direction
 
-**Enter when:** a direction needs validating before committing real build time - show something, de-risk, pick between use cases.
+**Enter when:** a direction needs validating before committing real build time - POC, spike, show something, de-risk, pick between use cases. The output is something a sponsor can reject in a room this week, not a polished product.
 
 **Read first:** `context.md`, `reality.md`. Load `terrain.md` only if the prototype touches the existing codebase.
 
@@ -10,7 +10,7 @@
 
 **1. Pick by score when several use cases compete.** Use the scoring model from `discover.md` - (Value × Data readiness) / Complexity. If discover already scored, reuse; never re-score independently.
 
-**2. Build the minimum that tests the assumption.** No error handling, no tests, no polish. Same-day demo if possible. Rough is honest - polish tricks people into believing it's further along than it is.
+**2. Build the minimum that tests the assumption.** No error handling, no polish. Same-day demo if possible. Rough is honest. The POC is done when the person who can say no has seen it and reacted, not when the code looks finished.
 
 **3. AI directions - test these before anything else:**
 - Data: available, clean, sufficient volume? Synthetic-data prototypes say nothing about production behaviour.


### PR DESCRIPTION
## Summary
- **Why FDEOps** is two paragraphs: agents forget the client; this is the engagement record. The four anecdotes are gone (they duplicated Commands).
- **Commands** split the map (6) from the tells (`/quiet` `/agreed` `/debrief` `/prep` `/status`). Principles are short.
- **How Skills Work** is the actual router (one skill → one reference → local CLI → `.fde/`), not a copied 24-skill anatomy box.
- **Project Structure** lists every reference file and every slash command, grouped by stage.

## Test plan
- [ ] Read Why out loud: does it answer "why not a coding skill pack?"
- [ ] Commands table: can a stranger pick `/quiet` vs `/agreed` without the Why section
- [ ] Project Structure matches `git ls-files skills/fde/references` and `.claude/commands`
- [ ] CI validate passes


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/66" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->