### PR TITLE
feat: 3.20.0 - formulate the public map as a skill catalog

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.20.0 - 2026-08-29
+
+The public map is a skill catalog. Lifecycle, then catalog, then how it works.
+
+- README Commands: one command per stage, skills load automatically.
+- README catalog: 30 skills, not prompts. How Skills Work is route, evidence, confirm.
+- Public docs say skills, not methods. Slash commands and file ids unchanged.
+
 ## 3.19.0 - 2026-08-29
 
 The public map is consulting language on FDE stages. Same 30 skills. Same slash commands.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Skills encode the workflows, quality gates, and judgment Forward Deployed Engine
 
 ## Commands
 
-One map. Sprint or programme. Greenfield or brownfield. Any industry. Each command loads the same `@fde` skill. You never pick from 30 names.
+One command per stage. Skills load automatically.
+
+Six commands map to the embed. Each one loads `@fde`, which opens the skill for that moment: a thin brief pulls land, a wrong brief pulls discover, a Friday number pulls readout. Sprint or programme. Greenfield or brownfield. Any industry. You never pick from 30 names.
 
 | Work | Command | Stage | Principle |
 |------|---------|-------|-----------|
@@ -95,7 +97,9 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](doc
 
 ## All 30 Skills
 
-The commands above are the entry points. Under the hood, `@fde` activates these 30 skills, each a structured workflow with steps, an artifact, and a checkpoint. You never pick one by name. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
+The catalog. 30 skills spanning the embed. Not prompts - structured workflows with steps, an artifact, and a checkpoint. Type English or a slash command. `@fde` activates the right skill. You never pick one by name.
+
+Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 
 ### Land - Engage
 
@@ -174,7 +178,7 @@ One skill. One reference file per situation. One folder per client.
   skills/fde/SKILL.md          hosts load this one file
            │  routes. you never pick a skill by name
            ▼
-  references/land.md           one workflow, then stop
+  references/land.md           one skill, then stop
            │
            ▼
   fde CLI (local)              dates, gates, redacts. no network
@@ -183,11 +187,13 @@ One skill. One reference file per situation. One folder per client.
   ~/fde-engagements/<client>/.fde/
 ```
 
-- **Process, not prose.** Each reference is a workflow with an artifact and a checkpoint, not a tip sheet.
-- **Ground loop.** Name → characterise → prove where they live → go live → log. The workspace compiles; `@fde` stays.
-- **You confirm.** Nothing is written until you say so.
-- **Progressive disclosure.** `SKILL.md` is the entry point. One `references/*.md` loads when routed.
-- **Local CLI.** Writes and status cost zero model tokens. The AI coding agent runs it.
+**One skill routes.** Hosts load `@fde`. It reads the situation and opens one `references/*.md`. Slash commands and English both land here. You never pick a skill by name.
+
+**Evidence, not memory.** Promised → measured → accepted. A dated line in `.fde/`, or it did not happen. Nothing is done on vibes.
+
+**Confirm before write.** Local CLI: git and files, no network. `.fde/` on your laptop. The AI coding agent runs the command. You confirm. Then it is on the record.
+
+**Progressive disclosure.** `SKILL.md` is the entry. One skill file loads when routed. Writes and status cost zero model tokens.
 
 Change hosts, install `@fde` on the new one, bind if needed, keep talking. The record is not inside any vendor.
 
@@ -263,9 +269,9 @@ fdeops/
 
 ## Why FDEOps?
 
-AI coding agents are built for a repo, not for a client. They forget the sponsor, the promise, who can say yes, and whether anyone accepted the number. Monday morning they start from the ticket again.
+AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
 
-FDEOps is what you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, their codebase, go-live, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
+FDEOps is the catalog you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, their codebase, go-live, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
 
 ---
 

--- a/adapters/LOCAL-LLM.md
+++ b/adapters/LOCAL-LLM.md
@@ -4,7 +4,7 @@ Use fdeops with **any local model** - Ollama, LM Studio, llama.cpp, vLLM, Open W
 
 ## Why it works
 
-fdeops is a SKILL.md file + markdown memory + a Node.js CLI. It calls no external API. The AI does the methodology; the CLI does the mechanics. Any model that can read a markdown system prompt can run fdeops.
+fdeops is a SKILL.md file + markdown memory + a Node.js CLI. It calls no external API. The AI does the skills; the CLI does the mechanics. Any model that can read a markdown system prompt can run fdeops.
 
 ## Setup
 
@@ -62,12 +62,12 @@ The model reads SKILL.md, routes to the right skill, and produces artifacts in y
 
 ## Model size recommendations
 
-The methodology is detailed (30 skills, routing logic, evidence format, memory contract). Larger models handle it better:
+The kit is detailed (30 skills, routing logic, evidence format, memory contract). Larger models handle it better:
 
 | Model class | Experience |
 |-------------|-----------|
 | **7-8B** (Llama 3.1 8B, Mistral 7B, Qwen 2.5 7B) | Handles individual skills (readout, log, land). May struggle with complex routing or multi-skill sessions. Good for the CLI-heavy workflow where you invoke skills explicitly. |
-| **13-34B** (Llama 3.1 13B, Mixtral 8x7B, Qwen 2.5 32B, DeepSeek-R1 32B) | Good across all domains. Routes correctly, follows memory contract, writes structured artifacts. Recommended minimum for full methodology use. |
+| **13-34B** (Llama 3.1 13B, Mixtral 8x7B, Qwen 2.5 32B, DeepSeek-R1 32B) | Good across all domains. Routes correctly, follows memory contract, writes structured artifacts. Recommended minimum for full use. |
 | **70B+** (Llama 3.1 405B, DeepSeek V3, Qwen 2.5 72B) | Full capability. Handles regulated overlays, switch-clients, board-memo pyramid, runbook handoff. |
 
 ## The CLI works without ANY model
@@ -105,6 +105,6 @@ ollama run my-fde-model --system "$(cat skills/fde/SKILL.md)"
 ## Tips for local models
 
 - **Context window matters.** SKILL.md + references can be large. Use a model with at least 8K context; 32K+ is ideal for loading skill references on demand.
-- **Temperature 0.2-0.4 works best.** The methodology is structured - lower temperature keeps routing accurate and artifacts consistent.
+- **Temperature 0.2-0.4 works best.** The skills are structured - lower temperature keeps routing accurate and artifacts consistent.
 - **Use the CLI for mechanics.** Don't ask the model to do what the CLI already does deterministically. Use `fde scan` for repo recon, `fde log` for memory writes, `fde receipts` for searching. Let the model handle judgment, routing, and artifact drafting.
-- **Explicit skill invocation.** If a smaller model struggles with routing, you can invoke skills directly: "@fde run the discover phase" or "@fde use hold-scope." The model skips routing and goes straight to the method.
+- **Explicit skill invocation.** If a smaller model struggles with routing, you can invoke skills directly: "@fde run the discover phase" or "@fde use hold-scope." The model skips routing and goes straight to the skill.

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -2,7 +2,7 @@
 
 **One brain, thin adapters.** fdeops has a single source of truth - the `@fde` skill at `skills/fde/SKILL.md` and the `fde` CLI. Each AI coding tool discovers it through a small pointer file in the place that tool already looks. No forked logic, no five copies to maintain - every adapter says the same thing: *route via `@fde`, read/write `.fde/` memory, talk like a peer, never touch what isn't yours.*
 
-**Switching tools:** the fieldbook does not live in the agent. It lives at `~/fde-engagements/<client>/.fde/`. Point a new tool at a bound workspace, drop adapters (or install the skill/plugin for that tool), and the same client record opens. Auto session hooks are Claude Code-first; elsewhere load via `@fde` / `fde resume`. See [README § How it works](../README.md#how-it-works).
+**Switching tools:** the fieldbook does not live in the agent. It lives at `~/fde-engagements/<client>/.fde/`. Point a new tool at a bound workspace, drop adapters (or install the skill/plugin for that tool), and the same client record opens. Auto session hooks are Claude Code-first; elsewhere load via `@fde` / `fde resume`. See [README § How Skills Work](../README.md#how-skills-work).
 
 ## What goes where
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -57,7 +57,7 @@ for (const dir of fs.readdirSync(path.join(root, 'skills'))) {
 ok('skills structure')
 
 if (fs.existsSync(path.join(root, 'skills', 'fde', 'archive'))) {
-  fail('skills/fde/archive must not exist - unrouted methods are dead code')
+  fail('skills/fde/archive must not exist - unrouted skills are dead code')
 } else ok('no archived skill dump')
 
 // v3: one skill + phase references (progressive disclosure)
@@ -164,7 +164,7 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
     documentedRows++
     documented.add(m[1])
     // A link nobody followed is the same unverifiable claim this gate exists for:
-    // the target must exist, and it must be the method the text names.
+    // the target must exist, and it must be the skill the text names.
     if (m[2] !== `${m[1]}.md`) {
       fail(`docs/skills-reference.md links [${m[1]}] at references/${m[2]}`)
     } else if (!fs.existsSync(path.join(root, 'skills', 'fde', 'references', m[2]))) {
@@ -172,13 +172,13 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
     }
   }
   if (documented.size !== documentedRows) {
-    fail(`docs/skills-reference.md lists ${documentedRows} method rows for ${documented.size} methods - a duplicate row inflates the count`)
+    fail(`docs/skills-reference.md lists ${documentedRows} skill rows for ${documented.size} skills - a duplicate row inflates the count`)
   }
   const undocumented = [...routed].filter(name => !documented.has(name))
   if (undocumented.length) {
     fail(`SKILL.md routes skill(s) missing from docs/skills-reference.md: ${undocumented.join(', ')}`)
   }
-  // and the other direction: a documented method nothing routes to is a method
+  // and the other direction: a documented skill nothing routes to is a skill
   // the agent can never reach, advertised anyway.
   const unrouted = [...documented].filter(name => !routed.has(name))
   if (unrouted.length) {
@@ -187,7 +187,7 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
   for (const rel of ['docs/skills.md', 'docs/skills-reference.md']) {
     const body = read(rel)
     // `-` is a word boundary, so \bscore\b matches inside `score-use-cases`:
-    // a method could disappear from the docs behind a hyphenated sibling.
+    // a skill could disappear from the docs behind a hyphenated sibling.
     const absent = [...documented].filter(name => !new RegExp(`(?<![\\w-])${name}(?![\\w-])`).test(body))
     if (absent.length) fail(`${rel} does not list skill(s): ${absent.join(', ')}`)
     const claims = [...body.matchAll(/(\d+)\s+skills/g)].map(m => Number(m[1]))
@@ -201,16 +201,16 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
 
   const refDir = path.join(root, 'skills', 'fde', 'references')
   const extra = fs.readdirSync(refDir).filter(f => f.endsWith('.md') && !mentioned.includes(f))
-  if (extra.length) fail(`unrouted reference file(s) - dead method: ${extra.join(', ')}`)
+  if (extra.length) fail(`unrouted reference file(s) - dead skill: ${extra.join(', ')}`)
   else ok('no unrouted reference files')
 
-  // The on-site change loop lives in ship.md. A sibling method is a split.
+  // The on-site change loop lives in ship.md. A sibling skill is a split.
   for (const dead of ['small-prs.md', 'thin-slices.md', 'implement.md']) {
     if (fs.existsSync(path.join(refDir, dead))) {
       fail(`${dead} must not exist - that craft lives in ship.md`)
     }
   }
-  ok('ship is one method (no implement / small-prs / thin-slices sibling)')
+  ok('ship is one skill (no implement / small-prs / thin-slices sibling)')
 
   if (/^### Prove\b/m.test(read('skills/fde/SKILL.md'))) {
     fail('SKILL.md must not use Prove as a stage heading - the public stage is Outcome')
@@ -355,6 +355,18 @@ for (const rx of derivativeFraming) {
 }
 if (/docs\/internal|PMF_360/i.test(readme)) {
   fail('README must not link docs/internal or PMF_360')
+}
+if (!/One command per stage/.test(readme) || !/Skills load automatically/.test(readme)) {
+  fail('README must formulate Commands as: one command per stage, skills load automatically')
+}
+if (!/Not prompts/.test(readme)) {
+  fail('README catalog must say skills are not prompts')
+}
+if (/\b(30|31|37)\s+methods\b|\broutes methods\b|\bphase methods\b|\bfield methods\b|\bengagement methods\b/.test(readme)) {
+  fail('README must call the catalog skills, not methods')
+}
+if (/\broutes methods\b|\bphase methods\b|\bengagement methods\b/.test(usage)) {
+  fail('docs/USAGE.md must call them skills, not methods')
 }
 ok('README tone')
 

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -40,7 +40,7 @@ Portfolio: tell `@fde` “show my portfolio” - it reads every engagement folde
 | No code access yet | Land + discover; fill `brief.md`, `stakeholders.md` |
 | Extra files forbidden in workspace | Notes only under `~/fde-engagements/` - the registry binding lives outside the workspace, so nothing is added to their tree |
 | Can't run `fde resume --init` in an environment | Set `FDEOPS_ENGAGEMENT=...` (env var or one line in an allowed `CLAUDE.md`) as the override |
-| Taking over from someone else | Tell `@fde` you're taking over - it runs the audit method and writes ground truth into your `.fde/` |
+| Taking over from someone else | Tell `@fde` you're taking over - it runs audit and writes ground truth into your `.fde/` |
 | Trust problem vs outage | Say which in the `@fde` message |
 
 ## Maintainer

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,10 +1,10 @@
 # fdeops usage guide
 
-**What it is:** the engagement layer for **you** (human FDE) + your **AI coding agent** - `@fde` routes methods; `.fde/` holds client-scoped memory on your machine.
+**What it is:** the engagement layer for **you** (human FDE) + your **AI coding agent** - `@fde` routes skills; `.fde/` holds client-scoped memory on your machine.
 
 **Terminology:** [README § Who this is for](../README.md#who-this-is-for) - **"agent" = AI software, not a human.**
 
-**Start here:** [README](../README.md) (command map → 30-second install → one chat).
+**Start here:** [README](../README.md) - Commands (lifecycle) → All 30 Skills (catalog) → How Skills Work.
 
 <p align="center"><img alt="A recorded fdeops session: kickoff notes routed into dated memory after you confirm" src="../media/session.gif" width="900" /></p>
 
@@ -22,7 +22,7 @@ Day-to-day reference below.
 4. Optional recon, zero config: `npx fdeops scan` in a repo
 5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what's the outcome)
 
-You do not read the phase methods. **`@fde` routes the AI and loads the right one.**
+You do not pick a skill. **`@fde` routes the AI and loads the right one.**
 
 ---
 
@@ -197,7 +197,7 @@ The rules that keep it from becoming a second memory:
 
 ## What fdeops does not do
 
-The skills are methods refined from real engagements, not autonomy - they tell you what to check, not what to decide. Concretely, fdeops does not:
+The skills are refined from real engagements, not autonomy - they tell you what to check, not what to decide. Concretely, fdeops does not:
 
 - Replace **you** in meetings or politics
 - Grant repo access or stakeholder buy-in
@@ -212,4 +212,4 @@ The skills are methods refined from real engagements, not autonomy - they tell y
 - [OPERATIONS.md](./OPERATIONS.md) - operating rules
 - [schema.md](./schema.md) - `.fde/` files
 - [skills.md](./skills.md) - the skills matrix + overlays
-- [skills-reference.md](./skills-reference.md) - the phase methods
+- [skills-reference.md](./skills-reference.md) - the 30 skills

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -1,8 +1,8 @@
-# fdeops Reference - one skill, 30 skills across 6 stages
+# The catalog - one skill, 30 skills across 6 stages
 
-v3 ships **one skill**: `@fde` ([skills/fde/SKILL.md](../skills/fde/SKILL.md)). You describe the situation; it routes to a phase and follows that phase's skill from [skills/fde/references/](../skills/fde/references/). Engagement memory lives in `~/fde-engagements/<name>/.fde/` (one folder per customer).
+v3 ships **one skill**: `@fde` ([skills/fde/SKILL.md](../skills/fde/SKILL.md)). You describe the situation; it routes to a stage and follows that skill from [skills/fde/references/](../skills/fde/references/). Engagement memory lives in `~/fde-engagements/<name>/.fde/` (one folder per customer).
 
-Each reference is a **skill, not advice**: the thinking the agent does, the artifact it drafts, and the checkpoint with the human FDE. The **Use when** column below is what the router actually matches on - the phrases in `skills/fde/SKILL.md` that send you to that skill, not a paraphrase.
+Each reference is a **skill, not a prompt**: the thinking the agent does, the artifact it drafts, and the checkpoint with the human FDE. The **Use when** column below is what the router actually matches on - the phrases in `skills/fde/SKILL.md` that send you to that skill, not a paraphrase.
 
 ---
 
@@ -92,7 +92,7 @@ Each reference is a **skill, not advice**: the thinking the agent does, the arti
 
 The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above. POC, the change on their repo, proof on their staging, go-live, and eval stay on `@fde` - they are not a side pack.
 
-| Phase | Enter when | Method highlights | Writes |
+| Phase | Enter when | What it does | Writes |
 |-------|-----------|-------------------|--------|
 | [land](../skills/fde/references/land.md) | New customer, first meeting | Interrogates the brief for what's missing; coaches the sponsor conversation; maps stakeholders and sacred data | `brief.md` `success.md` `stakeholders.md` `trust-profile.md` |
 | [discover](../skills/fde/references/discover.md) | Brief feels wrong, real problem unclear | Runs churn/test-gap/"temporary"-archaeology/AI-component scans; hunts the workaround; scores use cases | `reality.md` `terrain.md` |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,6 +1,8 @@
-# One skill, three layers
+# The catalog
 
-One skill (`@fde`) routes by situation - you never pick a skill by name. Three layers:
+One skill (`@fde`) routes. You never pick a skill by name. 30 skills across 6 stages. Not prompts - each skill is a workflow with an artifact and a checkpoint.
+
+Three layers:
 
 1. **Daily** - prep, debrief, receipts, status, triage / doctor
 2. **Engagement** - brief wrong, they went quiet, when did we agree, what's the outcome - plus the skills below
@@ -19,7 +21,7 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 | **Outcome** (Realize) | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
 | **Close** (Transfer) | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 
-Each skill is a workflow, not advice: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.
+Each skill is a workflow, not a prompt: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.
 
 **Field judgment (blended into skills, not a separate pack):** land/discover use **brief interrogation** when the brief is thin; `@fde` enforces **anti-invention gates**; ship/red-team run a **pre-blast challenge** before irreversible moves.
 

--- a/evals/skill-routing/README.md
+++ b/evals/skill-routing/README.md
@@ -5,7 +5,7 @@ Cheap eval for `@fde` (inspired by “don’t ship skills without evals”).
 | Layer | What it proves |
 |-------|----------------|
 | `node evals/skill-routing/check.js` | Happy prompts still have a documented `fde …` route in `SKILL.md` |
-| Live trial (you + agent) | Negatives don’t pull engagement methods; happies run the right CLI |
+| Live trial (you + agent) | Negatives don’t pull engagement skills; happies run the right CLI |
 
 CLI unit tests (`npm test`) remain the product bar. This only grades the skill.
 

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.19.0",
+  "version": "3.20.0",
   "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -77,7 +77,7 @@ Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on in
 
 ## The memory contract
 
-1. **On entry:** `fde resume` only. Pull other `.fde/` files when the method needs them.
+1. **On entry:** `fde resume` only. Pull other `.fde/` files when the skill needs them.
 2. **Deliverable = memory.** The work *is* the `.fde/` file. The reference names which one.
 3. **Evidence.** Every claim has a source. Traceable beats plausible.
 4. **No invented facts.** People, quotes, meetings, numbers: they said it or the repo shows it. Else `unknown - ask: <question>`.
@@ -107,7 +107,7 @@ CLI is local (`git` + files, no network). You see their code only when they poin
 
 Direct. Their words. No "Certainly." Playback 2-4 lines, then act. One question only when a missing fact changes the next move.
 
-New embed: sprint / standard / programme changes depth, not which methods exist. Before first code: safe place to break things, plus AI-code policy. Before go-live: who needs to know, what's the rollback. Before a sponsor artifact: as-is or gut-check first.
+New embed: sprint / standard / programme changes depth, not which skills exist. Before first code: safe place to break things, plus AI-code policy. Before go-live: who needs to know, what's the rollback. Before a sponsor artifact: as-is or gut-check first.
 
 Muddy signal: name it ("discover or rescue - leaning X"). Never a phase-picker interview. Default: land if new, audit if takeover.
 

--- a/skills/fde/references/ai.md
+++ b/skills/fde/references/ai.md
@@ -38,7 +38,7 @@ Write model selection rationale to `decisions.md`. Include: models tested, test 
 
 ## Engagement eval pack (before AI ships)
 
-When any slice touches a model, embeddings, RAG, or an agent: create or update `.fde/evals.md` **before** ship. Full method: `references/eval-pack.md`. This is the engagement-local test set - not unit tests.
+When any slice touches a model, embeddings, RAG, or an agent: create or update `.fde/evals.md` **before** ship. Full skill: `references/eval-pack.md`. This is the engagement-local test set - not unit tests.
 
 **Minimum pack (do not grow until the minimum exists):**
 1. **Component + quality bar** - one sentence each; kill switch / fallback named.

--- a/skills/fde/references/audit.md
+++ b/skills/fde/references/audit.md
@@ -9,7 +9,7 @@
 Before forming any opinion:
 
 1. **Inherit the paper.** Any previous `.fde/`, docs, README claims, ADRs, ticket history the FDE can export. Read it all - the previous FDE's decisions are evidence, not verdicts.
-2. **Run the discover scans** (see `discover.md` method part 1: churn, test gaps, "temporary" grep, AI components). On a takeover, add:
+2. **Run the discover scans** (see `discover.md` part 1: churn, test gaps, "temporary" grep, AI components). On a takeover, add:
 ```bash
 git log --format="%an" | sort | uniq -c | sort -rn | head   # who actually built this
 git log --since="60 days ago" --format="%ad %s" --date=short | head -20  # what was happening when they left

--- a/skills/fde/references/dashboard.md
+++ b/skills/fde/references/dashboard.md
@@ -8,7 +8,7 @@ The visual artifact is rendered by code, not by you. `fde dashboard` reads every
 
 ## Method (you do this work)
 
-0. **First move: `fde status`** - instant heuristic triage (trust-first ordering) across every engagement. Use it as the index; then deep-read only the folders that are red/amber or that the FDE asks about, and apply the full card method below.
+0. **First move: `fde status`** - instant heuristic triage (trust-first ordering) across every engagement. Use it as the index; then deep-read only the folders that are red/amber or that the FDE asks about, and apply the full card below.
 1. **Find the engagements:** `~/fde-engagements/*/.fde/` (primary) · workspace `./.fde/` if present · paths the FDE names. Read each folder **separately** - never merge two customers.
 2. **Per engagement, read the card the way a human would:**
    - Name, phase, week

--- a/skills/fde/references/encode-pattern.md
+++ b/skills/fde/references/encode-pattern.md
@@ -48,7 +48,7 @@ The difference between a 5-year FDE and a 15-year FDE is not talent - it's encod
 | **Repeatable?** | Applies to a class of situations, not just this one | Only worked because of a unique circumstance |
 | **Falsifiable?** | You can tell when the pattern is working or not | No way to measure whether applying it helped |
 
-**4. Classify by stage.** Patterns sort into the same stages as the methods:
+**4. Classify by stage.** Patterns sort into the same stages as the skills:
 
 | Stage | Pattern type | Example |
 |--------|-------------|---------|

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -12,7 +12,7 @@ Do not ask them to pick a mode. Name where you are, then start at the matching s
 
 If going live, opening question: **has anyone actually *run* the rollback, or is it still a slide?** If only planned, that's today's work - say so plainly.
 
-A same-day throwaway that kills an assumption is `poc`. This method is the real change on a repo they will own, then production.
+A same-day throwaway that kills an assumption is `poc`. This skill is the real change on a repo they will own, then production.
 
 ## Field (name it once, then the same loop)
 


### PR DESCRIPTION
## Summary
- README is now lifecycle → catalog → how it works: one command per stage (skills load automatically), 30 skills that are not prompts, then route / evidence / confirm.
- Public docs say **skills**, not methods. Slash commands, file ids, and the six stages are unchanged.
- `check.js` fails if the README advertises methods as the catalog unit.

## Test plan
- [x] `node bin/check.js`
- [x] `npm test` (131 pass)
- [ ] README on GitHub: Commands, All 30 Skills, How Skills Work read as a skill catalog
- [ ] No `/spec` `/build` `/test` stages added; no derivative framing


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/77" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->