### PR TITLE
docs: staging then live, hallway English on the command table

### DIFF
--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose. Treat the brief as a hypothesis.
+description: Diagnose. Check the brief is the real job.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,5 +1,5 @@
 ---
-description: Align. Sequence the work. Work backwards from done.
+description: Align. Sequence the work. Work backwards from success.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Six commands map to the embed. Each one loads `@fde`, which opens the skill for 
 | Work | Command | Stage | Principle |
 |------|---------|-------|-----------|
 | Engage | `/brief` | Land | Name who signs done |
-| Diagnose | `/discover` | Discover | Treat the brief as a hypothesis |
-| Align | `/plan` | Plan | Work backwards from done |
-| Deliver | `/ship` | Ship | One visible change, then go live |
+| Diagnose | `/discover` | Discover | Check the brief is the real job |
+| Align | `/plan` | Plan | Work backwards from success |
+| Deliver | `/ship` | Ship | Seen on their staging, then live |
 | Realize | `/outcome` | Outcome | Promised, measured, accepted |
 | Transfer | `/close` | Close | They operate it without you |
 
@@ -310,11 +310,11 @@ Local only - `git` + files, no network, no telemetry. Plain markdown. The model 
 
 ## Principles
 
-- **One map** - any scale, greenfield or brownfield, any industry. Overlays carry the vertical
-- **The artifact is the memory** - producing the work and recording it are one action
+- **Same six stages** - any scale, new or existing, any industry. Extra notes for your sector
+- **The write-up is the record** - doing the work and writing it down are one action
 - **Ground loop** - name the change, characterise their code, prove it on their staging, go live, log the outcome
 - **Skills, not autonomy** - the kit says what to check; judgment stays yours
-- **Brief is a hypothesis** - discover before building the wrong thing
+- **Check the brief is the real job** - discover before building the wrong thing
 - **Evidence on every claim** - these files get defended in the room
 - **One customer, one folder** - context never bleeds
 

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -40,7 +40,7 @@ Each reference is a **skill, not a prompt**: the thinking the agent does, the ar
 | [pick-three](../skills/fde/references/pick-three.md) | Prioritize three | 20 things are "urgent," need to pick the 3 that matter |
 
 ### Ship
-*Deliver. On their codebase (greenfield or brownfield), then go-live.*
+*Deliver. On their codebase, their staging, then go-live.*
 
 | Skill | What it does | Use when |
 |-------|-------------|----------|
@@ -88,9 +88,9 @@ Each reference is a **skill, not a prompt**: the thinking the agent does, the ar
 
 ---
 
-## Engagement phases (quick reference)
+## Core path (quick reference)
 
-The 9 phases most engagements actually run through, with what gets written where. This is a shorter cut through the table above. POC, the change on their repo, proof on their staging, go-live, and eval stay on `@fde` - they are not a side pack.
+The skills most engagements actually run through, with what gets written where. This is a shorter cut through the table above. POC, the change on their repo, proof on their staging, go-live, and eval stay on `@fde` - they are not a side pack.
 
 | Phase | Enter when | What it does | Writes |
 |-------|-----------|-------------------|--------|

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -17,7 +17,7 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 | **Land** (Engage) | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
 | **Discover** (Diagnose) | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
 | **Plan** (Align) | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
-| **Ship** (Deliver) | ship, what-breaks, rescue, review, rollback | One visible change on their repo, then go-live |
+| **Ship** (Deliver) | ship, what-breaks, rescue, review, rollback | Visible on their staging, then go-live |
 | **Outcome** (Realize) | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
 | **Close** (Transfer) | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 


### PR DESCRIPTION
## Summary
- Ship principle is now **Seen on their staging, then live** (three beats, not one PR to prod).
- Discover: **Check the brief is the real job.** Plan: **Work backwards from success.**
- Dropped “9 phases” and two jargon Principles bullets. Slash commands `/discover` `/plan` match.
- Kept: who signs done, promised/measured/accepted, they operate it without you. No stage or CLI changes.

## Test plan
- [x] `node bin/check.js`
- [ ] README Commands table reads as field-real


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/82" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->