### PR TITLE
feat: 3.18.0 - Outcome stage, verb-first names

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: First week on site. Name who signs done.
+description: Interrogate the brief. Name who signs done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -1,5 +1,5 @@
 ---
-description: After a meeting. Notes into the record.
+description: Capture the meeting. Notes into the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **after a meeting**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Find the real problem. Treat the brief as a hypothesis.
+description: Frame the real problem. Treat the brief as a hypothesis.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -2,7 +2,7 @@
 description: Get the number accepted. Promised, measured, accepted.
 ---
 
-Load `@fde` (`skills/fde/SKILL.md`). Stage: **prove**.
+Load `@fde` (`skills/fde/SKILL.md`). Stage: **outcome**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,5 +1,5 @@
 ---
-description: Prep before the meeting. One page from the record.
+description: Prep the meeting. One page from the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.

--- a/.claude/commands/readout.md
+++ b/.claude/commands/readout.md
@@ -1,5 +1,5 @@
 ---
-description: Friday sponsor update. Promised, measured, accepted.
+description: Brief the sponsor. Promised, measured, accepted.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.

--- a/.claude/commands/receipts.md
+++ b/.claude/commands/receipts.md
@@ -1,5 +1,5 @@
 ---
-description: When did we agree? A dated line, or it did not happen.
+description: Find when we agreed. A dated line, or it did not happen.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Ship to their production. One change they can see, then go live with a rollback you have run.
+description: Build one change they can see, then go live with a rollback you have run.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.

--- a/.claude/commands/trust.md
+++ b/.claude/commands/trust.md
@@ -1,5 +1,5 @@
 ---
-description: Sponsor went quiet. Process gap, or they stopped trusting you.
+description: Diagnose a quiet sponsor. Process gap, or they stopped trusting you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 3.18.0 - 2026-08-29
+
+Public names match the work: verb + object, six stages ending in Outcome.
+
+- Stage `prove` is now `outcome`. `fde log phase prove` still works. Catalog, slash commands, and skill titles use the same labels (`Interrogate the brief`, `Validate the bet`, `Build one change they can see`).
+- `/outcome` is the stage name in commands and the CLI. Display is Outcome, not Prove.
+
 ## 3.17.0 - 2026-08-29
 
 Ship is one method. Write or update on their repo, prove it on staging they operate, then go live with a rollback you have run. No extra method.

--- a/README.md
+++ b/README.md
@@ -10,14 +10,14 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
 
 ## Commands
 
-Each command loads the same `@fde` skill. You never pick from 31 names.
+Each command loads the same `@fde` skill. You never pick from 30 names.
 
 | What you're doing | Command | Key principle |
 |-------------------|---------|-----------|
-| First week on site | `/brief` | Name who signs done |
-| Find the real problem | `/discover` | Treat the brief as a hypothesis |
+| Interrogate the brief | `/brief` | Name who signs done |
+| Frame the real problem | `/discover` | Treat the brief as a hypothesis |
 | Sequence the work | `/plan` | Work backwards from done |
-| Ship to their production | `/ship` | One change they can see, then go live with a rollback you have run |
+| Build one change they can see | `/ship` | Then go live with a rollback you have run |
 | Get the number accepted | `/outcome` | Promised, measured, accepted |
 | Hand off so they run it | `/close` | They operate it without you |
 
@@ -25,11 +25,11 @@ Also:
 
 | What you're doing | Command | Key principle |
 |-------------------|---------|-----------|
-| Sponsor went quiet | `/trust` | Process gap, or they stopped trusting you |
-| When did we agree? | `/receipts` | A dated line, or it did not happen |
-| After a meeting | `/debrief` | Notes into the record |
-| Prep before the meeting | `/prep` | One page from the record |
-| Friday sponsor update | `/readout` | Promised, measured, accepted |
+| Diagnose a quiet sponsor | `/trust` | Process gap, or they stopped trusting you |
+| Find when we agreed | `/receipts` | A dated line, or it did not happen |
+| Capture the meeting | `/debrief` | Notes into the record |
+| Prep the meeting | `/prep` | One page from the record |
+| Brief the sponsor | `/readout` | Promised, measured, accepted |
 
 Skills also activate on English: naming a client, running a POC, changing their checkout, going live, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. Bound client work cannot.
 
