### PR TITLE
fix: 3.16.1 - stop volunteering false statements to a sponsor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: Land the embed. Who signs done.
+description: First week on site. Name who signs done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,5 +1,5 @@
 ---
-description: Close the embed. They run it without you.
+description: Hand off so they run it. They operate it without you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Find the real problem. Brief is a hypothesis.
+description: Find the real problem. Treat the brief as a hypothesis.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -8,7 +8,7 @@ If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once
 
 Say: "If this works, who in their company would have to agree that it worked?"
 
-Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/discover.md` and follow it. Evidence from the repo and the room - not the slide deck.
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/discover.md` and follow it. Frame Situation / Complication / Question before you scan. Evidence from the repo and the room - not the slide deck.
 
 Confirm before any write to `.fde/`. Do not invent stakeholders or quotes.
 

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -1,5 +1,5 @@
 ---
-description: Prove the outcome. Promised, measured, accepted
+description: Get the number accepted. Promised, measured, accepted.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **prove**.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -6,7 +6,7 @@ Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/plan.md` and follow it. Sequence backwards from done, PR-sized slices, who signs.
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/plan.md` and follow it. Sequence backwards from done, PR-sized slices, who signs. Each Now slice names `Kill if`.
 
 Do not invent a plan the record cannot support. Missing success criteria → `unknown - ask: <question>`.
 

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Plan the sequence. Backwards from done.
+description: Sequence the work. Work backwards from done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,5 +1,5 @@
 ---
-description: Walk-in prep. One page from the record.
+description: Prep before the meeting. One page from the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.

--- a/.claude/commands/readout.md
+++ b/.claude/commands/readout.md
@@ -1,5 +1,5 @@
 ---
-description: Friday sponsor update. Value ledger first.
+description: Friday sponsor update. Promised, measured, accepted.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.

--- a/.claude/commands/receipts.md
+++ b/.claude/commands/receipts.md
@@ -1,5 +1,5 @@
 ---
-description: When did we agree? Dated receipts, or a gap.
+description: When did we agree? A dated line, or it did not happen.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship a slice. Live with a rollback.
+description: Ship to their production. Go live with a rollback you have run.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.

--- a/.claude/commands/trust.md
+++ b/.claude/commands/trust.md
@@ -1,5 +1,5 @@
 ---
-description: They went quiet. Process gap or trust problem.
+description: Sponsor went quiet. Process gap, or they stopped trusting you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The CLI no longer volunteers a false statement to a sponsor. Signals key on the 
 - `fde log delivery "slice | bucket | …"` writes a value-ledger row. `fde log risk --retire <text>` moves matching open risks. `fde tidy --apply` can bless hand-written dirty files.
 - `status` and `dashboard` print doctor issues. README check allows the GitHub poster `<img>` (`user-attachments`).
 - Command map and slash descriptions use plain verbs (`Ship to their production`, `Prep before the meeting`). Craft words stay in the method, not the button.
+- Discover frames Situation / Complication / Question / Answer-space before any scan (same spine as readout, aimed at the floor). Plan copies the kill observation onto each Now slice as `Kill if`.
 
 ## 3.16.0 - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.16.1 - 2026-08-28
