### PR TITLE
feat: 3.19.0 - Engage to Transfer on the FDE map

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: Interrogate the brief. Name who signs done.
+description: Engage. Interrogate the brief. Name who signs done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,5 +1,5 @@
 ---
-description: Hand off so they run it. They operate it without you.
+description: Transfer operations. They operate it without you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Frame the real problem. Treat the brief as a hypothesis.
+description: Diagnose. Treat the brief as a hypothesis.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -1,5 +1,5 @@
 ---
-description: Get the number accepted. Promised, measured, accepted.
+description: Realize. Promised, measured, accepted.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **outcome**.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Sequence the work. Work backwards from done.
+description: Align. Sequence the work. Work backwards from done.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.

--- a/.claude/commands/prep.md
+++ b/.claude/commands/prep.md
@@ -1,5 +1,5 @@
 ---
-description: Prep the meeting. One page from the record.
+description: Prepare the meeting. One page from the record.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **prep for a meeting or readout**.

--- a/.claude/commands/readout.md
+++ b/.claude/commands/readout.md
@@ -1,5 +1,5 @@
 ---
-description: Brief the sponsor. Promised, measured, accepted.
+description: Report the outcome. Promised, measured, accepted.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **Friday or sponsor update**.

--- a/.claude/commands/receipts.md
+++ b/.claude/commands/receipts.md
@@ -1,5 +1,5 @@
 ---
-description: Find when we agreed. A dated line, or it did not happen.
+description: Find the receipt. A dated line, or it did not happen.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **when did we agree?**

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Build one change they can see, then go live with a rollback you have run.
+description: Deliver the increment. Then go live with a rollback you have run.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.

--- a/.claude/commands/trust.md
+++ b/.claude/commands/trust.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose a quiet sponsor. Process gap, or they stopped trusting you.
+description: Diagnose trust. Process gap, or they stopped trusting you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Situation: **they went quiet**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.19.0 - 2026-08-29
+
+The public map is consulting language on FDE stages. Same 30 skills. Same slash commands.
+
+- Work names sit on the command table: Engage, Diagnose, Align, Deliver, Realize, Transfer. Stages stay Land → Close.
+- Skill titles match: Deliver the increment, Validate the solution, Hold scope, Transfer operations.
+- Same six stages at any scale, greenfield or brownfield, any industry (overlays). Done is not claimed until they can reject it on staging they operate.
+
 ## 3.18.0 - 2026-08-29
 
 Public names match the work: verb + object, six stages ending in Outcome.

--- a/README.md
+++ b/README.md
@@ -10,26 +10,26 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
 
 ## Commands
 
-Each command loads the same `@fde` skill. You never pick from 30 names.
+One map. Sprint or programme. Greenfield or brownfield. Any industry. Each command loads the same `@fde` skill. You never pick from 30 names.
 
-| What you're doing | Command | Key principle |
-|-------------------|---------|-----------|
-| Interrogate the brief | `/brief` | Name who signs done |
-| Frame the real problem | `/discover` | Treat the brief as a hypothesis |
-| Sequence the work | `/plan` | Work backwards from done |
-| Build one change they can see | `/ship` | Then go live with a rollback you have run |
-| Get the number accepted | `/outcome` | Promised, measured, accepted |
-| Hand off so they run it | `/close` | They operate it without you |
+| Work | Command | Stage | Principle |
+|------|---------|-------|-----------|
+| Engage | `/brief` | Land | Name who signs done |
+| Diagnose | `/discover` | Discover | Treat the brief as a hypothesis |
+| Align | `/plan` | Plan | Work backwards from done |
+| Deliver | `/ship` | Ship | One visible change, then go live |
+| Realize | `/outcome` | Outcome | Promised, measured, accepted |
+| Transfer | `/close` | Close | They operate it without you |
 
 Also:
 
-| What you're doing | Command | Key principle |
-|-------------------|---------|-----------|
-| Diagnose a quiet sponsor | `/trust` | Process gap, or they stopped trusting you |
-| Find when we agreed | `/receipts` | A dated line, or it did not happen |
+| Work | Command | Principle |
+|------|---------|-----------|
+| Diagnose trust | `/trust` | Process gap, or they stopped trusting you |
+| Find the receipt | `/receipts` | A dated line, or it did not happen |
 | Capture the meeting | `/debrief` | Notes into the record |
-| Prep the meeting | `/prep` | One page from the record |
-| Brief the sponsor | `/readout` | Promised, measured, accepted |
+| Prepare the meeting | `/prep` | One page from the record |
+| Report the outcome | `/readout` | Promised, measured, accepted |
 
 Skills also activate on English: naming a client, running a POC, changing their checkout, going live, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. Bound client work cannot.
 