@@ -99,62 +99,62 @@ The commands above are the entry points. Under the hood, `@fde` activates these 
 
 ### Land - Brief and trust
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [land](skills/fde/references/land.md) | Interrogate the brief, map stakeholders, define success | New client, first meeting, just got the brief |
-| [audit](skills/fde/references/audit.md) | Verify claims, find the load-bearing wall | Taking over, previous consultant left |
-| [who-decides](skills/fde/references/who-decides.md) | Who decides, who blocks, who escalates | Need to know who matters |
-| [earn-trust](skills/fde/references/earn-trust.md) | Observer → trusted; navigate AI policy | Need access or credibility |
-| [hold-scope](skills/fde/references/hold-scope.md) | Scope receipts; the accumulation conversation | "Also can you…", timeline unchanged |
+| [land](skills/fde/references/land.md) | Interrogate the brief, name who signs | New client, first meeting, just got the brief |
+| [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
+| [who-decides](skills/fde/references/who-decides.md) | Map who decides | Need to know who matters |
+| [earn-trust](skills/fde/references/earn-trust.md) | Earn access; navigate AI policy | Need access or credibility |
+| [hold-scope](skills/fde/references/hold-scope.md) | Park the extra ask | "Also can you…", timeline unchanged |
 
 ### Discover - Find the real problem
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [discover](skills/fde/references/discover.md) | Question first, then repo + workaround | Brief feels wrong, shadow processes |
-| [test-assumptions](skills/fde/references/test-assumptions.md) | Untested assumptions by blast radius | Brief feels too neat |
-| [score-use-cases](skills/fde/references/score-use-cases.md) | Value × urgency × alignment / complexity | Everything is P0 |
-| [poc](skills/fde/references/poc.md) | Kill the killer assumption in a day | POC, spike, need to de-risk |
+| [discover](skills/fde/references/discover.md) | Frame the real problem | Brief feels wrong, shadow processes |
+| [test-assumptions](skills/fde/references/test-assumptions.md) | Kill the riskiest belief | Brief feels too neat |
+| [score-use-cases](skills/fde/references/score-use-cases.md) | Score what to build first | Everything is P0 |
+| [poc](skills/fde/references/poc.md) | Validate the bet in a day | POC, spike, need to de-risk |
 
 ### Plan - Sequence the work
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [plan](skills/fde/references/plan.md) | Backwards from done, Kill if on each PR | What order, what is done |
-| [business-case](skills/fde/references/business-case.md) | Cost of nothing → investment → return | Defend budget or timeline |
-| [three-options](skills/fde/references/three-options.md) | Three genuine options | "What should we do?" |
+| [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
+| [business-case](skills/fde/references/business-case.md) | Defend the investment | Defend budget or timeline |
+| [three-options](skills/fde/references/three-options.md) | Generate three real options | "What should we do?" |
 | [pick-three](skills/fde/references/pick-three.md) | Pick three from twenty urgents | Everything is urgent |
 
 ### Ship - On their repo, then live
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [ship](skills/fde/references/ship.md) | One change they can see (greenfield or brownfield), proven on their staging, then go live | Building, updating, or going live |
-| [what-breaks](skills/fde/references/what-breaks.md) | Impact from contained → irreversible | Touching shared infrastructure |
-| [rescue](skills/fde/references/rescue.md) | Production fire or trust fire | Down, or they went quiet |
-| [review](skills/fde/references/review.md) | Did we only build what we agreed | Before merge, scope creep |
-| [rollback](skills/fde/references/rollback.md) | Test the escape route before 2am | "We can always revert" |
+| [ship](skills/fde/references/ship.md) | Build one change they can see, then go live | Building, updating, or going live |
+| [what-breaks](skills/fde/references/what-breaks.md) | Name the blast radius | Touching shared infrastructure |
+| [rescue](skills/fde/references/rescue.md) | Resolve the incident or the trust fire | Down, or they went quiet |
+| [review](skills/fde/references/review.md) | Review the change against what we agreed | Before merge, scope creep |
+| [rollback](skills/fde/references/rollback.md) | Test the escape route | "We can always revert" |
 
 ### Outcome - Get the number accepted
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [readout](skills/fde/references/readout.md) | Promised → measured → accepted | Friday, sponsor update |
-| [demo-prep](skills/fde/references/demo-prep.md) | One number, five hard questions | Demo or exec walkthrough |
-| [debrief](skills/fde/references/debrief.md) | Meeting notes into the record | Just left a meeting |
-| [board-memo](skills/fde/references/board-memo.md) | Board / sponsor's boss | Justify continued investment |
-| [dashboard](skills/fde/references/dashboard.md) | Portfolio, trust-ordered | All my customers |
+| [readout](skills/fde/references/readout.md) | Get the number on paper | Friday, sponsor update |
+| [demo-prep](skills/fde/references/demo-prep.md) | Prep the demo they can reject | Demo or exec walkthrough |
+| [debrief](skills/fde/references/debrief.md) | Put the meeting in the record | Just left a meeting |
+| [board-memo](skills/fde/references/board-memo.md) | Brief the sponsor's boss | Justify continued investment |
+| [dashboard](skills/fde/references/dashboard.md) | See every client | All my customers |
 | [ingest](skills/fde/references/ingest.md) | Pull text you confirm | Transcript, Notion, Slack |
-| [connect](skills/fde/references/connect.md) | Wire a source MCP | Connect Granola |
+| [connect](skills/fde/references/connect.md) | Wire a source | Connect Granola |
 
 ### Close - They run it
 
-| Skill | What It Does | Use When |
+| Skill | What it does | Use when |
 |--------|--------------|----------|
-| [close](skills/fde/references/close.md) | Handoff that survives you | Wrapping up |
-| [runbook](skills/fde/references/runbook.md) | Runbook, confidence scoring | They must operate without you |
+| [close](skills/fde/references/close.md) | Hand off so they run it | Wrapping up |
+| [runbook](skills/fde/references/runbook.md) | Write the 2am document | They must operate without you |
 | [switch-clients](skills/fde/references/switch-clients.md) | Switch without bleed | 2+ clients |
-| [encode-pattern](skills/fde/references/encode-pattern.md) | If you did it twice, encode it | It will apply again |
+| [encode-pattern](skills/fde/references/encode-pattern.md) | Save what worked twice | It will apply again |
 | [red-team](skills/fde/references/red-team.md) | Stress-test before they do | "Poke holes in this" |
 
 Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) · [eval-pack](skills/fde/references/eval-pack.md)

--- a/adapters/AGENTS.md
+++ b/adapters/AGENTS.md
@@ -6,7 +6,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, small PRs, characterisation, proof on their staging, eval, and go-live.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, the change on their repo, characterisation, proof on their staging, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/GEMINI.md
+++ b/adapters/GEMINI.md
@@ -6,7 +6,7 @@ Context for Gemini CLI when assisting a **Forward Deployed Engineer (FDE)** - th
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, small PRs, characterisation, proof on their staging, eval, and go-live.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, the change on their repo, characterisation, proof on their staging, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/copilot-instructions.md
+++ b/adapters/copilot-instructions.md
@@ -6,7 +6,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load the skill. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, small PRs, characterisation, proof on their staging, eval, and go-live.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, the change on their repo, characterisation, proof on their staging, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md`
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/adapters/cursor.fde.mdc
+++ b/adapters/cursor.fde.mdc
@@ -11,7 +11,7 @@ You are the AI coding agent for a **Forward Deployed Engineer (FDE)** - the huma
 
 When the FDE types **`@fde`**, names a client, pastes meeting notes, asks what was agreed, or describes embed work (quiet sponsor, brief feels wrong, Friday update) - load `@fde`. If `fde resume` says NO ENGAGEMENT: ask the client name once, then **you** run `fde resume --init <slug>`. Never tell them to type it.
 
-Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, small PRs, characterisation, proof on their staging, eval, and go-live.
+Do **not** load `@fde` for a one-line typo in an unbound repo. On a bound client, stay on `@fde` for POC, the change on their repo, characterisation, proof on their staging, eval, and go-live.
 
 - Skill (single source of truth): `~/.claude/skills/fde/SKILL.md` (or the copy this install placed)
 - **Never ask the FDE to pick a skill.** Read the situation, route silently, do the work.

--- a/bin/check.js
+++ b/bin/check.js
@@ -211,6 +211,13 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
     }
   }
   ok('ship is one method (no implement / small-prs / thin-slices sibling)')
+
+  if (/^### Prove\b/m.test(read('skills/fde/SKILL.md'))) {
+    fail('SKILL.md must not use Prove as a stage heading - the public stage is Outcome')
+  } else ok('SKILL.md stage heading is Outcome')
+  if (/\b31 names\b|\b31 skills\b/.test(read('README.md'))) {
+    fail('README must not advertise 31 skills')
+  } else ok('README skill count is 30')
 }
 
 const install = read('bin/install.js')

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -740,11 +740,11 @@ function appendLogEntry(eng, type, entry, opts = {}) {
 // degrading to "nothing found" rather than guessing when the shape does not
 // match. Never fabricate a number, a name, or a signal that is not in the text.
 
-const PHASES = ['land', 'discover', 'plan', 'ship', 'prove', 'close']
-const PHASE_ALIASES = { build: 'ship' } // legacy SDLC name; public map is ship
+const PHASES = ['land', 'discover', 'plan', 'ship', 'outcome', 'close']
+const PHASE_ALIASES = { build: 'ship', prove: 'outcome' } // legacy names; public map is ship / outcome
 const PHASE_LABELS = {
   land: 'Land', discover: 'Discover', plan: 'Plan',
-  ship: 'Ship', prove: 'Prove', close: 'Close',
+  ship: 'Ship', outcome: 'Outcome', close: 'Close',
 }
 function canonicalPhase(phase) {
   const p = String(phase).toLowerCase()
@@ -1412,7 +1412,7 @@ function cmdLog(args) {
   const eng = resolveEngagement({ forWrite: true })
   if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exit(2) }
 
-  // fde log phase <land|discover|plan|ship|prove|close> - advances portfolio phase
+  // fde log phase <land|discover|plan|ship|outcome|close> - advances portfolio phase (prove → outcome)
   if (type === 'phase') {
     const phase = canonicalPhase((text || '').toLowerCase().trim())
     if (!PHASES.includes(phase)) {
@@ -2237,7 +2237,7 @@ function collectDoctorIssues(eng) {
     }
   }
   const success = readClean(eng, 'success.md')
-  if (!firstLine(success, 80)) issues.push('success.md has no stated done-definition - fill before plan/build')
+  if (!firstLine(success, 80)) issues.push('success.md has no stated done-definition - fill before plan/ship')
   const ctxMd = readClean(eng, 'context.md')
   if (!sectionBody(ctxMd, 'Next action', { lastNonEmpty: true })) {
     issues.push('no ## Next action in context.md - Monday morning has nothing to drive')
@@ -2278,7 +2278,7 @@ function collectDoctorIssues(eng) {
   }
   // Failure-path (exception-led operating map): required once past discover.
   // Land seeds; discover fills; plan+ without a real break→owner row is wallpaper.
-  if (/^(plan|ship|prove|close)$/.test(s.phase) && !hasOperatingMapContent(eng)) {
+  if (/^(plan|ship|outcome|close)$/.test(s.phase) && !hasOperatingMapContent(eng)) {
     issues.push(
       `phase is ${s.phase} with empty operating map - fill terrain.md ## Operating map (exception-led): break → who notices → workaround → evidence`
     )