+
+The CLI no longer volunteers a false statement to a sponsor. Signals key on the person, redact does not reprint the secret in `git log`, and the dashboard fails loud when `reality.md` is not the schema.
+
+- Trust signals key on the person in the bullet, not `words[0]`. `INCIDENT:` / `recovery` no longer become phantom stakeholders that pin the engagement RED.
+- `fde redact --apply` commit subject is `redact N line(s)` - never the search term. `log` also refuses `postgresql://user:pass@host` and `api_key=` assignments.
+- Dashboard fails loud when `reality.md` is not the schema. It will not label the inherited brief as "what's actually true".
+- `debrief --smart` prints the `decision:` / `risk:` / `delivery:` / `contact:` / `next:` vocabulary. Preview gate unchanged.
+- `fde log delivery "slice | bucket | …"` writes a value-ledger row. `fde log risk --retire <text>` moves matching open risks. `fde tidy --apply` can bless hand-written dirty files.
+- `status` and `dashboard` print doctor issues. README check allows the GitHub poster `<img>` (`user-attachments`).
+
 ## 3.16.0 - 2026-08-28
 
 Skill and command names are the job, in the language of the embed. You can read the filename and know what it is: `who-decides`, `hold-scope`, `thin-slices`, `readout`. Slash tells match how you ask: `/trust` `/receipts` `/readout`. CLI verbs stay (`fde status`, `fde receipts`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The CLI no longer volunteers a false statement to a sponsor. Signals key on the 
 - `debrief --smart` prints the `decision:` / `risk:` / `delivery:` / `contact:` / `next:` vocabulary. Preview gate unchanged.
 - `fde log delivery "slice | bucket | …"` writes a value-ledger row. `fde log risk --retire <text>` moves matching open risks. `fde tidy --apply` can bless hand-written dirty files.
 - `status` and `dashboard` print doctor issues. README check allows the GitHub poster `<img>` (`user-attachments`).
+- Command map and slash descriptions use plain verbs (`Ship to their production`, `Prep before the meeting`). Craft words stay in the method, not the button.
 
 ## 3.16.0 - 2026-08-28
 

--- a/README.md
+++ b/README.md
@@ -14,22 +14,22 @@ Each command loads the same `@fde` skill. You never pick from 31 names.
 
 | What you're doing | Command | Key principle |
 |-------------------|---------|-----------|
-| Land the embed | `/brief` | Who signs done |
-| Find the real problem | `/discover` | Brief is a hypothesis |
-| Plan the sequence | `/plan` | Backwards from done |
-| Ship a slice | `/ship` | Live with a rollback |
-| Prove the outcome | `/outcome` | Promised, measured, accepted |
-| Close the embed | `/close` | They run it without you |
+| First week on site | `/brief` | Name who signs done |
+| Find the real problem | `/discover` | Treat the brief as a hypothesis |
+| Sequence the work | `/plan` | Work backwards from done |
+| Ship to their production | `/ship` | Go live with a rollback you have run |
+| Get the number accepted | `/outcome` | Promised, measured, accepted |
+| Hand off so they run it | `/close` | They operate it without you |
 
 Also:
 
 | What you're doing | Command | Key principle |
 |-------------------|---------|-----------|
-| Sponsor went silent | `/trust` | Process or trust |
-| Scope dispute | `/receipts` | Dated, or a gap |
+| Sponsor went quiet | `/trust` | Process gap, or they stopped trusting you |
+| When did we agree? | `/receipts` | A dated line, or it did not happen |
 | After a meeting | `/debrief` | Notes into the record |
-| Walk-in | `/prep` | One page from the record |
-| Friday readout | `/readout` | Promised, measured, accepted |
+| Prep before the meeting | `/prep` | One page from the record |
+| Friday sponsor update | `/readout` | Promised, measured, accepted |
 
 Skills also activate on English: naming a client, running a POC, slicing a feature, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. A client slice cannot.
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 
 | Skill | What It Does | Use When |
 |--------|--------------|----------|
-| [discover](skills/fde/references/discover.md) | Repo + workaround + the real problem | Brief feels wrong, shadow processes |
+| [discover](skills/fde/references/discover.md) | Question first, then repo + workaround | Brief feels wrong, shadow processes |
 | [test-assumptions](skills/fde/references/test-assumptions.md) | Untested assumptions by blast radius | Brief feels too neat |
 | [score-use-cases](skills/fde/references/score-use-cases.md) | Value × urgency × alignment / complexity | Everything is P0 |
 | [poc](skills/fde/references/poc.md) | Kill the killer assumption in a day | POC, spike, need to de-risk |
@@ -120,7 +120,7 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 
 | Skill | What It Does | Use When |
 |--------|--------------|----------|
-| [plan](skills/fde/references/plan.md) | Backwards from done, PR-sized | What order, what is done |
+| [plan](skills/fde/references/plan.md) | Backwards from done, Kill if on each slice | What order, what is done |
 | [business-case](skills/fde/references/business-case.md) | Cost of nothing → investment → return | Defend budget or timeline |
 | [three-options](skills/fde/references/three-options.md) | Three genuine options | "What should we do?" |
 | [pick-three](skills/fde/references/pick-three.md) | Pick three from twenty urgents | Everything is urgent |

--- a/bin/check.js
+++ b/bin/check.js
@@ -221,8 +221,10 @@ if (read('package.json').includes('postinstall')) {
 }
 
 const readme = read('README.md')
-if (/session\.gif|demo\.gif|<img /i.test(readme)) {
-  fail('README must not embed images - front door is text; the recording lives in docs/USAGE.md')
+if (/session\.gif|demo\.gif/i.test(readme)) {
+  fail('README must not embed session.gif or demo.gif - the recording lives in docs/USAGE.md')
+} else if (/<img /i.test(readme) && !/user-attachments\/assets/.test(readme)) {
+  fail('README <img> must be the GitHub poster (user-attachments), not a local gif')
 } else ok('README is text (no gif)')
 
 const usage = read('docs/USAGE.md')
@@ -268,9 +270,11 @@ for (const cmd of ['/brief', '/discover', '/plan', '/ship', '/outcome', '/close'
 if (/(^|[^\w/])\/got\b/.test(readme)) fail('README must use /outcome, not /got')
 ok('README slash commands documented')
 
-// Front-door map is the embed left-to-right (LAND → CLOSE), not a pile of situations.
-if (!readme.slice(0, 4000).includes('LAND') || !readme.slice(0, 4000).includes('/discover')) {
-  fail('README must include the LAND→CLOSE command-map diagram near the top')
+// Front-door map is the embed left-to-right (Land → Close). After the GitHub
+// poster (#68) the table is the map: /brief /discover /plan /ship /outcome /close.
+const front = readme.slice(0, 4000)
+if (!['/brief', '/discover', '/plan', '/ship', '/outcome', '/close'].every(c => front.includes(c))) {
+  fail('README must include the Land→Close command map near the top')
 } else ok('README command-map diagram')
 
 if (readme.includes('your-client-repo')) {

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -408,6 +408,8 @@ const SECRET_PATTERNS = [
   { name: 'Slack token', re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/ },
   { name: 'PEM private key', re: /-----BEGIN (?:RSA |EC |OPENSSH )?PRIVATE KEY-----/ },
   { name: 'Bearer token', re: /\bBearer\s+[A-Za-z0-9._\-]{20,}\b/ },
+  { name: 'database URL', re: /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:]+:[^/\s@]+@/i },
+  { name: 'api key assignment', re: /\b(?:api[_-]?key|secret|password)\s*=\s*\S{8,}/i },
 ]
 
 function findSecretHit(text) {
@@ -769,6 +771,89 @@ function firstLine(md, maxLen) {
   return ''
 }
 
+// reality.md is the one panel whose job is "not the brief". If the file does
+// not carry Working theory / Evidence / Differs from brief, do not scrape a
+// first line that might be the inherited brief and label it truth.
+function parseReality(md, maxLen) {
+  const theory = (md.match(/\*\*Working theory:\*\*\s*(.*)/i) || [])[1]
+  const hasSchema = /\*\*(Working theory|Evidence|Differs from brief how):\*\*/i.test(md)
+  const theoryText = (theory || '').trim()
+  if (theoryText) {
+    const line = theoryText.length > maxLen ? theoryText.slice(0, maxLen - 1).trim() + '…' : theoryText
+    return { line, missing: '' }
+  }
+  if (hasSchema) return { line: '', missing: '' }
+  const prose = firstLine(md, maxLen)
+  if (prose) {
+    return {
+      line: '',
+      missing: 'UNREADABLE - reality.md does not match the schema (Working theory / Evidence / Differs from brief). Not showing the brief as truth.',
+    }
+  }
+  return { line: '', missing: '' }
+}
+
+function appendValueLedgerRow(eng, cells) {
+  ensureMemoryGit(eng)
+  const p = path.join(eng, 'delivery.md')
+  let md = readEng(eng, 'delivery.md')
+  if (!md) md = '# Delivery log\n\n## Value ledger\n\n'
+  const date = new Date().toISOString().slice(0, 10)
+  const cols = []
+  for (let i = 0; i < 7; i++) cols.push((cells[i] || '').replace(/\|/g, '\\|').trim() || ' ')
+  const row = `| ${date} | ${cols.join(' | ')} |`
+  const lines = md.split('\n')
+  let inLedger = false
+  let lastTableLine = -1
+  for (let i = 0; i < lines.length; i++) {
+    if (/^##\s+Value ledger\b/i.test(lines[i])) { inLedger = true; continue }
+    if (inLedger && /^##\s+/.test(lines[i])) break
+    if (inLedger && /^\|/.test(lines[i].trim())) lastTableLine = i
+  }
+  if (lastTableLine === -1) md = appendUnderSection(md, 'Value ledger', row)
+  else {
+    lines.splice(lastTableLine + 1, 0, row)
+    md = lines.join('\n')
+  }
+  withFileLock(p, () => { atomicWriteFile(p, md.endsWith('\n') ? md : md + '\n') })
+  recordLastWrite(eng, 'delivery.md', row)
+  commitMemory(eng, 'log delivery', { files: ['delivery.md'] })
+}
+
+function retireOpenRisks(eng, needle) {
+  const n = String(needle || '').toLowerCase()
+  if (!n) return 0
+  const p = path.join(eng, 'risks.md')
+  const md = readEng(eng, 'risks.md')
+  if (!md) return 0
+  const retired = []
+  const kept = []
+  let inRetired = false
+  for (const raw of md.split('\n')) {
+    const t = raw.trim()
+    if (/^#{1,6}\s+Retired\b/i.test(t)) { inRetired = true; kept.push(raw); continue }
+    if (!inRetired) {
+      const m = t.match(/^-\s*\[\d{4}-\d{2}-\d{2}\]\s*(?:\[@[^\]]+\]\s*)?(.*)$/)
+      if (m && m[1].toLowerCase().includes(n)) {
+        retired.push(raw)
+        continue
+      }
+    }
+    kept.push(raw)
+  }
+  if (!retired.length) return 0
+  let out = kept.join('\n')
+  if (!/^#{1,6}\s+Retired\b/im.test(out)) out = out.replace(/\n*$/, '\n\n## Retired\n')
+  const stamp = new Date().toISOString().slice(0, 10)
+  const block = retired.map(l => {
+    const body = l.trim().replace(/^-\s*/, '')
+    return `- [${stamp}] (retired) ${body}`
+  }).join('\n')
+  out = appendUnderSection(out, 'Retired', block)
+  withFileLock(p, () => { atomicWriteFile(p, out.endsWith('\n') ? out : out + '\n') })
+  return retired.length
+}
+
 // Engagement age from the .fde/ directory's own birth time - hidden (not
 // fabricated as 0) on filesystems that do not report birthtime.
 function daysElapsed(eng) {
@@ -817,6 +902,7 @@ function parseMdTable(md) {
 function colIndex(headers, rx) { return headers.findIndex(h => rx.test(h)) }
 
 const {
+  personFromSignalText,
   signalSubjectKey,
   nextActionLine,
   computeSignals,
@@ -856,6 +942,8 @@ function parseSignalHistoryEntries(eng) {
 }
 
 function displayNameFromSignalText(text) {
+  const person = personFromSignalText(text)
+  if (person) return person
   const t = String(text).trim()
   const proper = t.match(/^([A-Z][a-z]+(?:\s+[A-Z][a-z]+)?)/)
   if (proper) return proper[1]
@@ -885,11 +973,11 @@ function extractStakeholders(eng) {
         const stance = stanceIdx !== -1 ? (cs[stanceIdx] || '').trim() : ''
         const note = notesIdx !== -1 ? (cs[notesIdx] || '').trim() : ''
         const words = name.replace(/\([^)]*\)/g, '').split(/\s+/).filter(w => w && !/^(dr|mr|mrs|ms)\.?$/i.test(w))
-        const frag = (words[0] || '').replace(/[^a-z0-9]/gi, '')
+        const nameKey = signalSubjectKey(name)
         let signal = null, matchedDate = null
-        if (frag.length >= 3) {
+        if (nameKey) {
           for (const h of history) {
-            if (h.text.trim().toLowerCase().startsWith(frag.toLowerCase()) && (!matchedDate || h.date >= matchedDate)) {
+            if (signalSubjectKey(h.text) === nameKey && (!matchedDate || h.date >= matchedDate)) {
               signal = h.signal; matchedDate = h.date
             }
           }
@@ -1317,6 +1405,9 @@ function cmdLog(args) {
     if (!['red', 'amber', 'green'].includes(signal)) { console.error('usage: fde log contact <text> --signal red|amber|green'); process.exit(1) }
     args.splice(sigIdx, 2)
   }
+  let retire = false
+  const retireIdx = args.indexOf('--retire')
+  if (retireIdx !== -1) { retire = true; args.splice(retireIdx, 1) }
   const type = args[0]; const text = args.slice(1).join(' ')
   const eng = resolveEngagement({ forWrite: true })
   if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exit(2) }
@@ -1333,11 +1424,26 @@ function cmdLog(args) {
     return
   }
 
-  if (!LOG_FILES[type] || !text) { console.error(`usage: fde log <decision|risk|delivery|contact> <text> [--signal red|amber|green] [--force]\n       fde log phase <${PHASES.join('|')}>\n       fde log --undo`); process.exit(1) }
+  if (!LOG_FILES[type] || !text) { console.error(`usage: fde log <decision|risk|delivery|contact> <text> [--signal red|amber|green] [--force]\n       fde log risk --retire <text>\n       fde log phase <${PHASES.join('|')}>\n       fde log --undo`); process.exit(1) }
   if (signal && type !== 'contact') { console.error('--signal only applies to: fde log contact'); process.exit(1) }
+  if (retire && type !== 'risk') { console.error('--retire only applies to: fde log risk'); process.exit(1) }
   const hit = findSecretHit(text)
   if (hit && !force) { refuseSecret('log text', hit); process.exit(1) }
   if (hit && force) console.error(`warning: logging possible ${hit} (--force)`)
+  if (retire) {
+    const n = retireOpenRisks(eng, text)
+    if (!n) { console.error(`no open risk matched ${JSON.stringify(text)}`); process.exit(1) }
+    const hash = commitMemory(eng, 'retire risk', { files: ['risks.md'] })
+    console.log(`retired ${n} risk(s) → risks.md${hash ? ` @${hash}` : ''}`)
+    return
+  }
+  if (type === 'delivery' && text.includes('|')) {
+    const cells = text.split('|').map(s => s.trim())
+    appendValueLedgerRow(eng, cells)
+    const hash = memoryHead(eng)
+    console.log(`logged → delivery.md (value ledger)${hash ? ` @${hash}` : ''}`)
+    return
+  }
   const date = new Date().toISOString().slice(0, 10)
   const entry = datedEntry(eng, date, text, signal || '')
   appendLogEntry(eng, type, entry)
@@ -1651,9 +1757,11 @@ function cmdDebrief(args) {
     input = readDebriefInput(args)
   }
 
-  if (smart) {
+    if (smart) {
     const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
     console.log('SMART PROPOSE (heuristic - review before apply; no new facts invented beyond line rewrites)\n')
+    console.log('Prefix vocabulary (lines that route): decision:  risk:  delivery:  contact:  next:')
+    console.log('Everything else → context.md. Keep the prefixes; the preview gate stays.\n')
     routeDebriefInput(eng, clean, { dry: true, force, sealed: blocks })
     if (!apply) {
       console.log(`\nproposal saved → ${proposePath}`)
@@ -2182,6 +2290,8 @@ function collectDoctorIssues(eng) {
       `${aliases.length} stakeholder identity cluster(s) (e.g. "${sample}") - same person under different names? consolidate in stakeholders.md`
     )
   }
+  const reality = parseReality(readClean(eng, 'reality.md'), 220)
+  if (reality.missing) issues.push(reality.missing)
   return issues
 }
 
@@ -2484,7 +2594,7 @@ function cmdRedact(args) {
     console.log('nothing changed')
     return
   }
-  const hash = commitMemory(eng, `redact ${term.slice(0, 40)}`, { files: touched })
+  const hash = commitMemory(eng, `redact ${hits.length} line(s)`, { files: touched })
   console.log(`redacted ${hits.length} line(s) in ${touched.join(', ')}${hash ? ` @${hash}` : ''}`)
   console.log('rotate the real credential if this was a secret - history may still contain it')
 }
@@ -2585,6 +2695,15 @@ function cmdGarden(args) {
       sessionBlocks,
     })
   }
+  const dirty = memoryDirtyManual(eng)
+  if (dirty.length) {
+    proposals.push({
+      id: 'bless-manual',
+      kind: 'apply',
+      text: `Bless ${dirty.length} hand-written file(s) into the ledger: ${dirty.slice(0, 5).join(', ')}${dirty.length > 5 ? '…' : ''}`,
+      files: dirty,
+    })
+  }
   if (!proposals.length) {
     console.log('\nNothing to tidy.')
     return
@@ -2611,6 +2730,12 @@ function cmdGarden(args) {
         touched.add('risks.md')
         console.log(`applied: retired ${n} duplicate open-risk echo(s) → ## Retired`)
       }
+      continue
+    }
+    if (p.id === 'bless-manual') {
+      applied++
+      for (const f of p.files) touched.add(f)
+      console.log(`applied: bless ${p.files.join(', ')}`)
       continue
     }
     if (p.id !== 'archive-sessions') continue
@@ -2744,6 +2869,10 @@ function cmdStatus(args) {
     }
   }
   if (!all) console.log('\n(current engagement only - pass --all for the full portfolio)')
+  if (!all) {
+    const current = resolveEngagement()
+    if (current) for (const line of hygieneTriageLines(current)) console.log(line)
+  }
   console.log('\ntrust: worst active [signal:x] across stakeholders (latest per person) - a green from B cannot clear an amber/red on A; keyword heuristic only when none exists.')
 }
 
@@ -2801,7 +2930,9 @@ function cmdDashboard(args) {
     // line instead of sharing one, a shorter cap just meant more sentences
     // cut off mid-thought for no reason.
     e.brief = firstLine(readClean(e.dir, 'brief.md'), 220)
-    e.reality = firstLine(readClean(e.dir, 'reality.md'), 220)
+    const reality = parseReality(readClean(e.dir, 'reality.md'), 220)
+    e.reality = reality.line
+    e.realityMissing = reality.missing
     e.overlay = detectOverlay(e.dir)
     e.days = daysElapsed(e.dir)
     e.phaseLabel = phaseLabel(e.signals.phase)
@@ -2839,6 +2970,10 @@ function cmdDashboard(args) {
   }
   console.log(`fieldbook → ${outPath}`)
   console.log(`${engagements.length} engagement(s) rendered · ${counts.RED} red / ${counts.amber} amber / ${counts.green} green · 0 tokens (pure render)`)
+  if (!all) {
+    const current = resolveEngagement()
+    if (current) for (const line of hygieneTriageLines(current)) console.log(line)
+  }
   if (args.includes('--open')) {
     // arg-array form: the path is never interpolated into a shell string.
     const [bin, pre] = process.platform === 'darwin' ? ['open', []]
@@ -2985,7 +3120,8 @@ function cmdVault(args) {
     const ctx = readClean(e.dir, 'context.md')
     e.next = (sectionBody(ctx, 'Next action', { lastNonEmpty: true }).split('\n').find(l => l.trim()) || '').trim()
     e.brief = firstLine(readClean(e.dir, 'brief.md'), 400)
-    e.reality = firstLine(readClean(e.dir, 'reality.md'), 400)
+    const reality = parseReality(readClean(e.dir, 'reality.md'), 400)
+    e.reality = reality.line || reality.missing
     e.overlay = detectOverlay(e.dir)
     e.days = daysElapsed(e.dir)
     e.stakeholders = extractStakeholders(e.dir)
@@ -3186,19 +3322,20 @@ function printUsage() {
   fde resume --init <name> create + bind engagement for this workspace (rebind replaces)
   fde resume --bind        show what this workspace is bound to, and what resolves
   fde triage               TRIAGE block only (hooks / Cursor session entry)
-  fde log <type> <text>    append decision|risk|delivery|contact (contact takes --signal red|amber|green; --force to allow secret-like text)
+  fde log <type> <text>    append decision|risk|delivery|contact (contact takes --signal red|amber|green; delivery "a|b|c" writes the value ledger; --force to allow secret-like text)
+  fde log risk --retire    move matching open-risk bullets to ## Retired
   fde log phase <phase>    set engagement phase (land|discover|plan|ship|prove|close)
   fde log --undo           remove the last CLI log/debrief entry from memory
   fde debrief [file]       meeting notes → memory (prefixed lines; --dry-run; --force)
-  fde debrief --smart      heuristic propose (prefix + light keywords); agent routes, CLI gates → --apply
+  fde debrief --smart      heuristic propose (prints decision:/risk:/delivery:/contact:/next:); --apply after confirm
   fde ingest stage …       stage raw pull into <engagement>/.inbox/ (not .fde/)
   fde ingest list          list staged inbox items
   fde ingest propose <id>  smart-propose a staged item → .debrief-propose (confirm before apply)
   fde ingest apply         same as: fde debrief --apply
   fde prep [label]         grounded walk-in brief from existing .fde/ only
-  fde doctor               lint engagement memory (stale signals, gaps)
-  fde redact <term>        preview/remove lines containing a buried term (pass --apply to commit)
-  fde tidy [--apply]       propose safe consolidations (contract: no new facts; git-reversible)
+  fde doctor               lint engagement memory (stale signals, gaps). status/dashboard/resume print the same issues
+  fde redact <term>        preview/remove lines containing a buried term (pass --apply to commit; subject never repeats the term)
+  fde tidy [--apply]       propose consolidations; blesses hand-written dirty files when you apply
   fde owner [set email]    who keeps this engagement record
   fde receipts <term>      "what did we agree?" with dates
   fde status [--all]       value ledger, then trust (pass --all for full portfolio)

--- a/bin/lib/render.js
+++ b/bin/lib/render.js
@@ -467,10 +467,10 @@ ${e.lastSession ? `<div class="fb-now-session">${inlineMd(e.lastSession)}</div>`
   // needed vs what's actually true. Squeezed onto one truncated line, that
   // contrast disappears. Each gets its own line, its own room to finish a
   // thought, not a race to fit before an ellipsis.
-  const whyBlock = (e.brief || e.reality) ? `<div class="fb-block">
+  const whyBlock = (e.brief || e.reality || e.realityMissing) ? `<div class="fb-block">
 <div class="fb-sec">Why</div>
 ${e.brief ? `<p class="fb-why"><span class="t-faint">What they asked for:</span> ${inlineMd(e.brief)}</p>` : ''}
-${e.reality ? `<p class="fb-why fb-why-reality"><span class="fb-accent-label">What's actually true:</span> ${inlineMd(e.reality)}</p>` : ''}
+${e.realityMissing ? `<p class="fb-why fb-why-missing"><span class="fb-accent-label">What's actually true:</span> ${escapeHtml(e.realityMissing)}</p>` : e.reality ? `<p class="fb-why fb-why-reality"><span class="fb-accent-label">What's actually true:</span> ${inlineMd(e.reality)}</p>` : ''}
 </div>` : ''
 
   // Vitals: a fixed field-facing gut-check panel, not a Movement block that

--- a/bin/lib/trust.js
+++ b/bin/lib/trust.js
@@ -48,12 +48,46 @@ function createTrustApi(deps) {
     return { ok: true, warn: '' }
   }
 
-  // Subject key for a signal-history line - first real name word (same spirit as
-  // extractStakeholders). A green about Randy must not clear an amber about Denise.
+  // Event labels are not people. "INCIDENT: … Marcus escalated" must key on
+  // Marcus, or a recovered engagement stays RED in front of the sponsor.
+  const SIGNAL_EVENT_KEYS = new Set([
+    'incident', 'recovery', 'alert', 'update', 'note', 'status', 'escalation',
+    'blocker', 'outage', 'fire', 'issue', 'sev', 'sev1', 'sev2', 'p1', 'p2', 'p3',
+    'resolved', 'risk', 'decision', 'delivery', 'contact',
+  ])
+
+  function personFromSignalText(text) {
+    let cleaned = String(text || '')
+      .replace(/\[@[^\]]+\]/g, '')
+      .replace(/\([^)]*\)/g, '')
+      .replace(/\[signal:[^\]]+\]/gi, '')
+      .replace(/\[\d{4}-\d{2}-\d{2}\]/g, '')
+      .replace(/^([A-Z]{2,}[A-Z0-9_-]*):?\s+/, '')
+      .trim()
+    const names = cleaned.match(/\b[A-Z][a-z]{1,20}(?:\s+[A-Z][a-z]{1,20})?\b/g) || []
+    for (const name of names) {
+      const first = name.split(/\s+/)[0].toLowerCase()
+      if (SIGNAL_EVENT_KEYS.has(first)) continue
+      return name
+    }
+    return ''
+  }
+
+  // Subject key for a signal-history line. Prefer a proper name in the bullet.
+  // A green about Randy must not clear an amber about Denise.
   // Strip author tags [@email-local] so attribution never becomes the subject key.
   function signalSubjectKey(text) {
+    const person = personFromSignalText(text)
+    if (person) {
+      const frag = person.split(/\s+/)[0].replace(/[^a-z0-9]/gi, '').toLowerCase()
+      if (frag.length >= 3) return frag
+    }
     const cleaned = String(text).replace(/\[@[^\]]+\]/g, '').replace(/\([^)]*\)/g, '')
-    const words = cleaned.split(/\s+/).filter(w => w && !/^(dr|mr|mrs|ms)\.?$/i.test(w))
+      .replace(/^([A-Z]{2,}[A-Z0-9_-]*):?\s+/, '')
+    const words = cleaned.split(/\s+/).filter(w => {
+      const n = w.replace(/[^a-z0-9]/gi, '').toLowerCase()
+      return n.length >= 3 && !SIGNAL_EVENT_KEYS.has(n) && !/^(dr|mr|mrs|ms)$/i.test(w)
+    })
     const frag = (words[0] || '').replace(/[^a-z0-9]/gi, '').toLowerCase()
     return frag.length >= 3 ? frag : ('anon:' + cleaned.slice(0, 48).toLowerCase())
   }
@@ -196,6 +230,7 @@ function createTrustApi(deps) {
 
   return {
     stakeholdersMemoryHealth,
+    personFromSignalText,
     signalSubjectKey,
     parsePhase,
     countOpenRisks,

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -24,7 +24,7 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [discover](../skills/fde/references/discover.md) | Scan repo + hunt the workaround + **workshop facilitation** + **data estate assessment** | Don't know the real problem, brief feels wrong, shadow processes |
+| [discover](../skills/fde/references/discover.md) | Frame the decision (Situation / Complication / Question) then scan repo + hunt the workaround + **workshop facilitation** + **data estate assessment** | Don't know the real problem, brief feels wrong, shadow processes |
 | [test-assumptions](../skills/fde/references/test-assumptions.md) | Extract untested assumptions, classify by blast radius, kill the riskiest first | The brief feels too neat, assumptions untested, "we just need..." |
 | [score-use-cases](../skills/fde/references/score-use-cases.md) | Score on value x urgency x alignment x data readiness / complexity | Multiple use cases competing, "we want to do everything" |
 | [poc](../skills/fde/references/poc.md) | Prototype the killer assumption in one day; kill fast, log the learning | Need to validate a direction, prototype, demo to de-risk |

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.16.0",
+  "version": "3.16.1",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -31,15 +31,28 @@ Q: <one question that changes where you dig>
 GUESS: <your answer, so they can correct it>
 ```
 
-Stop when you can write the decision sentence under **Frame the decision first**. If a name, quote, or metric is still missing, write `unknown - ask:` - never invent ops folklore to make the map look complete.
+Stop when you can write the four lines under **Frame the decision first**. If a name, quote, or metric is still missing, write `unknown - ask:` - never invent ops folklore to make the map look complete.
 
 ## Frame the decision first
 
-Before any scanning, write one sentence at the top of your working notes:
+Same SCQA spine as readout (`S → C → Q → A`), aimed at the floor, not a deck. Write it **before** any scan. Confirm with the FDE, then dig.
 
-> "What will the sponsor do differently because of this discovery?"
+| Line | What it is | Fail if |
+|------|------------|---------|
+| **Situation** | What they already treat as true - the workaround, the sheet, the owner who left | It could be copied from the RFP |
+| **Complication** | What broke, so they cannot stay here | No tension, or three problems joined by "and" |
+| **Question** | One decision the named signer must make | It smuggles the solution ("how do we add alerting") |
+| **Answer-space** | Shape of a satisfying answer: confirm brief / descope / rescope / pause | A novel, or "insights" |
 
-If you can't name the decision this informs (descope? rescope? pick use case A over B? touch module X first?), you're collecting trivia, not discovering. Every output of this phase is aimed at that decision.
+Tests on **Question** - rewrite until all five hold:
+
+1. **Decision-shaped** - answering it changes what someone does.
+2. **Single** - one thing, not three.
+3. **Scoped** - who, where, by when.
+4. **Answerable** - evidence could settle it in this engagement.
+5. **Neutral** - does not assume the fix.
+
+Cannot write the Question → keep interrogating. Do not `fde scan`. Every later output of this phase aims at that Question. Sub-questions go to the operating map or `assumptions.md`, not into the Question.
 
 ## Method - part 1: the codebase (you do this work)
 
@@ -147,12 +160,17 @@ Score every candidate use case before anything gets prototyped:
 
 ## Artifact (this IS the memory - write it as you work)
 
-**`reality.md`** - the readout the FDE takes into the sponsor meeting:
+**`reality.md`** - the readout the FDE takes into the sponsor meeting. Keep the three schema lines the dashboard reads (`Working theory` / `Evidence` / `Differs from brief how`). Then the decision frame:
+
 ```markdown
 # Reality (actual problem)
-**Decision this informs:** <one line>
-**Confirmed:** <real problem> (evidence: <workaround/data/quote, source, day>)
-**Stated brief was wrong/right because:** <delta, with evidence>
+**Working theory:** <the real problem, one sentence>
+**Evidence:** <workaround/data/quote, source, day>
+**Differs from brief how:** <delta, with evidence>
+**Situation:** <what the floor already treats as true>
+**Complication:** <what forces a decision now>
+**Question:** <one decision-shaped sentence>
+**Answer-space:** confirm brief / descope / rescope / pause - and what a yes looks like
 **Implication for build:** <thin-slice direction>
 **Validated with:** <who, when>
 ```
@@ -180,11 +198,11 @@ Every line carries its evidence. `(churn: 47/90d)` `(ops lead, Day 5)` `(stated,
 ## Checkpoint (before any build)
 
 Present to the FDE, five things, one paragraph each - no padding:
-1. The real problem, with the two strongest pieces of evidence.
+1. The Question, then the real problem, with the two strongest pieces of evidence.
 2. The top 3 risk areas of the codebase, one line of why each.
 3. What must not be touched without characterisation tests.
 4. The exception-led operating map: the two breaks that matter most, who owns the workaround, and where shadow systems live.
-5. The recommendation: confirm brief / descope / rescope - and the decision it puts in front of the sponsor.
+5. The Answer-space: confirm brief / descope / rescope - and the decision it puts in front of the sponsor.
 
 If discovery revealed the problem is 3× the brief: the FDE tells the customer **before** telling themselves it's manageable. Lead with evidence, offer three paths (descope / rescope / pause-and-plan), confirm any reset in writing - update `success.md` and `brief.md` before continuing.
 
@@ -198,13 +216,14 @@ Acme's brief blamed missing monitoring. Discovery goes to the workaround first.
 
 `git log` shows the reconciliation module at 47 commits/90d with no tests, all from one author who left in February. Marco (ops lead) turns out to keep a spreadsheet: every morning he re-runs the job manually and eyeballs the totals - a habit nobody mentioned because to him it is just the job. That spreadsheet is the system of record when the job fails, which is the actual finding.
 
-`reality.md`: **Confirmed:** the job has no owner, and the manual re-run masks failures for a day (evidence: Marco's sheet, Day 5; two silent failures since March, finance escalation Mar 14). **Stated brief was wrong because:** alerting existed last year and was disabled - adding it again without an owner reproduces the same outcome. `terrain.md` gets the hotspot row and an operating-map row: `job fails silently → Marco notices next morning → re-runs by hand → spreadsheet is truth → LOAD-BEARING (Marco, Day 5)`.
+`reality.md` keeps the schema, then the frame. **Working theory:** the job has no owner, and the manual re-run masks failures for a day. **Evidence:** Marco's sheet, Day 5; two silent failures since March, finance escalation Mar 14. **Differs from brief how:** alerting existed last year and was disabled - adding it again without an owner reproduces the same outcome. **Situation:** Marco re-runs the job every morning and the spreadsheet is truth when it fails. **Complication:** two silent failures since March already hit finance, and the author of the module left in February. **Question:** should Priya fund a named owner on the failure path, or fund alerting and accept the same miss in six months? **Answer-space:** fund ownership / fund alerting-as-theatre / pause until she names who acks. `terrain.md` gets the hotspot row and an operating-map row: `job fails silently → Marco notices next morning → re-runs by hand → spreadsheet is truth → LOAD-BEARING (Marco, Day 5)`.
 
-Checkpoint to the FDE names the sponsor decision this creates: fund ownership, or fund alerting and accept the same failure in six months.
+Checkpoint to the FDE leads with that Question, not a tour of the repo.
 
 ## Principles
 
 - The brief is a hypothesis until evidence confirms it.
+- No scan until the Question is one decision the signer must make.
 - The workaround is more honest than the requirements document.
 - Churn data + the human's "don't touch that" pointing at the same module = the map is true.
 - Never modify code before the terrain map exists.

--- a/skills/fde/references/plan.md
+++ b/skills/fde/references/plan.md
@@ -22,7 +22,7 @@ An FDE plan is not a sprint backlog. The technical sequence is the easy part. Th
 
 ## Method (you do this work)
 
-**0. Lock scope first.** Read `success.md` and `assumptions.md`. If out-of-scope is undefined, define it now with the FDE - a plan on undefined scope accumulates silent commitments. If any CRITICAL assumption is still `OPEN`, stop and run test-assumptions / discover before sequencing work.
+**0. Lock scope first.** Read `success.md`, `assumptions.md`, and the **Question** on `reality.md`. If out-of-scope is undefined, define it now with the FDE - a plan on undefined scope accumulates silent commitments. If any CRITICAL assumption is still `OPEN`, stop and run test-assumptions / discover before sequencing work. If `reality.md` has no Question, stop and finish discover - you are sequencing trivia.
 
 **1. Work backwards from success.** What's the last thing that must be true before done? And before that? That's the dependency chain - not a wish list.
 
@@ -54,6 +54,7 @@ Delivers: <what someone can see/test>
 Accepts: <happy path> / <unhappy path>
 Touches: <files/systems - blast radius declared upfront>
 Risk: <what could go wrong + fallback>
+Kill if: <the observation that voids this slice - copy from assumptions.md How we test, or the check that means stop>
 Verify: <specific check>
 Value promised: <business unit change this slice claims>
 
@@ -72,7 +73,7 @@ Value promised: <business unit change this slice claims>
 No kill list → not a finished plan. Reopen with the FDE until the deferrals are written.
 ## Checkpoint
 
-Walk the FDE through: sequence + why this order, where the fragile work sits, where the touchpoints land, the acceptance gate on task 1, and the kill list. One question: "Which stakeholder sees the first visible slice, and when?" Second: "Who accepted what we are not doing?"
+Walk the FDE through: sequence + why this order, where the fragile work sits, where the touchpoints land, the acceptance gate and **Kill if** on task 1, and the kill list. One question: "Which stakeholder sees the first visible slice, and when?" Second: "Who accepted what we are not doing?" Third: "What observation stops task 1 this week?"
 
 ## Method - estimation (when the sponsor asks "how long, how much?")
 
@@ -96,6 +97,7 @@ Every FDE gets asked this in week one. The honest answer is a range, not a numbe
 - Add 30% buffer for integration work (it always takes longer).
 - Add 50% buffer for AI/ML work (eval cycles are unpredictable).
 - Name assumptions explicitly: "assumes API docs are accurate", "assumes staging environment exists."
+- Each named assumption needs a **kill observation**: the result that voids the estimate. Copy it from `assumptions.md` → How we test. No kill observation = it is not an assumption, it is hope.
 - Revisit estimates every 2 weeks. An estimate that never updates is fiction.
 
 Write estimates to `decisions.md` under `## Sizing`. Include the assumptions - when they break, the estimate changes and the FDE has evidence for the conversation.
@@ -135,7 +137,7 @@ Never quietly update tasks. Name the reset: update `reality.md` and `success.md`
 
 Acme, after discover: the reconciliation job is unowned, Marco's spreadsheet is the real fallback.
 
-**Now** is three tasks, not eight. Task 1 is *failures reach a named human* - delivers a page to a rota, accepts "kill the job mid-run → the on-call is paged within 15 min", touches the job wrapper and the alert config, rollback is re-disable the route, verify by killing it in staging. Value promised: `risk-mitigation - a silent failure becomes a 15-minute one`.
+**Now** is three tasks, not eight. Task 1 is *failures reach a named human* - delivers a page to a rota, accepts "kill the job mid-run → the on-call is paged within 15 min", touches the job wrapper and the alert config, rollback is re-disable the route, **Kill if:** a real failure page is acked by nobody on the rota (the *finance would act* assumption, DISPROVED if Marco is the only name that answers), verify by killing it in staging. Value promised: `risk-mitigation - a silent failure becomes a 15-minute one`.
 
 The kill list in `decisions.md` is where the plan earns its keep: the rewrite of the reconciliation service that Tom keeps proposing goes there - *deferred, the failure mode is ownership not architecture (Priya accepted, Jun 12)* - along with the finance dashboard finance asked for directly. Both stay visible so the same argument is not re-litigated in week 4 without a receipt.
 
@@ -148,5 +150,6 @@ First visible slice goes to Marco, not Priya: he is the one whose morning change
 - Every 2-3 tasks, a stakeholder touchpoint. Trust decays without visibility.
 - No written acceptance criteria, no build.
 - No kill list, no finished plan.
-- Estimates are ranges, not promises. Name the assumptions.
+- No **Kill if** on a Now slice, that slice is hope.
+- Estimates are ranges, not promises. Name the assumptions and the observation that voids them.
 - Migrations: leaf nodes first, core last. Rollback before cutover.

--- a/skills/fde/references/test-assumptions.md
+++ b/skills/fde/references/test-assumptions.md
@@ -40,7 +40,7 @@ CONVENIENCE - if wrong, a task changes but the approach holds
 | "The team will adopt the new tool" | Ask three team members individually: "Show me how you'd use this" | 1h | 2 of 3 can describe a use case without prompting |
 | "The data is clean enough for ML" | Sample 200 records, count nulls/duplicates/format errors | 1h | <5% error rate on the fields the model needs |
 
-**4. Run the killer test first.** The assumption with the highest blast radius AND the cheapest validation gets tested immediately. This single principle saves more engagement time than any other: if the killer assumption is wrong, you've saved weeks; if it holds, you've bought confidence.
+**4. Run the killer test first.** The assumption with the highest blast radius AND the cheapest validation gets tested immediately. This single principle saves more engagement time than any other: if the killer assumption is wrong, you've saved weeks; if it holds, you've bought confidence. Write the kill observation in `How we test` as the result that would **stop** the plan - plan copies that line onto each Now slice as `Kill if`.
 
 **5. Present findings as a fact base, not a challenge.**
 

--- a/templates/.fde/assumptions.md
+++ b/templates/.fde/assumptions.md
@@ -8,4 +8,4 @@
 **Blast radius:** `CRITICAL` · `LOAD-BEARING` · `CONVENIENCE`  
 **Status:** `OPEN` · `TESTING` · `CONFIRMED` · `DISPROVED` · `PARKED`
 
-**Rule:** a CRITICAL assumption still OPEN blocks plan. DISPROVED → update `reality.md` / `success.md` and log the reset in `decisions.md` the same day.
+**Rule:** a CRITICAL assumption still OPEN blocks plan. `How we test` is the kill observation (the result that stops the work) - plan copies it as `Kill if`. DISPROVED → update `reality.md` / `success.md` and log the reset in `decisions.md` the same day.

--- a/templates/.fde/reality.md
+++ b/templates/.fde/reality.md
@@ -1,7 +1,12 @@
 # Reality (actual problem)
 
-<!-- Hypothesis until the discover phase confirms with evidence. -->
+<!-- Hypothesis until the discover phase confirms with evidence. Dashboard reads Working theory / Evidence / Differs from brief how. -->
 
 **Working theory:**
 **Evidence:**
 **Differs from brief how:**
+
+**Situation:**
+**Complication:**
+**Question:**
+**Answer-space:**

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3064,7 +3064,7 @@ test('a redacted vault strips internal tokens from next action, brief and realit
   const eng = engagementPath(sandbox, 'acme')
   fs.appendFileSync(path.join(eng, 'context.md'), '\n## Next action\n\nchase the sign-off [@alice] [signal:red]\n')
   fs.writeFileSync(path.join(eng, 'brief.md'), '# Brief\n\nreplace the batch job [signal:amber]\n')
-  fs.writeFileSync(path.join(eng, 'reality.md'), '# Reality\n\nthe batch job is load-bearing [@bob]\n')
+  fs.writeFileSync(path.join(eng, 'reality.md'), '# Reality\n\n**Working theory:** the batch job is load-bearing [@bob]\n')
 
   assert.equal(runFde(sandbox, ['vault', '--redacted']).status, 0)
   const out = path.join(sandbox.home, 'fde-vault-redacted')
@@ -3100,4 +3100,149 @@ test('a symlinked parent cannot smuggle the vault into the engagements root', ()
   const res2 = runFde(sandbox, ['vault', '--out', path.join(homeLink, '..', path.basename(sandbox.home))])
   assert.equal(res2.status, 1, res2.stdout + res2.stderr)
   assert.match(res2.stderr, /deleted and rebuilt|engagements root/)
+})
+
+test('signal key follows the person, not INCIDENT/recovery event words', () => {
+  const sandbox = makeSandbox('signal-incident')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'incco']).status, 0)
+  assert.equal(runFde(sandbox, [
+    'log', 'contact',
+    'INCIDENT: overnight AP batch failed, Marcus Hale escalated',
+    '--signal', 'red',
+  ]).status, 0)
+  assert.equal(runFde(sandbox, [
+    'log', 'contact',
+    'recovery confirmed by Marcus Hale, batch green two nights running',
+    '--signal', 'green',
+  ]).status, 0)
+
+  const prep = runFde(sandbox, ['prep'])
+  assert.equal(prep.status, 0, prep.stderr)
+  assert.match(prep.stdout, /Marcus/)
+  assert.doesNotMatch(prep.stdout, /\[red\] INCIDENT/)
+  assert.doesNotMatch(prep.stdout, /\[green\] recovery/)
+
+  const status = runFde(sandbox, ['status'])
+  assert.equal(status.status, 0, status.stderr)
+  assert.doesNotMatch(status.stdout, /\[RED\s*\]/)
+  assert.match(status.stdout, /\[green\s*\]/)
+})
+
+test('redact --apply commit subject does not contain the secret', () => {
+  const sandbox = makeSandbox('redact-subject')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'redactlog']).status, 0)
+  const eng = engagementPath(sandbox, 'redactlog')
+  const secret = 'AKIAIOSFODNN7EXAMPLE'
+  assert.equal(runFde(sandbox, ['log', 'decision', `leaked ${secret} into chat`, '--force']).status, 0)
+  const applied = runFde(sandbox, ['redact', secret, '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  const log = gitInEng(eng, ['log', '--oneline', '-5'])
+  assert.equal(log.status, 0, log.stderr)
+  assert.doesNotMatch(log.stdout, new RegExp(secret))
+  assert.doesNotMatch(log.stdout, /AKIA/)
+  assert.match(log.stdout, /redact \d+ line/)
+})
+
+test('log refuses a postgres URL and an api_key assignment', () => {
+  const sandbox = makeSandbox('secret-url')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'urlco']).status, 0)
+  const pg = runFde(sandbox, ['log', 'decision', 'dsn postgresql://user:PASSWORD@db.internal:5432/app'])
+  assert.notEqual(pg.status, 0)
+  assert.match(pg.stderr, /refused/)
+  const key = runFde(sandbox, ['log', 'risk', 'rotate api_key=not-an-openai-shape-but-still-a-secret'])
+  assert.notEqual(key.status, 0)
+  assert.match(key.stderr, /refused/)
+})
+
+test('dashboard does not render a schema-less reality.md as what is actually true', () => {
+  const sandbox = makeSandbox('reality-schema')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'realco']).status, 0)
+  const eng = engagementPath(sandbox, 'realco')
+  fs.writeFileSync(path.join(eng, 'brief.md'), '# Brief\n**Stated problem:** build a dispatch dashboard\n')
+  fs.writeFileSync(
+    path.join(eng, 'reality.md'),
+    '# Reality\n**Stated problem:** build a dispatch dashboard\nThe spreadsheet is still the system of record.\n'
+  )
+  const out = path.join(sandbox.dir, 'fieldbook.html')
+  const dash = runFde(sandbox, ['dashboard', '--out', out])
+  assert.equal(dash.status, 0, dash.stderr)
+  const html = fs.readFileSync(out, 'utf8')
+  assert.match(html, /UNREADABLE|does not match the schema/i)
+  assert.match(html, /fb-why-missing/)
+  assert.doesNotMatch(html, /fb-why-reality">/)
+})
+
+test('debrief --smart prints the prefix vocabulary before the preview', () => {
+  const sandbox = makeSandbox('smart-vocab')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'vocabco']).status, 0)
+  const notes = path.join(sandbox.dir, 'notes.md')
+  fs.writeFileSync(notes, 'talked about the audit date\n')
+  const smart = runFde(sandbox, ['debrief', '--smart', notes])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /decision:/)
+  assert.match(smart.stdout, /risk:/)
+  assert.match(smart.stdout, /delivery:/)
+  assert.match(smart.stdout, /contact:/)
+  assert.match(smart.stdout, /next:/)
+})
+
+test('log delivery with pipes writes a value-ledger row', () => {
+  const sandbox = makeSandbox('log-ledger')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'ledco']).status, 0)
+  const logged = runFde(sandbox, [
+    'log', 'delivery',
+    'retry slice | cost-save | 4h/week | 3.2h/week | Denise | Marco sheet | revert 412',
+  ])
+  assert.equal(logged.status, 0, logged.stderr)
+  const eng = engagementPath(sandbox, 'ledco')
+  const md = fs.readFileSync(path.join(eng, 'delivery.md'), 'utf8')
+  assert.match(md, /retry slice/)
+  assert.match(md, /cost-save/)
+  assert.match(md, /Denise/)
+  const section = md.split(/## Value ledger/)[1].split(/^## /m)[0]
+  assert.match(section, /retry slice/)
+})
+
+test('log risk --retire moves the matching open risk under Retired', () => {
+  const sandbox = makeSandbox('risk-retire')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'retco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'risk', 'cutover window still unsigned']).status, 0)
+  const retired = runFde(sandbox, ['log', 'risk', '--retire', 'cutover window'])
+  assert.equal(retired.status, 0, retired.stderr)
+  const eng = engagementPath(sandbox, 'retco')
+  const md = fs.readFileSync(path.join(eng, 'risks.md'), 'utf8')
+  const open = md.split(/^##\s+Retired/m)[0]
+  const rest = md.split(/^##\s+Retired/m)[1] || ''
+  assert.doesNotMatch(open, /cutover window still unsigned/)
+  assert.match(rest, /cutover window still unsigned/)
+})
+
+test('tidy proposes blessing handwritten dirty files', () => {
+  const sandbox = makeSandbox('tidy-bless')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'blessco']).status, 0)
+  const eng = engagementPath(sandbox, 'blessco')
+  fs.appendFileSync(path.join(eng, 'brief.md'), '\nHand-written sponsor line.\n')
+  const preview = runFde(sandbox, ['tidy'])
+  assert.equal(preview.status, 0, preview.stderr)
+  assert.match(preview.stdout, /bless|hand-written|brief\.md/i)
+  assert.doesNotMatch(preview.stdout, /Nothing to tidy/)
+  const applied = runFde(sandbox, ['tidy', '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  const dirty = gitInEng(eng, ['status', '--porcelain'])
+  assert.equal(dirty.stdout.trim(), '')
+})
+
+test('status and dashboard consult doctor instead of ignoring it', () => {
+  const sandbox = makeSandbox('doctor-consult')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'docco']).status, 0)
+  const eng = engagementPath(sandbox, 'docco')
+  assert.equal(runFde(sandbox, ['log', 'decision', 'descope reporting until audit']).status, 0)
+  fs.writeFileSync(
+    path.join(eng, 'context.md'),
+    '# Engagement context\n**Phase:** ship\n\n## Next action\n- canary the parity fix\n'
+  )
+  const status = runFde(sandbox, ['status'])
+  assert.match(status.stdout + status.stderr, /hygiene:|doctor|issue/i)
+  const dash = runFde(sandbox, ['dashboard'])
+  assert.match(dash.stdout + dash.stderr, /hygiene:|doctor|issue/i)
 })