@@ -97,65 +97,65 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](doc
 
 The commands above are the entry points. Under the hood, `@fde` activates these 30 skills, each a structured workflow with steps, an artifact, and a checkpoint. You never pick one by name. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 
-### Land - Brief and trust
+### Land - Engage
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
-| [land](skills/fde/references/land.md) | Interrogate the brief, name who signs | New client, first meeting, just got the brief |
+| [land](skills/fde/references/land.md) | Interrogate the brief | New client, first meeting, just got the brief |
 | [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
-| [who-decides](skills/fde/references/who-decides.md) | Map who decides | Need to know who matters |
-| [earn-trust](skills/fde/references/earn-trust.md) | Earn access; navigate AI policy | Need access or credibility |
-| [hold-scope](skills/fde/references/hold-scope.md) | Park the extra ask | "Also can you…", timeline unchanged |
+| [who-decides](skills/fde/references/who-decides.md) | Map decision rights | Need to know who matters |
+| [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
+| [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
 
-### Discover - Find the real problem
+### Discover - Diagnose
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
-| [discover](skills/fde/references/discover.md) | Frame the real problem | Brief feels wrong, shadow processes |
-| [test-assumptions](skills/fde/references/test-assumptions.md) | Kill the riskiest belief | Brief feels too neat |
-| [score-use-cases](skills/fde/references/score-use-cases.md) | Score what to build first | Everything is P0 |
-| [poc](skills/fde/references/poc.md) | Validate the bet in a day | POC, spike, need to de-risk |
+| [discover](skills/fde/references/discover.md) | Frame the problem | Brief feels wrong, shadow processes |
+| [test-assumptions](skills/fde/references/test-assumptions.md) | Test assumptions | Brief feels too neat |
+| [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
+| [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
 
-### Plan - Sequence the work
+### Plan - Align
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
 | [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
-| [business-case](skills/fde/references/business-case.md) | Defend the investment | Defend budget or timeline |
-| [three-options](skills/fde/references/three-options.md) | Generate three real options | "What should we do?" |
-| [pick-three](skills/fde/references/pick-three.md) | Pick three from twenty urgents | Everything is urgent |
+| [business-case](skills/fde/references/business-case.md) | Build the business case | Defend budget or timeline |
+| [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
+| [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
 
-### Ship - On their repo, then live
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [ship](skills/fde/references/ship.md) | Build one change they can see, then go live | Building, updating, or going live |
-| [what-breaks](skills/fde/references/what-breaks.md) | Name the blast radius | Touching shared infrastructure |
-| [rescue](skills/fde/references/rescue.md) | Resolve the incident or the trust fire | Down, or they went quiet |
-| [review](skills/fde/references/review.md) | Review the change against what we agreed | Before merge, scope creep |
-| [rollback](skills/fde/references/rollback.md) | Test the escape route | "We can always revert" |
-
-### Outcome - Get the number accepted
+### Ship - Deliver
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
-| [readout](skills/fde/references/readout.md) | Get the number on paper | Friday, sponsor update |
-| [demo-prep](skills/fde/references/demo-prep.md) | Prep the demo they can reject | Demo or exec walkthrough |
-| [debrief](skills/fde/references/debrief.md) | Put the meeting in the record | Just left a meeting |
-| [board-memo](skills/fde/references/board-memo.md) | Brief the sponsor's boss | Justify continued investment |
-| [dashboard](skills/fde/references/dashboard.md) | See every client | All my customers |
-| [ingest](skills/fde/references/ingest.md) | Pull text you confirm | Transcript, Notion, Slack |
-| [connect](skills/fde/references/connect.md) | Wire a source | Connect Granola |
+| [ship](skills/fde/references/ship.md) | Deliver the increment | Building, updating, or going live |
+| [what-breaks](skills/fde/references/what-breaks.md) | Assess impact | Touching shared infrastructure |
+| [rescue](skills/fde/references/rescue.md) | Resolve the incident | Down, or they went quiet |
+| [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
+| [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
 
-### Close - They run it
+### Outcome - Realize
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
-| [close](skills/fde/references/close.md) | Hand off so they run it | Wrapping up |
-| [runbook](skills/fde/references/runbook.md) | Write the 2am document | They must operate without you |
-| [switch-clients](skills/fde/references/switch-clients.md) | Switch without bleed | 2+ clients |
-| [encode-pattern](skills/fde/references/encode-pattern.md) | Save what worked twice | It will apply again |
-| [red-team](skills/fde/references/red-team.md) | Stress-test before they do | "Poke holes in this" |
+| [readout](skills/fde/references/readout.md) | Report the outcome | Friday, sponsor update |
+| [demo-prep](skills/fde/references/demo-prep.md) | Prepare the demo | Demo or exec walkthrough |
+| [debrief](skills/fde/references/debrief.md) | Capture the meeting | Just left a meeting |
+| [board-memo](skills/fde/references/board-memo.md) | Brief the board | Justify continued investment |
+| [dashboard](skills/fde/references/dashboard.md) | View the portfolio | All my customers |
+| [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
+| [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
+
+### Close - Transfer
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [close](skills/fde/references/close.md) | Transfer operations | Wrapping up |
+| [runbook](skills/fde/references/runbook.md) | Write the runbook | They must operate without you |
+| [switch-clients](skills/fde/references/switch-clients.md) | Switch engagements | 2+ clients |
+| [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
+| [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
 
 Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) · [eval-pack](skills/fde/references/eval-pack.md)
 
@@ -304,6 +304,7 @@ Local only - `git` + files, no network, no telemetry. Plain markdown. The model 
 
 ## Principles
 
+- **One map** - any scale, greenfield or brownfield, any industry. Overlays carry the vertical
 - **The artifact is the memory** - producing the work and recording it are one action
 - **Ground loop** - name the change, characterise their code, prove it on their staging, go live, log the outcome
 - **Skills, not autonomy** - the kit says what to check; judgment stays yours

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -9,70 +9,70 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 ## The 6 stages
 
 ### Land
-*First days. Getting access, building credibility, understanding scope.*
+*Engage. First days. Access, credibility, scope.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [land](../skills/fde/references/land.md) | Interrogate the brief, map who signs, define success | Starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief |
-| [audit](../skills/fde/references/audit.md) | Verify inherited claims, find the load-bearing wall | Taking over, previous consultant left, joining mid-project |
-| [who-decides](../skills/fde/references/who-decides.md) | Map who decides, who blocks, who escalates | Need to understand who matters, who decides, who blocks quietly |
-| [earn-trust](../skills/fde/references/earn-trust.md) | Earn access; navigate AI policy | Need to earn access, navigate AI policy, build credibility |
-| [hold-scope](../skills/fde/references/hold-scope.md) | Park the extra ask; keep the timeline honest | "Also can you...", scope expanding, timeline unchanged, scope the brief after kickoff |
+| [land](../skills/fde/references/land.md) | Interrogate the brief | Starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief |
+| [audit](../skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left, joining mid-project |
+| [who-decides](../skills/fde/references/who-decides.md) | Map decision rights | Need to understand who matters, who decides, who blocks quietly |
+| [earn-trust](../skills/fde/references/earn-trust.md) | Earn access | Need to earn access, navigate AI policy, build credibility |
+| [hold-scope](../skills/fde/references/hold-scope.md) | Hold scope | "Also can you...", scope expanding, timeline unchanged, scope the brief after kickoff |
 
 ### Discover
-*Finding the real problem. Testing what the brief claims.*
+*Diagnose. Finding the real problem. Testing what the brief claims.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [discover](../skills/fde/references/discover.md) | Frame the real problem, then scan; stop if data is not ready | Don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate |
-| [test-assumptions](../skills/fde/references/test-assumptions.md) | Kill the riskiest untested belief first | The brief feels too neat, assumptions untested, "we just need..." |
-| [score-use-cases](../skills/fde/references/score-use-cases.md) | Score what to build first | Multiple use cases competing, "we want to do everything" |
-| [poc](../skills/fde/references/poc.md) | Validate the bet in a day | Need to validate a direction, prototype, demo to de-risk, validate the solution, build prototype |
+| [discover](../skills/fde/references/discover.md) | Frame the problem | Don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate |
+| [test-assumptions](../skills/fde/references/test-assumptions.md) | Test assumptions | The brief feels too neat, assumptions untested, "we just need..." |
+| [score-use-cases](../skills/fde/references/score-use-cases.md) | Score use cases | Multiple use cases competing, "we want to do everything" |
+| [poc](../skills/fde/references/poc.md) | Validate the solution | Need to validate a direction, prototype, demo to de-risk, validate the solution, build prototype |
 
 ### Plan
-*Sequencing work and getting sponsor alignment.*
+*Align. Sequencing work and getting sponsor alignment.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [plan](../skills/fde/references/plan.md) | Sequence the work backwards from done | Break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks |
-| [business-case](../skills/fde/references/business-case.md) | Defend the investment | Sponsor needs justification, need to defend budget or timeline |
-| [three-options](../skills/fde/references/three-options.md) | Generate three real options | Significant decision, multiple approaches, "what should we do?", generate solutions |
-| [pick-three](../skills/fde/references/pick-three.md) | Pick three from twenty urgents | 20 things are "urgent," need to pick the 3 that matter |
+| [plan](../skills/fde/references/plan.md) | Sequence the work | Break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks |
+| [business-case](../skills/fde/references/business-case.md) | Build the business case | Sponsor needs justification, need to defend budget or timeline |
+| [three-options](../skills/fde/references/three-options.md) | Generate options | Significant decision, multiple approaches, "what should we do?", generate solutions |
+| [pick-three](../skills/fde/references/pick-three.md) | Prioritize three | 20 things are "urgent," need to pick the 3 that matter |
 
 ### Ship
-*On their codebase (greenfield or brownfield), then go-live.*
+*Deliver. On their codebase (greenfield or brownfield), then go-live.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [what-breaks](../skills/fde/references/what-breaks.md) | Name the blast radius | What could go wrong, touching shared infrastructure, need to assess impact, provision, IaC, shared infra |
-| [rescue](../skills/fde/references/rescue.md) | Resolve the incident or the trust fire | Production down, urgent, fix a prod bug, resolve incident - or stakeholder gone quiet, trust slipping |
-| [ship](../skills/fde/references/ship.md) | Build one change they can see, then go live | Start building, update their checkout, first module, visible progress, going live, pre-flight, build the increment, create the launch plan |
-| [review](../skills/fde/references/review.md) | Review the change against what we agreed | Review this change, review the pull request, is it safe, does it match what we agreed, scope creep in the PR |
-| [rollback](../skills/fde/references/rollback.md) | Test the escape route before 2am | "We can always revert" - need to actually test the escape route |
+| [what-breaks](../skills/fde/references/what-breaks.md) | Assess impact | What could go wrong, touching shared infrastructure, need to assess impact, provision, IaC, shared infra |
+| [rescue](../skills/fde/references/rescue.md) | Resolve the incident | Production down, urgent, fix a prod bug, resolve incident - or stakeholder gone quiet, trust slipping |
+| [ship](../skills/fde/references/ship.md) | Deliver the increment | Start building, update their checkout, first module, visible progress, going live, pre-flight, build the increment, create the launch plan |
+| [review](../skills/fde/references/review.md) | Review the change | Review this change, review the pull request, is it safe, does it match what we agreed, scope creep in the PR |
+| [rollback](../skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" - need to actually test the escape route |
 
 ### Outcome
-*Show the outcome. Dated receipts, not memory.*
+*Realize. Dated receipts, not memory.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [readout](../skills/fde/references/readout.md) | Get the week's number on paper | Weekly update due, "need to send the sponsor something" |
-| [demo-prep](../skills/fde/references/demo-prep.md) | Prep the demo they can reject | Demo coming up, show-and-tell, exec walkthrough |
-| [debrief](../skills/fde/references/debrief.md) | Put the meeting in the record | Just out of a meeting, raw notes, "they said...", "debrief", user interviews, workshop notes |
-| [board-memo](../skills/fde/references/board-memo.md) | Brief the sponsor's boss | Sponsor's boss needs a summary, board update, justify continued investment |
-| [dashboard](../skills/fde/references/dashboard.md) | See every client | Status across all my customers |
-| [ingest](../skills/fde/references/ingest.md) | Pull text you confirm | "Pull today's transcript," "bring in the Notion page" |
-| [connect](../skills/fde/references/connect.md) | Wire a source | "Connect Granola," "wire up Drive" |
+| [readout](../skills/fde/references/readout.md) | Report the outcome | Weekly update due, "need to send the sponsor something" |
+| [demo-prep](../skills/fde/references/demo-prep.md) | Prepare the demo | Demo coming up, show-and-tell, exec walkthrough |
+| [debrief](../skills/fde/references/debrief.md) | Capture the meeting | Just out of a meeting, raw notes, "they said...", "debrief", user interviews, workshop notes |
+| [board-memo](../skills/fde/references/board-memo.md) | Brief the board | Sponsor's boss needs a summary, board update, justify continued investment |
+| [dashboard](../skills/fde/references/dashboard.md) | View the portfolio | Status across all my customers |
+| [ingest](../skills/fde/references/ingest.md) | Ingest sources | "Pull today's transcript," "bring in the Notion page" |
+| [connect](../skills/fde/references/connect.md) | Connect a source | "Connect Granola," "wire up Drive" |
 
 ### Close
-*They can run it without you.*
+*Transfer. They can run it without you.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
-| [close](../skills/fde/references/close.md) | Hand off so they run it | Wrapping up, handoff, making yourself replaceable |
-| [runbook](../skills/fde/references/runbook.md) | Write the 2am document | Engagement ending, team needs to operate without you |
-| [switch-clients](../skills/fde/references/switch-clients.md) | Switch without bleed | Juggling 2+ customers, losing track, context-switching |
-| [encode-pattern](../skills/fde/references/encode-pattern.md) | Save what worked twice | Something worked well and will apply to future engagements |
-| [red-team](../skills/fde/references/red-team.md) | Stress-test before they do | "Red-team this," "stress-test my plan," poke holes, what am I missing |
+| [close](../skills/fde/references/close.md) | Transfer operations | Wrapping up, handoff, making yourself replaceable |
+| [runbook](../skills/fde/references/runbook.md) | Write the runbook | Engagement ending, team needs to operate without you |
+| [switch-clients](../skills/fde/references/switch-clients.md) | Switch engagements | Juggling 2+ customers, losing track, context-switching |
+| [encode-pattern](../skills/fde/references/encode-pattern.md) | Encode the pattern | Something worked well and will apply to future engagements |
+| [red-team](../skills/fde/references/red-team.md) | Challenge the plan | "Red-team this," "stress-test my plan," poke holes, what am I missing |
 
 ### Overlays (activate on signal, alongside whatever skill is running)
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -12,12 +12,12 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 
 | Stage | Skills | What it covers |
 |--------|--------|---------------|
-| **Land** | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
-| **Discover** | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
-| **Plan** | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
-| **Ship** | ship, what-breaks, rescue, review, rollback | One change they can see on their repo, then go-live - not generic debug/build |
-| **Outcome** | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
-| **Close** | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
+| **Land** (Engage) | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
+| **Discover** (Diagnose) | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
+| **Plan** (Align) | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
+| **Ship** (Deliver) | ship, what-breaks, rescue, review, rollback | One visible change on their repo, then go-live |
+| **Outcome** (Realize) | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
+| **Close** (Transfer) | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 
 Each skill is a workflow, not advice: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.
 

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.18.0",
+  "version": "3.19.0",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -7,7 +7,7 @@ description: Keeps the engagement record for client work. Use when they name a c
 
 ## Purpose
 
-The **engagement record** for one client, from first meeting to signed outcome. One skill; six stages (land → close). You route; they never pick a skill. Confirm, then write `.fde/`. The workspace still compiles and commits. `@fde` does not leave.
+The **engagement record** for one client, from first meeting to signed outcome. One skill; six stages (land → close). Same map at any scale, on greenfield or brownfield, in any industry (overlays). You route; they never pick a skill. Confirm, then write `.fde/`. The workspace still compiles and commits. `@fde` does not leave.
 
 ## When to use
 
@@ -113,70 +113,70 @@ Muddy signal: name it ("discover or rescue - leaning X"). Never a phase-picker i
 
 ## Routing - 6 stages
 
-Read **one** reference and follow it. Do not improvise from memory.
+Work names (engage, diagnose, align, deliver, realize, transfer) are the same map. Read **one** reference and follow it. Do not improvise from memory.
 
 ### Land
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief | land | `references/land.md` |
+| Engage, onboarding, starting fresh, new customer, first meeting, just got the brief, set product strategy, define success metrics, scope the brief | land | `references/land.md` |
 | Taking over, previous consultant left, joining mid-project | audit | `references/audit.md` |
-| Need to understand who matters, who decides, who blocks quietly | who-decides | `references/who-decides.md` |
+| Need to understand who matters, who decides, map decision rights, who blocks quietly | who-decides | `references/who-decides.md` |
 | Need to earn access, navigate AI policy, build credibility | earn-trust | `references/earn-trust.md` |
-| "Also can you…", scope expanding, timeline unchanged, scope the brief after kickoff | hold-scope | `references/hold-scope.md` |
+| "Also can you…", scope expanding, timeline unchanged, hold scope, scope the brief after kickoff | hold-scope | `references/hold-scope.md` |
 
 ### Discover
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate, catalog the data | discover | `references/discover.md` |
-| The brief feels too neat, assumptions untested, "we just need…" | test-assumptions | `references/test-assumptions.md` |
-| Multiple use cases competing, "we want to do everything" | score-use-cases | `references/score-use-cases.md` |
+| Diagnose, don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate, catalog the data | discover | `references/discover.md` |
+| The brief feels too neat, assumptions untested, "we just need…", test assumptions | test-assumptions | `references/test-assumptions.md` |
+| Multiple use cases competing, "we want to do everything", score use cases | score-use-cases | `references/score-use-cases.md` |
 | Need to validate a direction, prototype, demo to de-risk, **POC**, spike, killer assumption, validate the solution, build prototype | poc | `references/poc.md` |
 
 ### Plan
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks | plan | `references/plan.md` |
-| Sponsor needs justification, need to defend budget or timeline | business-case | `references/business-case.md` |
-| Significant decision, multiple approaches, "what should we do?", generate solutions | three-options | `references/three-options.md` |
-| 20 things are "urgent," need to pick the 3 that matter | pick-three | `references/pick-three.md` |
+| Align, break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks | plan | `references/plan.md` |
+| Sponsor needs justification, need to defend budget or timeline, build the business case | business-case | `references/business-case.md` |
+| Significant decision, multiple approaches, "what should we do?", generate solutions, generate options | three-options | `references/three-options.md` |
+| 20 things are "urgent," need to pick the 3 that matter, prioritize three | pick-three | `references/pick-three.md` |
 
 ### Ship
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| What could go wrong, touching shared infrastructure, need to assess impact, provision, IaC, shared infra | what-breaks | `references/what-breaks.md` |
-| Production down, urgent, fix a prod bug, resolve incident - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
-| Start building, update their checkout, first module, visible progress, their tests, POC follow-through, ready to deploy, going live, pre-flight, build the increment, create the launch plan, design their UI | ship | `references/ship.md` |
+| What could go wrong, touching shared infrastructure, need to assess impact, assess impact, provision, IaC, shared infra | what-breaks | `references/what-breaks.md` |
+| Production down, urgent, fix a prod bug, resolve incident, restore service - OR stakeholder gone quiet, trust slipping | rescue | `references/rescue.md` |
+| Deliver, start building, update their checkout, first module, visible progress, their tests, POC follow-through, ready to deploy, going live, pre-flight, deliver the increment, build the increment, create the launch plan, design their UI | ship | `references/ship.md` |
 | Review this change, review the pull request, is it safe, does it match what we agreed | review | `references/review.md` |
 | Diff grew / scope creep in the PR / "did we only build what we said" / KEEP JUSTIFY SPLIT DROP | review (+ ship if going live) | `references/review.md` Stage 1 · `references/ship.md` Intent vs diff |
 | Wrap the session / share the thinking / catch teammates up / before I open the PR | (memory contract - session digest) | SKILL.md **On exit** - write TL;DR + decisions/why into `.fde/`; no transcript sync |
-| "We can always revert" - need to actually test the escape route | rollback | `references/rollback.md` |
+| "We can always revert" - need to actually test the escape route, rehearse rollback | rollback | `references/rollback.md` |
 
 ### Outcome
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Weekly update due, "need to send the sponsor something" | readout | `references/readout.md` |
-| Demo coming up, show-and-tell, exec walkthrough | demo-prep | `references/demo-prep.md` |
-| Just out of a meeting, raw notes, "they said…", "debrief", user interviews, workshop notes | debrief | the debrief verb (above) + `references/debrief.md` |
+| Realize, weekly update due, "need to send the sponsor something", report the outcome | readout | `references/readout.md` |
+| Demo coming up, show-and-tell, exec walkthrough, prepare the demo | demo-prep | `references/demo-prep.md` |
+| Just out of a meeting, raw notes, "they said…", "debrief", user interviews, workshop notes, capture the meeting | debrief | the debrief verb (above) + `references/debrief.md` |
 | Make sure we're up to date, pull what's relevant, fetch from Granola/Slack/Gmail/transcript | ingest | `references/ingest.md` (capability check → stage → propose → confirm → apply) |
 | Connect a new MCP / connect Granola Slack or Notion / what can you pull | connect | `references/connect.md` (+ `mcp/recipes/`) |
 | Prep me for a meeting / walk-in brief / "what should I know before I talk to…" | - | run `fde prep "<label>"`, present in plain language |
-| Sponsor's boss needs a summary, board update, justify continued investment | board-memo | `references/board-memo.md` |
-| Status across all my customers | dashboard | `references/dashboard.md` |
+| Sponsor's boss needs a summary, board update, brief the board, justify continued investment | board-memo | `references/board-memo.md` |
+| Status across all my customers, view the portfolio | dashboard | `references/dashboard.md` |
 
 ### Close
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Juggling 2+ customers, losing track, context-switching | switch-clients | `references/switch-clients.md` |
-| Wrapping up, handoff, making yourself replaceable | close | `references/close.md` |
-| Engagement ending, team needs to operate without you | runbook | `references/runbook.md` |
-| Something worked well and will apply to future engagements | encode-pattern | `references/encode-pattern.md` |
-| "Red-team this," "stress-test my plan," poke holes, what am I missing | red-team | `references/red-team.md` |
+| Juggling 2+ customers, losing track, context-switching, switch engagements | switch-clients | `references/switch-clients.md` |
+| Transfer, wrapping up, handoff, making yourself replaceable, transfer operations | close | `references/close.md` |
+| Engagement ending, team needs to operate without you, write the runbook | runbook | `references/runbook.md` |
+| Something worked well and will apply to future engagements, encode the pattern | encode-pattern | `references/encode-pattern.md` |
+| "Red-team this," "stress-test my plan," poke holes, challenge the plan, what am I missing | red-team | `references/red-team.md` |
 | "What did we agree about X?", scope dispute, receipts | - | run `fde receipts <term>`, answer with dates |
 
 **Overlays - activate alongside any skill on signal, don't wait to be told:**
@@ -195,7 +195,9 @@ Ready to build with no `terrain.md` / plan: discover or plan first. Takeover wit
 ## Principles
 
 - Never ask the FDE to pick a phase. That's your job.
+- Same six stages at any scale. Overlays carry the industry. Greenfield and brownfield change the first move inside ship, not the map.
 - Ground loop on a bound client: name → characterise → prove on their staging → go live → log. Do not hand their repo to a generic coding pack.
+- Do not call a change done until the signer in `success.md` can reject it on staging they operate.
 - Read `context.md` before speaking. One sharp question - never a barrage.
 - Never invent people, meetings, or numbers - `unknown - ask:` beats a polished lie.
 - Every phase ends with its artifact written. No artifact, no "done."

--- a/skills/fde/references/board-memo.md
+++ b/skills/fde/references/board-memo.md
@@ -1,4 +1,4 @@
-# board-memo - Brief the sponsor's boss
+# board-memo - Brief the board
 
 **Enter when:** the sponsor's boss needs a summary, a board update mentions the engagement, the FDE needs to justify continued investment, or a quarterly review is approaching.
 

--- a/skills/fde/references/business-case.md
+++ b/skills/fde/references/business-case.md
@@ -1,4 +1,4 @@
-# business-case - Defend the investment
+# business-case - Build the business case
 
 **Enter when:** the sponsor needs justification for the next phase, the FDE needs to defend budget or timeline, a feature decision needs cost/benefit evidence, or poc produced a direction that needs funding.
 

--- a/skills/fde/references/close.md
+++ b/skills/fde/references/close.md
@@ -1,4 +1,4 @@
-# close - Hand off so they run it
+# close - Transfer operations
 
 **Enter when:** the engagement is ending - the customer team must run this without the FDE.
 

--- a/skills/fde/references/connect.md
+++ b/skills/fde/references/connect.md
@@ -1,4 +1,4 @@
-# connect - Wire a source
+# connect - Connect a source
 
 **Enter when:** the FDE says "I want to connect a new MCP", "connect Granola / Slack / Notion", "how do I pull from …", or a pull request fails because no source tools exist.
 

--- a/skills/fde/references/dashboard.md
+++ b/skills/fde/references/dashboard.md
@@ -1,4 +1,4 @@
-# dashboard - See every client
+# dashboard - View the portfolio
 
 **Enter when:** the FDE runs several customers and asks "where am I across everything?"
 

--- a/skills/fde/references/debrief.md
+++ b/skills/fde/references/debrief.md
@@ -1,4 +1,4 @@
-# debrief - Put the meeting in the record
+# debrief - Capture the meeting
 
 **Enter when:** the FDE just left a meeting/call and dumps raw notes, a transcript, or "they said…". Highest-frequency moment in FDE life. Capture within the hour.
 

--- a/skills/fde/references/demo-prep.md
+++ b/skills/fde/references/demo-prep.md
@@ -1,4 +1,4 @@
-# demo-prep - Prep the demo they can reject
+# demo-prep - Prepare the demo
 
 **Enter when:** a demo, show-and-tell, or exec walkthrough is coming. FDE engagements live demo-to-demo; a flat demo costs more than a slipped task.
 

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -1,4 +1,4 @@
-# discover - Frame the real problem
+# discover - Frame the problem
 
 **Enter when:** the brief feels wrong, the real problem is unclear, shadow processes are suspected, or any phase found that the map is missing.
 

--- a/skills/fde/references/encode-pattern.md
+++ b/skills/fde/references/encode-pattern.md
@@ -1,4 +1,4 @@
-# encode-pattern - Save what worked twice
+# encode-pattern - Encode the pattern
 
 **Enter when:** the engagement is closing and reusable patterns exist, a technique worked well and will apply to future clients, the FDE notices themselves doing the same thing on a second engagement, or close identified a pattern worth preserving.
 

--- a/skills/fde/references/hold-scope.md
+++ b/skills/fde/references/hold-scope.md
@@ -1,4 +1,4 @@
-# hold-scope - Park the extra ask
+# hold-scope - Hold scope
 
 **Enter when:** "also can you…" mid-build, a stakeholder adds requirements without adjusting timeline, the FDE feels scope creeping but can't name it, or `success.md` no longer matches what's being asked.
 

--- a/skills/fde/references/ingest.md
+++ b/skills/fde/references/ingest.md
@@ -1,4 +1,4 @@
-# ingest - Pull text you confirm
+# ingest - Ingest sources
 
 **Enter when:** the FDE wants to catch the engagement up from external sources - "make sure Acme is up to date," "pull what's relevant," "grab today's Granola and Denise's last email." Raw transcripts and long emails that are too big to paste usefully.
 

--- a/skills/fde/references/pick-three.md
+++ b/skills/fde/references/pick-three.md
@@ -1,4 +1,4 @@
-# pick-three - Pick three from twenty urgents
+# pick-three - Prioritize three
 
 **Enter when:** a transformation engagement with a long list of initiatives, the customer's roadmap has more items than weeks, competing teams want different things, or the FDE needs to recommend what to do *first* across a complex programme.
 

--- a/skills/fde/references/poc.md
+++ b/skills/fde/references/poc.md
@@ -1,4 +1,4 @@
-# poc - Validate the bet in a day
+# poc - Validate the solution
 
 **Enter when:** a direction needs validating before committing real build time - POC, spike, show something, de-risk, pick between use cases. The output is something a sponsor can reject in a room this week, not a polished product.
 

--- a/skills/fde/references/readout.md
+++ b/skills/fde/references/readout.md
@@ -1,4 +1,4 @@
-# readout - Get the week's number on paper
+# readout - Report the outcome
 
 **Enter when:** the weekly update is due, an exec asks "where are we," or the FDE says "I need to send Dana something." This artifact decides renewals; engineers underinvest in it.
 

--- a/skills/fde/references/red-team.md
+++ b/skills/fde/references/red-team.md
@@ -1,4 +1,4 @@
-# red-team - Stress-test before they do
+# red-team - Challenge the plan
 
 **Enter when:** the FDE says "red-team this," "stress-test my thinking," "poke holes in this," "what am I missing," "challenge my plan" - or anytime they are about to walk into a high-stakes conversation (sponsor meeting, accumulation conversation, handoff, go-live) and want their blind spots exposed first.
 

--- a/skills/fde/references/rescue.md
+++ b/skills/fde/references/rescue.md
@@ -1,4 +1,4 @@
-# rescue - Resolve the incident or the trust fire
+# rescue - Resolve the incident
 
 **Enter when:** production is down, something's bleeding - OR a stakeholder went quiet, confidence is slipping, or three weeks into the build the brief turned out to be wrong. Trust fires get the same urgency as outages.
 

--- a/skills/fde/references/review.md
+++ b/skills/fde/references/review.md
@@ -1,4 +1,4 @@
-# review - Review the change against what we agreed
+# review - Review the change
 
 **Enter when:** a change needs review before merge - "is this safe," "does it match what we agreed."
 

--- a/skills/fde/references/rollback.md
+++ b/skills/fde/references/rollback.md
@@ -1,4 +1,4 @@
-# rollback - Test the escape route
+# rollback - Rehearse rollback
 
 **Enter when:** a deploy is planned for the next 48 hours, the FDE says "we can always revert," a previous rollback failed or took too long, or the engagement involves regulated/critical systems.
 

--- a/skills/fde/references/runbook.md
+++ b/skills/fde/references/runbook.md
@@ -1,4 +1,4 @@
-# runbook - Write the 2am document
+# runbook - Write the runbook
 
 **Enter when:** the engagement is entering its final phase, the customer team needs to operate without the FDE, a new FDE is taking over, or the sponsor asks "what happens when you leave?"
 

--- a/skills/fde/references/score-use-cases.md
+++ b/skills/fde/references/score-use-cases.md
@@ -1,4 +1,4 @@
-# score-use-cases - Score what to build first
+# score-use-cases - Score use cases
 
 **Enter when:** multiple potential use cases compete for attention, the customer says "we want to do everything," a transformation engagement needs a starting point, or the FDE needs to recommend which problem to solve first.
 

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -1,4 +1,4 @@
-# ship - Build one change they can see, then go live
+# ship - Deliver the increment
 
 **Enter when:** you are writing or updating on their codebase, they need to see something real, or you are going live.
 
@@ -24,6 +24,8 @@ A same-day throwaway that kills an assumption is `poc`. This method is the real 
 | Undo | Revert this change on its own | Same. If you cannot undo it, the design is coupled. |
 
 Skip POC only when the killer assumption already lives in the repo (typical brownfield). If the bet is unproven, `poc` first.
+
+**Done means:** the signer in `success.md` can reject this on staging they operate. A green check on your laptop is not delivery. Do not start the next change until this one is rejectable.
 
 If `terrain.md` **Data estate** lists a **Blocker** this change depends on: stop. That is discover, not ship. Do not build a path they cannot feed.
 

--- a/skills/fde/references/switch-clients.md
+++ b/skills/fde/references/switch-clients.md
@@ -1,4 +1,4 @@
-# switch-clients - Switch without bleed
+# switch-clients - Switch engagements
 
 **Enter when:** the FDE is running 2+ engagements simultaneously, context-switching is causing mistakes or delays, a new customer is being onboarded while existing engagements are active, or the FDE says "I'm losing track."
 

--- a/skills/fde/references/test-assumptions.md
+++ b/skills/fde/references/test-assumptions.md
@@ -1,4 +1,4 @@
-# test-assumptions - Kill the riskiest belief
+# test-assumptions - Test assumptions
 
 **Enter when:** the brief feels too neat, the customer is very confident about the solution (not the problem), someone says "we just need…" about a complex system, or discover surfaced contradictions between what was said and what the codebase shows.
 

--- a/skills/fde/references/three-options.md
+++ b/skills/fde/references/three-options.md
@@ -1,4 +1,4 @@
-# three-options - Generate three real options
+# three-options - Generate options
 
 **Enter when:** a significant technical or strategic decision needs to be made, the FDE is asked "what should we do?", the team is stuck between approaches, or a fork in the engagement requires the sponsor's input.
 

--- a/skills/fde/references/what-breaks.md
+++ b/skills/fde/references/what-breaks.md
@@ -1,4 +1,4 @@
-# what-breaks - Name the blast radius
+# what-breaks - Assess impact
 
 **Enter when:** about to make a change on a system you don't fully understand, touching a high-churn module from `terrain.md`, modifying shared infrastructure (auth, database, messaging), or the FDE asks "what could go wrong?"
 

--- a/skills/fde/references/who-decides.md
+++ b/skills/fde/references/who-decides.md
@@ -1,4 +1,4 @@
-# who-decides - Map who decides
+# who-decides - Map decision rights
 
 **Enter when:** new stakeholders appear, signals shift mid-engagement, a meeting felt off but you can't say why, or it's been two weeks and the map hasn't been updated.
 


### PR DESCRIPTION
## Summary
- Public map uses consulting work names on the six FDE stages: Engage, Diagnose, Align, Deliver, Realize, Transfer. Slash commands and file ids are unchanged.
- Skill titles match (`Deliver the increment`, `Validate the solution`, `Transfer operations`). Same 30 skills. Greenfield, brownfield, and industry stay one map (overlays).
- Done is not claimed until they can reject the change on staging they operate. No generic coding packs added.

## Test plan
- [x] `node bin/check.js`
- [x] `npm test` (131)
- [ ] README command table: Work | Command | Stage | Principle
- [ ] `/brief` still Land, `/ship` still Ship


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/76" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->