@@ -3324,7 +3324,7 @@ function printUsage() {
   fde triage               TRIAGE block only (hooks / Cursor session entry)
   fde log <type> <text>    append decision|risk|delivery|contact (contact takes --signal red|amber|green; delivery "a|b|c" writes the value ledger; --force to allow secret-like text)
   fde log risk --retire    move matching open-risk bullets to ## Retired
-  fde log phase <phase>    set engagement phase (land|discover|plan|ship|prove|close)
+  fde log phase <phase>    set engagement phase (land|discover|plan|ship|outcome|close)
   fde log --undo           remove the last CLI log/debrief entry from memory
   fde debrief [file]       meeting notes → memory (prefixed lines; --dry-run; --force)
   fde debrief --smart      heuristic propose (prints decision:/risk:/delivery:/contact:/next:); --apply after confirm

--- a/bin/lib/trust.js
+++ b/bin/lib/trust.js
@@ -98,9 +98,11 @@ function createTrustApi(deps) {
     if (!m) return '?'
     const raw = m[1].replace(/\*/g, '').trim()
     if (!raw || /\|/.test(raw) || /^unset$/i.test(raw) || /^[\[(]/.test(raw)) return '?'
-    const one = raw.toLowerCase().match(/^(land|discover|plan|build|ship|prove|close)\b/)
+    const one = raw.toLowerCase().match(/^(land|discover|plan|build|ship|prove|outcome|close)\b/)
     if (!one) return '?'
-    return one[1] === 'build' ? 'ship' : one[1]
+    if (one[1] === 'build') return 'ship'
+    if (one[1] === 'prove') return 'outcome'
+    return one[1]
   }
 
   function countOpenRisks(eng) {

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -31,9 +31,9 @@ After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same rou
 |------|---------|------------|
 | `reality.md` | Actual problem vs brief | discover |
 | `terrain.md` | Codebase map, hotspots, test gaps, exception-led operating map (doctor requires ≥1 row from plan+) | discover, audit |
-| `decisions.md` | Plan + kill list + technical choices + reviews | plan, pick-three, build, review, `fde debrief` |
-| `risks.md` | Live risk register | plan, build, rescue, `fde debrief` |
-| `delivery.md` | Value ledger (bucket → promised → measured → accepted by → evidence) + ship receipts + status memos | build, ship, status, close, `fde debrief` |
+| `decisions.md` | Plan + kill list + technical choices + reviews | plan, pick-three, ship, review, `fde debrief` |
+| `risks.md` | Live risk register | plan, ship, rescue, `fde debrief` |
+| `delivery.md` | Value ledger (bucket → promised → measured → accepted by → evidence) + ship receipts + status memos | ship, status, close, `fde debrief` |
 
 ### Decision entries
 

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -2,7 +2,7 @@
 
 v3 ships **one skill**: `@fde` ([skills/fde/SKILL.md](../skills/fde/SKILL.md)). You describe the situation; it routes to a phase and follows that phase's skill from [skills/fde/references/](../skills/fde/references/). Engagement memory lives in `~/fde-engagements/<name>/.fde/` (one folder per customer).
 
-Each reference is a **skill, not advice**: the thinking the agent does, the artifact it drafts, and the checkpoint with the human FDE. The **Use When** column below is what the router actually matches on - the phrases in `skills/fde/SKILL.md` that send you to that skill, not a paraphrase.
+Each reference is a **skill, not advice**: the thinking the agent does, the artifact it drafts, and the checkpoint with the human FDE. The **Use when** column below is what the router actually matches on - the phrases in `skills/fde/SKILL.md` that send you to that skill, not a paraphrase.
 
 ---
 
@@ -13,66 +13,66 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [land](../skills/fde/references/land.md) | First 48 hours: interrogate the brief, map stakeholders, define success before code | Starting fresh, new customer, first meeting, just got the brief |
-| [audit](../skills/fde/references/audit.md) | Taking over mid-project: verify claims, find the load-bearing wall | Taking over, previous consultant left, joining mid-project |
-| [who-decides](../skills/fde/references/who-decides.md) | Map who decides, who blocks, who's about to escalate | Need to understand who matters, who decides, who blocks quietly |
-| [earn-trust](../skills/fde/references/earn-trust.md) | The trust ladder from observer to trusted; navigate AI policy | Need to earn access, navigate AI policy, build credibility |
-| [hold-scope](../skills/fde/references/hold-scope.md) | "Let me place it": scope receipts, the accumulation conversation | "Also can you...", scope expanding, timeline unchanged |
+| [land](../skills/fde/references/land.md) | Interrogate the brief, map who signs, define success | Starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief |
+| [audit](../skills/fde/references/audit.md) | Verify inherited claims, find the load-bearing wall | Taking over, previous consultant left, joining mid-project |
+| [who-decides](../skills/fde/references/who-decides.md) | Map who decides, who blocks, who escalates | Need to understand who matters, who decides, who blocks quietly |
+| [earn-trust](../skills/fde/references/earn-trust.md) | Earn access; navigate AI policy | Need to earn access, navigate AI policy, build credibility |
+| [hold-scope](../skills/fde/references/hold-scope.md) | Park the extra ask; keep the timeline honest | "Also can you...", scope expanding, timeline unchanged, scope the brief after kickoff |
 
 ### Discover
 *Finding the real problem. Testing what the brief claims.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [discover](../skills/fde/references/discover.md) | Frame the decision (Situation / Complication / Question) then scan repo + hunt the workaround + **workshop facilitation** + **data estate assessment** | Don't know the real problem, brief feels wrong, shadow processes |
-| [test-assumptions](../skills/fde/references/test-assumptions.md) | Extract untested assumptions, classify by blast radius, kill the riskiest first | The brief feels too neat, assumptions untested, "we just need..." |
-| [score-use-cases](../skills/fde/references/score-use-cases.md) | Score on value x urgency x alignment x data readiness / complexity | Multiple use cases competing, "we want to do everything" |
-| [poc](../skills/fde/references/poc.md) | Prototype the killer assumption in one day; kill fast, log the learning | Need to validate a direction, prototype, demo to de-risk |
+| [discover](../skills/fde/references/discover.md) | Frame the real problem, then scan; stop if data is not ready | Don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate |
+| [test-assumptions](../skills/fde/references/test-assumptions.md) | Kill the riskiest untested belief first | The brief feels too neat, assumptions untested, "we just need..." |
+| [score-use-cases](../skills/fde/references/score-use-cases.md) | Score what to build first | Multiple use cases competing, "we want to do everything" |
+| [poc](../skills/fde/references/poc.md) | Validate the bet in a day | Need to validate a direction, prototype, demo to de-risk, validate the solution, build prototype |
 
 ### Plan
 *Sequencing work and getting sponsor alignment.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [plan](../skills/fde/references/plan.md) | Work backwards from success + **estimation** (3-point sizing) + **migration strategy** | Break this down, what order, sequence the build |
-| [business-case](../skills/fde/references/business-case.md) | Cost of doing nothing -> investment -> return -> sensitivity check | Sponsor needs justification, need to defend budget or timeline |
-| [three-options](../skills/fde/references/three-options.md) | Three genuine options (conservative / pragmatic / ambitious) | Significant decision, multiple approaches, "what should we do?" |
-| [pick-three](../skills/fde/references/pick-three.md) | 20 things are "urgent"; pick 3 for Now, make trade-offs visible | 20 things are "urgent," need to pick the 3 that matter |
+| [plan](../skills/fde/references/plan.md) | Sequence the work backwards from done | Break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks |
+| [business-case](../skills/fde/references/business-case.md) | Defend the investment | Sponsor needs justification, need to defend budget or timeline |
+| [three-options](../skills/fde/references/three-options.md) | Generate three real options | Significant decision, multiple approaches, "what should we do?", generate solutions |
+| [pick-three](../skills/fde/references/pick-three.md) | Pick three from twenty urgents | 20 things are "urgent," need to pick the 3 that matter |
 
 ### Ship
 *On their codebase (greenfield or brownfield), then go-live.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [what-breaks](../skills/fde/references/what-breaks.md) | Trace dependencies, classify impact (CONTAINED -> IRREVERSIBLE) | What could go wrong, touching shared infrastructure, need to assess impact |
-| [rescue](../skills/fde/references/rescue.md) | Production fire, trust fire, wrong-brief-mid-build, **or full pivot** | Production down, urgent - or stakeholder gone quiet, trust slipping |
-| [ship](../skills/fde/references/ship.md) | One change they can see, proven on staging they operate, then **intent vs diff** + pre-flight + canary + rollback | Start building, update their checkout, first module, visible progress, going live, pre-flight |
-| [review](../skills/fde/references/review.md) | Stage 1 **intent vs diff** (KEEP/JUSTIFY/SPLIT/DROP), then safety | Review this change, is it safe, does it match what we agreed, scope creep in the PR |
-| [rollback](../skills/fde/references/rollback.md) | Test the escape route on staging before you need it at 2am | "We can always revert" - need to actually test the escape route |
+| [what-breaks](../skills/fde/references/what-breaks.md) | Name the blast radius | What could go wrong, touching shared infrastructure, need to assess impact, provision, IaC, shared infra |
+| [rescue](../skills/fde/references/rescue.md) | Resolve the incident or the trust fire | Production down, urgent, fix a prod bug, resolve incident - or stakeholder gone quiet, trust slipping |
+| [ship](../skills/fde/references/ship.md) | Build one change they can see, then go live | Start building, update their checkout, first module, visible progress, going live, pre-flight, build the increment, create the launch plan |
+| [review](../skills/fde/references/review.md) | Review the change against what we agreed | Review this change, review the pull request, is it safe, does it match what we agreed, scope creep in the PR |
+| [rollback](../skills/fde/references/rollback.md) | Test the escape route before 2am | "We can always revert" - need to actually test the escape route |
 
 ### Outcome
 *Show the outcome. Dated receipts, not memory.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [readout](../skills/fde/references/readout.md) | Sponsor update from the week's actual record | Weekly update due, "need to send the sponsor something" |
-| [demo-prep](../skills/fde/references/demo-prep.md) | The one number, live-vs-canned, five hard questions | Demo coming up, show-and-tell, exec walkthrough |
-| [debrief](../skills/fde/references/debrief.md) | Walk out of any meeting -> decisions, signals, actions in memory | Just out of a meeting, raw notes, "they said...", "debrief" |
-| [board-memo](../skills/fde/references/board-memo.md) | Pyramid: governing thought, three supports, SCQA frame | Sponsor's boss needs a summary, board update, justify continued investment |
-| [dashboard](../skills/fde/references/dashboard.md) | Portfolio view across all customers, trust-ordered | Status across all my customers |
-| [ingest](../skills/fde/references/ingest.md) | Pull raw text from any source MCP into `.inbox/`, propose, you confirm | "Pull today's transcript," "bring in the Notion page" |
-| [connect](../skills/fde/references/connect.md) | Guided config for a source MCP you already trust, plus a reusable recipe | "Connect Granola," "wire up Drive" |
+| [readout](../skills/fde/references/readout.md) | Get the week's number on paper | Weekly update due, "need to send the sponsor something" |
+| [demo-prep](../skills/fde/references/demo-prep.md) | Prep the demo they can reject | Demo coming up, show-and-tell, exec walkthrough |
+| [debrief](../skills/fde/references/debrief.md) | Put the meeting in the record | Just out of a meeting, raw notes, "they said...", "debrief", user interviews, workshop notes |
+| [board-memo](../skills/fde/references/board-memo.md) | Brief the sponsor's boss | Sponsor's boss needs a summary, board update, justify continued investment |
+| [dashboard](../skills/fde/references/dashboard.md) | See every client | Status across all my customers |
+| [ingest](../skills/fde/references/ingest.md) | Pull text you confirm | "Pull today's transcript," "bring in the Notion page" |
+| [connect](../skills/fde/references/connect.md) | Wire a source | "Connect Granola," "wire up Drive" |
 
 ### Close
 *They can run it without you.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [close](../skills/fde/references/close.md) | Retrospective, the 2am handoff document, what we learned | Wrapping up, handoff, making yourself replaceable |
-| [runbook](../skills/fde/references/runbook.md) | Operations runbook, knowledge transfer, confidence scoring | Engagement ending, team needs to operate without you |
-| [switch-clients](../skills/fde/references/switch-clients.md) | Daily triage, context-switch, cross-contamination prevention | Juggling 2+ customers, losing track, context-switching |
-| [encode-pattern](../skills/fde/references/encode-pattern.md) | If you did it twice, encode it; patterns are compound interest | Something worked well and will apply to future engagements |
-| [red-team](../skills/fde/references/red-team.md) | Stress-test a plan, handoff, or narrative before someone else does | "Red-team this," "stress-test my plan," poke holes, what am I missing |
+| [close](../skills/fde/references/close.md) | Hand off so they run it | Wrapping up, handoff, making yourself replaceable |
+| [runbook](../skills/fde/references/runbook.md) | Write the 2am document | Engagement ending, team needs to operate without you |
+| [switch-clients](../skills/fde/references/switch-clients.md) | Switch without bleed | Juggling 2+ customers, losing track, context-switching |
+| [encode-pattern](../skills/fde/references/encode-pattern.md) | Save what worked twice | Something worked well and will apply to future engagements |
+| [red-team](../skills/fde/references/red-team.md) | Stress-test before they do | "Red-team this," "stress-test my plan," poke holes, what am I missing |
 
 ### Overlays (activate on signal, alongside whatever skill is running)
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -16,7 +16,7 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 | **Discover** | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
 | **Plan** | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
 | **Ship** | ship, what-breaks, rescue, review, rollback | One change they can see on their repo, then go-live - not generic debug/build |
-| **Prove** | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | The outcome; pulling from source MCPs |
+| **Outcome** | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
 | **Close** | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 
 Each skill is a workflow, not advice: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.

--- a/examples/garvey-payments/README.md
+++ b/examples/garvey-payments/README.md
@@ -48,11 +48,11 @@ Open your workspace for this embed. Type `@fde`.
 
 ---
 
-### Day 10 - Build & ship slice
+### Day 10 - Ship one change
 
 **You:** `@fde Ship thinnest path by Friday. Legacy `payments-eu` module, no tests in repo.`
 
-**AI coding agent should:** route engineering - characterise, small PR, `decisions.md` + `delivery.md`.
+**AI coding agent should:** route engineering - characterise, one change they can see, `decisions.md` + `delivery.md`.
 
 | File | What gets written |
 |------|-------------------|

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -119,49 +119,49 @@ Read **one** reference and follow it. Do not improvise from memory.
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Starting fresh, new customer, first meeting, just got the brief | land | `references/land.md` |
+| Starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief | land | `references/land.md` |
 | Taking over, previous consultant left, joining mid-project | audit | `references/audit.md` |
 | Need to understand who matters, who decides, who blocks quietly | who-decides | `references/who-decides.md` |
 | Need to earn access, navigate AI policy, build credibility | earn-trust | `references/earn-trust.md` |
-| "Also can you…", scope expanding, timeline unchanged | hold-scope | `references/hold-scope.md` |
+| "Also can you…", scope expanding, timeline unchanged, scope the brief after kickoff | hold-scope | `references/hold-scope.md` |
 
 ### Discover
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Don't know the real problem, brief feels wrong, shadow processes | discover | `references/discover.md` |
+| Don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate, catalog the data | discover | `references/discover.md` |
 | The brief feels too neat, assumptions untested, "we just need…" | test-assumptions | `references/test-assumptions.md` |
 | Multiple use cases competing, "we want to do everything" | score-use-cases | `references/score-use-cases.md` |
-| Need to validate a direction, prototype, demo to de-risk, **POC**, spike, killer assumption | poc | `references/poc.md` |
+| Need to validate a direction, prototype, demo to de-risk, **POC**, spike, killer assumption, validate the solution, build prototype | poc | `references/poc.md` |
 
 ### Plan
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Break this down, what order, sequence the build | plan | `references/plan.md` |
+| Break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks | plan | `references/plan.md` |
 | Sponsor needs justification, need to defend budget or timeline | business-case | `references/business-case.md` |
-| Significant decision, multiple approaches, "what should we do?" | three-options | `references/three-options.md` |
+| Significant decision, multiple approaches, "what should we do?", generate solutions | three-options | `references/three-options.md` |
 | 20 things are "urgent," need to pick the 3 that matter | pick-three | `references/pick-three.md` |
 
 ### Ship
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| What could go wrong, touching shared infrastructure, need to assess impact | what-breaks | `references/what-breaks.md` |
-| Production down, urgent - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
-| Start building, update their checkout, first module, visible progress, their tests, POC follow-through, ready to deploy, going live, pre-flight | ship | `references/ship.md` |
-| Review this change, is it safe, does it match what we agreed | review | `references/review.md` |
+| What could go wrong, touching shared infrastructure, need to assess impact, provision, IaC, shared infra | what-breaks | `references/what-breaks.md` |
+| Production down, urgent, fix a prod bug, resolve incident - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
+| Start building, update their checkout, first module, visible progress, their tests, POC follow-through, ready to deploy, going live, pre-flight, build the increment, create the launch plan, design their UI | ship | `references/ship.md` |
+| Review this change, review the pull request, is it safe, does it match what we agreed | review | `references/review.md` |
 | Diff grew / scope creep in the PR / "did we only build what we said" / KEEP JUSTIFY SPLIT DROP | review (+ ship if going live) | `references/review.md` Stage 1 · `references/ship.md` Intent vs diff |
 | Wrap the session / share the thinking / catch teammates up / before I open the PR | (memory contract - session digest) | SKILL.md **On exit** - write TL;DR + decisions/why into `.fde/`; no transcript sync |
 | "We can always revert" - need to actually test the escape route | rollback | `references/rollback.md` |
 
-### Prove
+### Outcome
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
 | Weekly update due, "need to send the sponsor something" | readout | `references/readout.md` |
 | Demo coming up, show-and-tell, exec walkthrough | demo-prep | `references/demo-prep.md` |
-| Just out of a meeting, raw notes, "they said…", "debrief" | debrief | the debrief verb (above) + `references/debrief.md` |
+| Just out of a meeting, raw notes, "they said…", "debrief", user interviews, workshop notes | debrief | the debrief verb (above) + `references/debrief.md` |
 | Make sure we're up to date, pull what's relevant, fetch from Granola/Slack/Gmail/transcript | ingest | `references/ingest.md` (capability check → stage → propose → confirm → apply) |
 | Connect a new MCP / connect Granola Slack or Notion / what can you pull | connect | `references/connect.md` (+ `mcp/recipes/`) |
 | Prep me for a meeting / walk-in brief / "what should I know before I talk to…" | - | run `fde prep "<label>"`, present in plain language |
@@ -183,7 +183,7 @@ Read **one** reference and follow it. Do not improvise from memory.
 
 | Signal | Overlay |
 |--------|---------|
-| AI, ML, LLM, model, embeddings, RAG, agents, fine-tuning, inference, drift | `references/ai.md` |
+| AI, ML, LLM, model, embeddings, RAG, agents, fine-tuning, inference, drift, train the model | `references/ai.md` |
 | Golden set, eval suite, eval pack, pass/fail before AI ship, HITL gate for model, POC the model | `references/eval-pack.md` (+ `ai.md`) |
 | Deck, slides, report, governance framework, compliance pack, ADR, PDF | `references/artifacts.md` |
 | Patient data, PHI, HIPAA, EHR, clinical | `references/healthcare.md` |

--- a/skills/fde/references/ai.md
+++ b/skills/fde/references/ai.md
@@ -47,7 +47,7 @@ When any slice touches a model, embeddings, RAG, or an agent: create or update `
 4. **Pass/fail** - dated run; Verdict **SHIP** or **NO-SHIP**; critical fails must be 0.
 5. **HITL gate** - which decisions need human review before action (align with `trust-profile.md`). Empty when policy requires review → NO-SHIP.
 
-**When to write:** plan seeds the pack; poc/build grows goldens; ship requires Verdict SHIP and a receipt in `delivery.md` → `## Ship receipts`. Non-AI work skips this file entirely.
+**When to write:** plan seeds the pack; poc/ship grows goldens; ship requires Verdict SHIP and a receipt in `delivery.md` → `## Ship receipts`. Non-AI work skips this file entirely.
 
 ## RAG architecture (retrieval-augmented generation)
 

--- a/skills/fde/references/audit.md
+++ b/skills/fde/references/audit.md
@@ -1,4 +1,4 @@
-# audit - taking over mid-engagement
+# audit - Verify inherited claims
 
 **Enter when:** picking up someone else's work - previous consultant left, joining mid-project, half-done system.
 

--- a/skills/fde/references/board-memo.md
+++ b/skills/fde/references/board-memo.md
@@ -1,4 +1,4 @@
-# board-memo - the story that gets the next phase funded
+# board-memo - Brief the sponsor's boss
 
 **Enter when:** the sponsor's boss needs a summary, a board update mentions the engagement, the FDE needs to justify continued investment, or a quarterly review is approaching.
 

--- a/skills/fde/references/business-case.md
+++ b/skills/fde/references/business-case.md
@@ -1,4 +1,4 @@
-# business-case - the economics that get the sponsor to say yes
+# business-case - Defend the investment
 
 **Enter when:** the sponsor needs justification for the next phase, the FDE needs to defend budget or timeline, a feature decision needs cost/benefit evidence, or poc produced a direction that needs funding.
 

--- a/skills/fde/references/close.md
+++ b/skills/fde/references/close.md
@@ -1,4 +1,4 @@
-# close - handoff and pattern extraction
+# close - Hand off so they run it
 
 **Enter when:** the engagement is ending - the customer team must run this without the FDE.
 

--- a/skills/fde/references/connect.md
+++ b/skills/fde/references/connect.md
@@ -1,4 +1,4 @@
-# connect - wire a source MCP in plain language
+# connect - Wire a source
 
 **Enter when:** the FDE says "I want to connect a new MCP", "connect Granola / Slack / Notion", "how do I pull from …", or a pull request fails because no source tools exist.
 

--- a/skills/fde/references/dashboard.md
+++ b/skills/fde/references/dashboard.md
@@ -1,4 +1,4 @@
-# dashboard - the portfolio view
+# dashboard - See every client
 
 **Enter when:** the FDE runs several customers and asks "where am I across everything?"
 

--- a/skills/fde/references/debrief.md
+++ b/skills/fde/references/debrief.md
@@ -1,4 +1,4 @@
-# debrief - capture the meeting before it evaporates
+# debrief - Put the meeting in the record
 
 **Enter when:** the FDE just left a meeting/call and dumps raw notes, a transcript, or "they said…". Highest-frequency moment in FDE life. Capture within the hour.
 

--- a/skills/fde/references/demo-prep.md
+++ b/skills/fde/references/demo-prep.md
@@ -1,4 +1,4 @@
-# demo-prep - the demo is the heartbeat of the engagement
+# demo-prep - Prep the demo they can reject
 
 **Enter when:** a demo, show-and-tell, or exec walkthrough is coming. FDE engagements live demo-to-demo; a flat demo costs more than a slipped task.
 

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -1,4 +1,4 @@
-# discover - find the real problem, map the terrain
+# discover - Frame the real problem
 
 **Enter when:** the brief feels wrong, the real problem is unclear, shadow processes are suspected, or any phase found that the map is missing.
 
@@ -105,7 +105,7 @@ The real spec is what people **do** when the system fails - not what the slide d
 - **The hesitation.** When someone says "well, there's also this other thing we do…" - stop them, ask them to finish. The main story is what they're comfortable explaining; the hesitation is the real problem.
 - **"Which part of the codebase do you least want to touch?"** The answer is unanimous and it's the load-bearing wall. Check it against your churn scan - when the human answer and the churn data agree, that's your first map landmark.
 - **Shadow AI.** Someone pasting data into ChatGPT to cope = a real unmet need + an uncontrolled data risk. Note both.
-- **Exception-led operating map.** For each real break (not the slide-deck process): what fails, who notices first, what they do today, and which artifact is trusted in that moment. Prefer exceptions over happy-path swimlanes - the workaround is the operating system. Write rows under `terrain.md` → `## Operating map (exception-led)`. If the section is missing on an older engagement, add it; never regenerate the rest of terrain. When AI is in play, also fill `## Intelligence placement` (deterministic vs LLM judgement vs human approve). **`fde doctor` requires at least one filled exception row before plan/build/ship/close** - empty map after discover is a hygiene fail, not optional polish.
+- **Exception-led operating map.** For each real break (not the slide-deck process): what fails, who notices first, what they do today, and which artifact is trusted in that moment. Prefer exceptions over happy-path swimlanes - the workaround is the operating system. Write rows under `terrain.md` → `## Operating map (exception-led)`. If the section is missing on an older engagement, add it; never regenerate the rest of terrain. When AI is in play, also fill `## Intelligence placement` (deterministic vs LLM judgement vs human approve). **`fde doctor` requires at least one filled exception row before plan/ship/outcome/close** - empty map after discover is a hygiene fail, not optional polish.
 
 ## Method - part 3: workshop facilitation
 
@@ -171,7 +171,7 @@ Score every candidate use case before anything gets prototyped:
 **Complication:** <what forces a decision now>
 **Question:** <one decision-shaped sentence>
 **Answer-space:** confirm brief / descope / rescope / pause - and what a yes looks like
-**Implication for build:** <first small PR>
+**Implication for build:** <first change they can see>
 **Validated with:** <who, when>
 ```
 

--- a/skills/fde/references/earn-trust.md
+++ b/skills/fde/references/earn-trust.md
@@ -1,4 +1,4 @@
-# earn-trust - earning commit access one move at a time
+# earn-trust - Earn access
 
 **Enter when:** new engagement where you don't have full access yet, trust is thin, the customer said "let's start small," or you need to navigate "we don't trust AI-generated code."
 

--- a/skills/fde/references/encode-pattern.md
+++ b/skills/fde/references/encode-pattern.md
@@ -1,4 +1,4 @@
-# encode-pattern - if you did it twice, encode it
+# encode-pattern - Save what worked twice
 
 **Enter when:** the engagement is closing and reusable patterns exist, a technique worked well and will apply to future clients, the FDE notices themselves doing the same thing on a second engagement, or close identified a pattern worth preserving.
 
@@ -56,7 +56,7 @@ The difference between a 5-year FDE and a 15-year FDE is not talent - it's encod
 | **Discover** | Investigative / analytical | "The cron-job discovery checklist for legacy systems" |
 | **Plan** | Structural / strategic | "The three-option presentation for nervous sponsors" |
 | **Ship** | Technical / safety | "The Strangler Fig on financial transaction code" |
-| **Prove** | Operational / process | "The regulated-environment change-approval timeline buffer" |
+| **Outcome** | Operational / process | "The regulated-environment change-approval timeline buffer" |
 | **Close** | Knowledge / handoff | "The 2am document format that actually gets used" |
 
 **5. Version and evolve.** Patterns are living documents:

--- a/skills/fde/references/eval-pack.md
+++ b/skills/fde/references/eval-pack.md
@@ -1,4 +1,4 @@
-# eval-pack - prove the system before it acts
+# eval-pack - Gate the model before it acts
 
 **Enter when:** the work touches AI/LLM/agents/RAG, or they need to POC a model, or ship/close is blocked because there is no evidence the non-deterministic path is safe. Activate alongside `ai.md`, `poc`, or `ship` - not instead of them.
 

--- a/skills/fde/references/hold-scope.md
+++ b/skills/fde/references/hold-scope.md
@@ -1,4 +1,4 @@
-# hold-scope - holding the line without losing the relationship
+# hold-scope - Park the extra ask
 
 **Enter when:** "also can you…" mid-build, a stakeholder adds requirements without adjusting timeline, the FDE feels scope creeping but can't name it, or `success.md` no longer matches what's being asked.
 

--- a/skills/fde/references/ingest.md
+++ b/skills/fde/references/ingest.md
@@ -1,4 +1,4 @@
-# ingest - pull large artifacts into the fieldbook loop
+# ingest - Pull text you confirm
 
 **Enter when:** the FDE wants to catch the engagement up from external sources - "make sure Acme is up to date," "pull what's relevant," "grab today's Granola and Denise's last email." Raw transcripts and long emails that are too big to paste usefully.
 

--- a/skills/fde/references/land.md
+++ b/skills/fde/references/land.md
@@ -1,4 +1,4 @@
-# land - first 48 hours
+# land - Interrogate the brief
 
 **Enter when:** new customer, first meeting, just got the brief, nothing started yet.
 

--- a/skills/fde/references/pick-three.md
+++ b/skills/fde/references/pick-three.md
@@ -1,4 +1,4 @@
-# pick-three - when 20 things are "urgent," pick the 3 that matter
+# pick-three - Pick three from twenty urgents
 
 **Enter when:** a transformation engagement with a long list of initiatives, the customer's roadmap has more items than weeks, competing teams want different things, or the FDE needs to recommend what to do *first* across a complex programme.
 

--- a/skills/fde/references/plan.md
+++ b/skills/fde/references/plan.md
@@ -1,4 +1,4 @@
-# plan - sequence the work
+# plan - Sequence the work
 
 **Enter when:** scope is understood and the work needs breaking down - a slice, a phase, or the whole delivery.
 

--- a/skills/fde/references/poc.md
+++ b/skills/fde/references/poc.md
@@ -1,8 +1,10 @@
-# poc - kill or confirm a direction in a day
+# poc - Validate the bet in a day
 
 **Enter when:** a direction needs validating before committing real build time - POC, spike, show something, de-risk, pick between use cases. The output is something a sponsor can reject in a room this week, not a polished product.
 
-**Read first:** `context.md`, `reality.md`. Load `terrain.md` only if the prototype touches the existing codebase.
+**Read first:** `context.md`, `reality.md`. Load `terrain.md` only if the prototype touches the existing codebase. If `terrain.md` **Data estate** has a Blocker source this prototype needs, stop - that is discover, not a day's demo.
+
+A green check on synthetic data is not a validated solution. The person who can say no has to see it on evidence they already believe.
 
 ## Method (you do this work)
 

--- a/skills/fde/references/readout.md
+++ b/skills/fde/references/readout.md
@@ -1,4 +1,4 @@
-# readout - the sponsor update that keeps the engagement alive
+# readout - Get the week's number on paper
 
 **Enter when:** the weekly update is due, an exec asks "where are we," or the FDE says "I need to send Dana something." This artifact decides renewals; engineers underinvest in it.
 

--- a/skills/fde/references/red-team.md
+++ b/skills/fde/references/red-team.md
@@ -1,4 +1,4 @@
-# red-team - adversarial stress-test of your plan, position, or deliverable
+# red-team - Stress-test before they do
 
 **Enter when:** the FDE says "red-team this," "stress-test my thinking," "poke holes in this," "what am I missing," "challenge my plan" - or anytime they are about to walk into a high-stakes conversation (sponsor meeting, accumulation conversation, handoff, go-live) and want their blind spots exposed first.
 

--- a/skills/fde/references/rescue.md
+++ b/skills/fde/references/rescue.md
@@ -1,4 +1,4 @@
-# rescue - production fire, trust fire, or wrong-brief mid-build
+# rescue - Resolve the incident or the trust fire
 
 **Enter when:** production is down, something's bleeding - OR a stakeholder went quiet, confidence is slipping, or three weeks into the build the brief turned out to be wrong. Trust fires get the same urgency as outages.
 
@@ -13,7 +13,8 @@ Open by narrowing time, like a human: "Walk me through the last couple hours - d
 git log --since="6 hours ago" --format="%ad %an %s" --date=relative
 ```
 
-**The sequence:**
+**The sequence:** no fix until the cause is named. A symptom patch is the second incident.
+
 1. **Stabilise first.** Roll back? Disable the broken path? Route around it? Buy time before diagnosing. The instinct to fix fast causes the second incident.
 2. **Name the unknowns.** "We don't know if the queue is corrupted / if this hits all users / if the cache is stale." Written down. Named unknowns are safer than assumed knowns.
 3. **Assume maximum blast radius.** The unrecognised integration in the stack trace is load-bearing until proven otherwise.

--- a/skills/fde/references/review.md
+++ b/skills/fde/references/review.md
@@ -1,4 +1,4 @@
-# review - two stages, always in order
+# review - Review the change against what we agreed
 
 **Enter when:** a change needs review before merge - "is this safe," "does it match what we agreed."
 

--- a/skills/fde/references/rollback.md
+++ b/skills/fde/references/rollback.md
@@ -1,4 +1,4 @@
-# rollback - test the escape route before you need it
+# rollback - Test the escape route
 
 **Enter when:** a deploy is planned for the next 48 hours, the FDE says "we can always revert," a previous rollback failed or took too long, or the engagement involves regulated/critical systems.
 

--- a/skills/fde/references/runbook.md
+++ b/skills/fde/references/runbook.md
@@ -1,4 +1,4 @@
-# runbook - making yourself replaceable is the goal
+# runbook - Write the 2am document
 
 **Enter when:** the engagement is entering its final phase, the customer team needs to operate without the FDE, a new FDE is taking over, or the sponsor asks "what happens when you leave?"
 

--- a/skills/fde/references/score-use-cases.md
+++ b/skills/fde/references/score-use-cases.md
@@ -1,4 +1,4 @@
-# score-use-cases - pick the right battle, not the interesting one
+# score-use-cases - Score what to build first
 
 **Enter when:** multiple potential use cases compete for attention, the customer says "we want to do everything," a transformation engagement needs a starting point, or the FDE needs to recommend which problem to solve first.
 

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -1,4 +1,4 @@
-# ship - on their site, then live
+# ship - Build one change they can see, then go live
 
 **Enter when:** you are writing or updating on their codebase, they need to see something real, or you are going live.
 
@@ -24,6 +24,8 @@ A same-day throwaway that kills an assumption is `poc`. This method is the real 
 | Undo | Revert this change on its own | Same. If you cannot undo it, the design is coupled. |
 
 Skip POC only when the killer assumption already lives in the repo (typical brownfield). If the bet is unproven, `poc` first.
+
+If `terrain.md` **Data estate** lists a **Blocker** this change depends on: stop. That is discover, not ship. Do not build a path they cannot feed.
 
 ## Method - one change they can see
 

--- a/skills/fde/references/switch-clients.md
+++ b/skills/fde/references/switch-clients.md
@@ -1,4 +1,4 @@
-# switch-clients - juggling engagements without dropping any
+# switch-clients - Switch without bleed
 
 **Enter when:** the FDE is running 2+ engagements simultaneously, context-switching is causing mistakes or delays, a new customer is being onboarded while existing engagements are active, or the FDE says "I'm losing track."
 

--- a/skills/fde/references/test-assumptions.md
+++ b/skills/fde/references/test-assumptions.md
@@ -1,4 +1,4 @@
-# test-assumptions - pressure-test the brief before building on it
+# test-assumptions - Kill the riskiest belief
 
 **Enter when:** the brief feels too neat, the customer is very confident about the solution (not the problem), someone says "we just need…" about a complex system, or discover surfaced contradictions between what was said and what the codebase shows.
 

--- a/skills/fde/references/three-options.md
+++ b/skills/fde/references/three-options.md
@@ -1,4 +1,4 @@
-# three-options - three paths, not one recommendation
+# three-options - Generate three real options
 
 **Enter when:** a significant technical or strategic decision needs to be made, the FDE is asked "what should we do?", the team is stuck between approaches, or a fork in the engagement requires the sponsor's input.
 

--- a/skills/fde/references/what-breaks.md
+++ b/skills/fde/references/what-breaks.md
@@ -1,4 +1,4 @@
-# what-breaks - know what breaks before you touch it
+# what-breaks - Name the blast radius
 
 **Enter when:** about to make a change on a system you don't fully understand, touching a high-churn module from `terrain.md`, modifying shared infrastructure (auth, database, messaging), or the FDE asks "what could go wrong?"
 

--- a/skills/fde/references/who-decides.md
+++ b/skills/fde/references/who-decides.md
@@ -1,4 +1,4 @@
-# who-decides - reading the room before it reads you
+# who-decides - Map who decides
 
 **Enter when:** new stakeholders appear, signals shift mid-engagement, a meeting felt off but you can't say why, or it's been two weeks and the map hasn't been updated.
 

--- a/templates/.fde/terrain.md
+++ b/templates/.fde/terrain.md
@@ -9,7 +9,7 @@
 ## Operating map (exception-led)
 
 <!-- How work actually runs when the happy path fails. Fill in discover; leave blank until heard/seen.
-     fde doctor requires ≥1 real exception row before plan/build/ship/close. -->
+     fde doctor requires ≥1 real exception row before plan/ship/outcome/close. -->
 
 | Exception / break | Who notices first | What they do today (workaround) | System of record then | Blast if wrong | Evidence |
 |-------------------|-------------------|---------------------------------|-----------------------|----------------|----------|

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -998,6 +998,24 @@ test('resume leads with triage; log phase advances portfolio phase', () => {
   assert.match(fs.readFileSync(path.join(eng, 'context.md'), 'utf8'), /\*\*Phase:\*\*\s*discover/)
 })
 
+test('log phase prove aliases to outcome', () => {
+  const sandbox = makeSandbox('phase-outcome')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'acme']).status, 0)
+  const eng = engagementPath(sandbox, 'acme')
+  const prove = runFde(sandbox, ['log', 'phase', 'prove'])
+  assert.equal(prove.status, 0, prove.stderr)
+  assert.match(prove.stdout, /phase → outcome/)
+  assert.match(fs.readFileSync(path.join(eng, 'context.md'), 'utf8'), /\*\*Phase:\*\*\s*outcome/)
+  const status = runFde(sandbox, ['status'])
+  assert.match(status.stdout, /phase:outcome/)
+  assert.equal(runFde(sandbox, ['log', 'phase', 'outcome']).status, 0)
+
+  fs.writeFileSync(path.join(eng, 'context.md'), '# Engagement context\n**Phase:** prove\n\n## Next action\n- get the number signed\n')
+  const legacy = runFde(sandbox, ['status'])
+  assert.equal(legacy.status, 0, legacy.stderr)
+  assert.match(legacy.stdout, /phase:outcome/)
+})
+
 test('engagement memory is git-versioned with owner attribution on writes', () => {
   const sandbox = makeSandbox('mem-git')
   const init = runFde(sandbox, ['resume', '--init', 'ledgerco'])


### PR DESCRIPTION
## Summary
- Public names are verb + object across the README command map, slash commands, skill titles, and catalog (`Interrogate the brief`, `Validate the bet`, `Build one change they can see`).
- Stage `prove` is now `outcome`. `fde log phase prove` still works. Display is Outcome.
- Catalog stays 30 skills. File ids are unchanged.

## Test plan
- [x] `npm run check` (check.js + 131 tests)
- [ ] README command table and `/outcome` match on GitHub after merge
- [ ] `fde log phase prove` writes `outcome`; old `**Phase:** prove` files still triage as Outcome


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/75" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->