### PR TITLE
Fix image tag for fdeops in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent can run the embed end-to-end: discovery, POC, their codebase (greenfield or brownfield), go-live, eval, signed outcome. The workspace still compiles and commits. `@fde` does not leave.
 
-<img width="1536" height="1024" alt="fdeops" src="https://github.com/user-attachments/assets/f861618c-0caf-4a19-8e1b-7af6d4d5f8f6" />
+![Uploading fdeops.png…]()
 
 ---
 


### PR DESCRIPTION
Updated image tag for fdeops in README.

## Why

<!-- Open an issue first unless this is a one-line typo. Skill and doc changes are reviewed by the maintainer only. -->

## What changed

## Checks

- [ ] `npm run check` passes
- [ ] No client names, `.fde/` exports, credentials, or screenshots with real people

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/79" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->