### PR TITLE
docs: tighten the README hero to the embed job

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Forward deployed engineering skills for AI coding agents.**
 
-Skills encode the workflows, quality gates, and judgment Forward Deployed Engineers use on someone else's site. Packaged so an AI coding agent can run the embed end-to-end: discovery, POC, their codebase (greenfield or brownfield), go-live, eval, signed outcome. The workspace still compiles and commits. `@fde` does not leave.
+You embed on someone else's site with an AI coding agent. One `@fde` skill runs the work from the brief to a signed outcome: discovery, POC, their codebase (greenfield or brownfield), go-live, eval. You confirm; then it is on the record. The workspace still compiles and commits. `@fde` does not leave.
 
 <img width="1536" height="1024" alt="fdeops" src="https://github.com/user-attachments/assets/2bcb8739-55ee-445d-8a1a-8b38433b7b58" />
 


### PR DESCRIPTION
## Summary
- README opener now says who, where, and what `@fde` does, instead of “encode the workflows.”
- One-liner unchanged. Distinctive closer unchanged.

## Test plan
- [x] `node bin/check.js`
- [ ] Read the first three lines on GitHub


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/80" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->