### PR DESCRIPTION
## Summary

Field report from the four cold runs (#70): everything deterministic held up; three CLI surfaces volunteered a false statement to a sponsor. This patch is those three, plus the record verbs the method already demanded, plus the README gate that has been red on Main since the #68 poster.

- Trust signals key on the person in the bullet, not `words[0]`. `INCIDENT:` / later `recovery` no longer invent phantom stakeholders that pin the engagement RED.
- `fde redact --apply` commits `redact N line(s)` so `git log --oneline` never reprints the secret. `log` also refuses `postgresql://user:PASSWORD@host` and `api_key=` assignments.
- Dashboard (and vault) fail loud when `reality.md` is not Working theory / Evidence / Differs from brief. They will not label the inherited brief as what is actually true.
- `debrief --smart` prints the prefix vocabulary. Preview gate unchanged.
- `fde log delivery "a|b|c"` writes a value-ledger row. `fde log risk --retire` moves matching open risks. `fde tidy --apply` can bless hand-written dirty files.
- `status` and `dashboard` print doctor issues. `bin/check.js` allows the GitHub poster and treats the commands table as the Land→Close map, so Main is no longer blocked.

Four manifests bumped to **3.16.1**. After merge: `git pull && git tag v3.16.1 && git push origin v3.16.1`.

## Test plan

- [x] `npm run check` (130 tests) on this branch
- [ ] `fde log contact "INCIDENT: batch failed, Marcus Hale escalated" --signal red` then a later green about recovery → people list shows Marcus, status is not stuck RED
- [ ] `fde redact <secret> --apply` → `git log --oneline` in `.fde/` does not contain the secret
- [ ] `fde log decision "dsn postgresql://user:PASSWORD@host/db"` is refused
- [ ] Dashboard on a `reality.md` that is just the brief shows UNREADABLE, not "what's actually true"
- [ ] `fde debrief --smart` prints `decision:` `risk:` `delivery:` `contact:` `next:`
- [ ] `fde log delivery "retry | cost-save | 4h | 3h | Denise | sheet | revert"` lands in the value ledger
- [ ] `fde tidy` on a hand-edited `brief.md` proposes bless, `--apply` clears porcelain


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/71" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->