### PR TITLE
feat: 3.21.0 - hallway copy and harder field gates

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
-  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill is the client record - brief wrong, they went quiet, when did we agree, what's the outcome - and the dated memory (sponsor, promise, decision, acceptance) lands in local .fde/ files as you confirm judgment. For Forward Deployed Engineers running several clients at once.",
-  "version": "3.20.0",
+  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
+  "version": "3.21.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/brief.md
+++ b/.claude/commands/brief.md
@@ -1,5 +1,5 @@
 ---
-description: Engage. Interrogate the brief. Name who signs done.
+description: Name who signs done. First meeting, new client.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **land**.

--- a/.claude/commands/close.md
+++ b/.claude/commands/close.md
@@ -1,5 +1,5 @@
 ---
-description: Transfer operations. They operate it without you.
+description: They operate it without you.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **close**.

--- a/.claude/commands/discover.md
+++ b/.claude/commands/discover.md
@@ -1,5 +1,5 @@
 ---
-description: Diagnose. Check the brief is the real job.
+description: Check the brief is the real job.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **discover**.

--- a/.claude/commands/outcome.md
+++ b/.claude/commands/outcome.md
@@ -1,5 +1,5 @@
 ---
-description: Realize. Promised, measured, accepted.
+description: Promised, measured, accepted. A number nobody signed is claimed, not delivered.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **outcome**.

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,12 +1,12 @@
 ---
-description: Align. Sequence the work. Work backwards from success.
+description: Sequence from done, not from the ticket.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **plan**.
 
 If `fde resume` shows NO ENGAGEMENT: ask "What should we call this client?" once, then **you** run `fde resume --init`. Never tell the human to type the CLI.
 
-Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/plan.md` and follow it. Sequence backwards from done, one change they can see at a time, who signs. Each Now item names `Kill if`.
+Run `fde resume` (fallback: `npx --yes fdeops resume`). Read `references/plan.md` and follow it. Sequence from done, not from the ticket. Who signs. Each Now item names `Kill if`.
 
 Do not invent a plan the record cannot support. Missing success criteria → `unknown - ask: <question>`.
 

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -1,5 +1,5 @@
 ---
-description: Deliver the increment. Then go live with a rollback you have run.
+description: Seen on their staging, then live. Rollback you have run.
 ---
 
 Load `@fde` (`skills/fde/SKILL.md`). Stage: **ship**.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ This repository **is** fdeops - the engagement record for Forward Deployed Engin
 
 ## If you are helping use fdeops in an engagement
 
-Route via **`@fde`** - read `skills/fde/SKILL.md` (the single source of truth), pick the phase, do the work, and write `.fde/` memory. Never ask the human to pick a skill. Other tools get the same behavior through thin pointer files in [`adapters/`](adapters/README.md).
+Route via **`@fde`** - read `skills/fde/SKILL.md` (the single source of truth), route to one `references/*.md`, do the work, and write `.fde/` memory. Never ask the human to pick a skill. Other tools get the same behavior through thin pointer files in [`adapters/`](adapters/README.md).
 
 ## If you are contributing to this repository
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 3.21.0 - 2026-09-01
+
+The public map is hallway English. Ship and review got harder field gates. Same six stages. Same 30 skills.
+
+- README hero: the client work around the code. Commands table: What you're doing | Type this | Remember. Dual consulting verbs are gone from the front door.
+- Quick Start before Commands. First hour: folder exists, one confirmed write, then `/brief`. Do not start coding.
+- Discover: data estate always; the pipe; their words in `terrain.md`.
+- Ship: run their command in this turn or you cannot write that it passed. Monday-shaped staging. No unsupervised loop on their production.
+- Review: their PR comments are to check, not to obey.
+- Readout: old path still live = claimed. Runbook: floor drill, do not document-and-leave. Eval-pack: side effect without a named human on their side is NO-SHIP.
+
 ## 3.20.0 - 2026-08-29
 
 The public map is a skill catalog. Lifecycle, then catalog, then how it works.

--- a/README.md
+++ b/README.md
@@ -1,89 +1,61 @@
 # FDEOps
 
-**Forward deployed engineering skills for AI coding agents.**
+**The client work around the code the AI coding agent writes in their repo.**
 
-You work at a customer. The AI coding agent writes code in their repo. `@fde` is the one skill for the client work around that code: the brief, who can say yes, what went live, whether they signed off. You confirm each write. The files live on your laptop. Their project still compiles. `@fde` does not leave when you start coding.
+You're on site. The AI coding agent writes code in their repo. This is everything around that code that still gets you fired if you skip it: the brief, who can say yes, their staging then live, whether they signed off, whether they can run it after you leave. Notes stay on your laptop. Their repo stays theirs. You confirm before anything is written down.
 
 <img width="1536" height="1024" alt="fdeops" src="https://github.com/user-attachments/assets/2bcb8739-55ee-445d-8a1a-8b38433b7b58" />
 
 ---
 
-## Commands
-
-One command per stage. Skills load automatically.
-
-Six commands map to the embed. Each one loads `@fde`, which opens the skill for that moment: a thin brief pulls land, a wrong brief pulls discover, a Friday number pulls readout. Sprint or programme. Greenfield or brownfield. Any industry. You never pick from 30 names.
-
-| Work | Command | Stage | Principle |
-|------|---------|-------|-----------|
-| Engage | `/brief` | Land | Name who signs done |
-| Diagnose | `/discover` | Discover | Check the brief is the real job |
-| Align | `/plan` | Plan | Work backwards from success |
-| Deliver | `/ship` | Ship | Seen on their staging, then live |
-| Realize | `/outcome` | Outcome | Promised, measured, accepted |
-| Transfer | `/close` | Close | They operate it without you |
-
-Also:
-
-| Work | Command | Principle |
-|------|---------|-----------|
-| Diagnose trust | `/trust` | Process gap, or they stopped trusting you |
-| Find the receipt | `/receipts` | A dated line, or it did not happen |
-| Capture the meeting | `/debrief` | Notes into the record |
-| Prepare the meeting | `/prep` | One page from the record |
-| Report the outcome | `/readout` | Promised, measured, accepted |
-
-Skills also activate on English: naming a client, running a POC, changing their checkout, going live, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. Bound client work cannot.
-
----
-
 ## Quick Start
 
-```bash
-npx skills add suboss87/fdeops --skill fde
-```
-
-Then one chat. Name the client. The AI coding agent binds.
-
-```text
-@fde this is Acme
-```
-
-Paste kickoff notes in the same thread. `@fde` routes; you confirm judgment. Same folder every time: `~/fde-engagements/<client>/.fde/`. Workflow: [docs/USAGE.md](docs/USAGE.md).
-
-<details>
-<summary><b>Claude Code (recommended)</b></summary>
+**Claude Code**
 
 ```text
 /plugin marketplace add suboss87/fdeops
 /plugin install fdeops@fdeops
 ```
 
-Hooks load where you left off. Slash commands match the map above.
-
-</details>
-
-<details>
-<summary><b>Cursor</b></summary>
+**Cursor and other agents**
 
 ```bash
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Or `npx fdeops adapters .`. See [adapters/](adapters/README.md).
+Then one chat. Name the client. That's you on this job.
+
+```text
+@fde this is Acme
+```
+
+That creates `~/fde-engagements/acme/.fde/` on your laptop. Paste kickoff notes in the same thread. It picks what to check. You still decide.
+
+**You are done with the first hour when** that folder exists and you have confirmed one write. Next: `/brief`. Do not start coding yet.
+
+Workflow after that: [docs/USAGE.md](docs/USAGE.md).
+
+<details>
+<summary><b>Cursor: pointer in the client repo</b></summary>
+
+After the skill install, in the **client repo** you open in Cursor (pointer, not a second skill pack):
+
+```bash
+npx fdeops adapters .
+```
+
+Adapters do not replace the skill install. See [adapters/](adapters/README.md).
 
 </details>
 
 <details>
-<summary><b>Other agents</b></summary>
+<summary><b>Air-gap, PATH, override</b></summary>
 
 ```bash
-npx skills add suboss87/fdeops --skill fde
+git clone https://github.com/suboss87/fdeops.git && node bin/install.js
 ```
 
-Gemini, Copilot, Codex, local LLMs: [adapters/](adapters/README.md). Air-gapped: `git clone https://github.com/suboss87/fdeops.git && node bin/install.js`.
-
-Fallback if the agent cannot bind:
+Fallback if the agent cannot create the folder:
 
 ```bash
 npx fdeops resume --init acme   # ~/fde-engagements/acme + bind this checkout
@@ -95,90 +67,37 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](doc
 
 ---
 
-## All 30 Skills
+## Commands
 
-The catalog. 30 skills spanning the embed. Not prompts - structured workflows with steps, an artifact, and a checkpoint. Type English or a slash command. `@fde` activates the right skill. You never pick one by name.
+One command per stage. Skills load automatically.
 
-Full detail: [docs/skills-reference.md](docs/skills-reference.md).
+Six commands. That's the job. Same six stages every time: Land, Discover, Plan, Ship, Outcome, Close.
 
-### Land - Engage
+| What you're doing | Type this | Remember |
+|-------------------|-----------|----------|
+| First days. Get the brief. Name who signs. | `/brief` | Who signs |
+| The brief they handed you may not be the real job. | `/discover` | Brief vs real job |
+| Sequence from done, not from the ticket. | `/plan` | Back from done |
+| Prove it on their staging, then go live. | `/ship` | Their staging then live |
+| What you promised, what you measured, who accepted. | `/outcome` | Promised, measured, accepted |
+| Hand it over. They run it without you. | `/close` | They run it |
 
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [land](skills/fde/references/land.md) | Interrogate the brief | New client, first meeting, just got the brief |
-| [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
-| [who-decides](skills/fde/references/who-decides.md) | Map decision rights | Need to know who matters |
-| [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
-| [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
+After your first loop, same `@fde`: `/debrief` (notes into the record), `/prep` (one page before you walk in), `/trust` (process gap, or they stopped trusting you), `/receipts` (a dated line, or it did not happen). `/readout` is the Friday page for the sponsor; it is not a seventh stage.
 
-### Discover - Diagnose
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [discover](skills/fde/references/discover.md) | Frame the problem | Brief feels wrong, shadow processes |
-| [test-assumptions](skills/fde/references/test-assumptions.md) | Test assumptions | Brief feels too neat |
-| [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
-| [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
-
-### Plan - Align
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
-| [business-case](skills/fde/references/business-case.md) | Build the business case | Defend budget or timeline |
-| [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
-| [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
-
-### Ship - Deliver
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [ship](skills/fde/references/ship.md) | Deliver the increment | Building, updating, or going live |
-| [what-breaks](skills/fde/references/what-breaks.md) | Assess impact | Touching shared infrastructure |
-| [rescue](skills/fde/references/rescue.md) | Resolve the incident | Down, or they went quiet |
-| [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
-| [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
-
-### Outcome - Realize
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [readout](skills/fde/references/readout.md) | Report the outcome | Friday, sponsor update |
-| [demo-prep](skills/fde/references/demo-prep.md) | Prepare the demo | Demo or exec walkthrough |
-| [debrief](skills/fde/references/debrief.md) | Capture the meeting | Just left a meeting |
-| [board-memo](skills/fde/references/board-memo.md) | Brief the board | Justify continued investment |
-| [dashboard](skills/fde/references/dashboard.md) | View the portfolio | All my customers |
-| [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
-| [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
-
-### Close - Transfer
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [close](skills/fde/references/close.md) | Transfer operations | Wrapping up |
-| [runbook](skills/fde/references/runbook.md) | Write the runbook | They must operate without you |
-| [switch-clients](skills/fde/references/switch-clients.md) | Switch engagements | 2+ clients |
-| [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
-| [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
-
-Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) · [eval-pack](skills/fde/references/eval-pack.md)
-
-Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mcp/recipes/)
+You can also just say it in the chat: naming a client, a POC, changing their checkout, going live, asking what was agreed. A typo in a repo that isn't a client job can skip this. Named client, POC, go-live cannot.
 
 ---
 
 ## How Skills Work
 
-One skill. One reference file per situation. One folder per client.
+One `@fde`. One file per situation. One folder per client.
 
 ```
-  /brief   or   "@fde this is Acme"
-           │
-           ▼
-  skills/fde/SKILL.md          hosts load this one file
+  "@fde this is Acme"          creates ~/fde-engagements/<client>/.fde/
+  /brief  or  English          the AI coding agent loads skills/fde/SKILL.md
            │  routes. you never pick a skill by name
            ▼
-  references/land.md           one skill, then stop
+  references/<one>.md          one skill, then stop
            │
            ▼
   fde CLI (local)              dates, gates, redacts. no network
@@ -187,91 +106,13 @@ One skill. One reference file per situation. One folder per client.
   ~/fde-engagements/<client>/.fde/
 ```
 
-**One skill routes.** Hosts load `@fde`. It reads the situation and opens one `references/*.md`. Slash commands and English both land here. You never pick a skill by name.
+**A dated line, or it did not happen.** Promised → measured → accepted. If it is not in `.fde/`, it is not on the record.
 
-**Evidence, not memory.** Promised → measured → accepted. A dated line in `.fde/`, or it did not happen. Nothing is done on vibes.
+**Confirm, then it is written.** The CLI stays on your laptop: git and files, no network. The AI coding agent runs the command. You say yes. Then it is in the folder.
 
-**Confirm before write.** Local CLI: git and files, no network. `.fde/` on your laptop. The AI coding agent runs the command. You confirm. Then it is on the record.
+**The record is on your laptop.** Change hosts, install `@fde` on the new one, keep talking. The notes are not inside any vendor.
 
-**Progressive disclosure.** `SKILL.md` is the entry. One skill file loads when routed. Writes and status cost zero model tokens.
-
-Change hosts, install `@fde` on the new one, bind if needed, keep talking. The record is not inside any vendor.
-
----
-
-## Project Structure
-
-```
-fdeops/
-├── skills/fde/                            # the one skill hosts load
-│   ├── SKILL.md                           #   router
-│   └── references/                        #   30 skills + overlays (you never pick)
-│       ├── land.md                        #   Land
-│       ├── audit.md
-│       ├── who-decides.md
-│       ├── earn-trust.md
-│       ├── hold-scope.md
-│       ├── discover.md                    #   Discover
-│       ├── test-assumptions.md
-│       ├── score-use-cases.md
-│       ├── poc.md
-│       ├── plan.md                        #   Plan
-│       ├── business-case.md
-│       ├── three-options.md
-│       ├── pick-three.md
-│       ├── ship.md                        #   Ship
-│       ├── what-breaks.md
-│       ├── rescue.md
-│       ├── review.md
-│       ├── rollback.md
-│       ├── readout.md                      #   Outcome
-│       ├── demo-prep.md
-│       ├── debrief.md
-│       ├── board-memo.md
-│       ├── dashboard.md
-│       ├── ingest.md
-│       ├── connect.md
-│       ├── close.md                       #   Close
-│       ├── runbook.md
-│       ├── switch-clients.md
-│       ├── encode-pattern.md
-│       ├── red-team.md
-│       ├── ai.md                          #   overlays (on signal)
-│       ├── artifacts.md
-│       ├── eval-pack.md
-│       ├── fintech.md
-│       ├── healthcare.md
-│       └── gov.md
-├── .claude/commands/                      # slash commands (each loads @fde)
-│   ├── brief.md
-│   ├── discover.md
-│   ├── plan.md
-│   ├── ship.md
-│   ├── outcome.md
-│   ├── close.md
-│   ├── trust.md
-│   ├── receipts.md
-│   ├── debrief.md
-│   ├── prep.md
-│   └── readout.md
-├── .claude-plugin/                        # Claude Code marketplace
-├── bin/                                   # local CLI: git + files, no network
-├── hooks/                                 # session-start / session-stop / pre-compact
-├── adapters/                              # Cursor, Gemini, Copilot, Codex pointers
-├── templates/.fde/                        # memory files created on bind
-├── examples/                              # fictional walkthroughs
-├── mcp/                                   # optional ingest + source recipes
-├── evals/                                 # routing checks
-└── docs/                                  # usage, schema, install
-```
-
----
-
-## Why FDEOps?
-
-AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
-
-FDEOps is the catalog you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, their codebase, go-live, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
+One skill hosts load: `skills/fde/SKILL.md`. It opens one file in `skills/fde/references/` and stops. Slash commands live in `.claude/commands/`. The local CLI is `bin/fde.js` (git + files, no network). Layout for contributors: [docs/REPO_LAYOUT.md](docs/REPO_LAYOUT.md).
 
 ---
 
@@ -294,29 +135,111 @@ Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
 
 ## Who this is for
 
-You embed with a customer and an AI coding agent. Take this on the ground. Discovery through signed outcome lives in `@fde`. One `.fde/` per client so they do not blur.
+You sit with a customer's team. An AI coding agent writes in their repo. You need a record of the brief, who can say yes, what went live, and whether they signed off.
 
-If you only write code in your own repo with no client record to defend, you do not need this kit.
+If you ship your own company's product from HQ, with no customer team that has to run it after you leave, you do not need this kit.
 
 ---
 
 ## Your data stays yours
 
-Local only - `git` + files, no network, no telemetry. Plain markdown. The model sees client code only when you point the AI coding agent at it. `<private>` is redacted from CLI, dashboard, and hooks. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
+The **CLI** is local: git + files, no network, no telemetry. The **host model** sees `.fde/` the agent loads (usually a bounded `context.md`) and any client code you open. It must not see `<private>` blocks  - redacted from CLI, dashboard, and hooks; do not paste them or open them with file tools. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
 
 [PRIVACY.md](PRIVACY.md) · [SECURITY.md](SECURITY.md)
 
 ---
 
+## The rest of the kit
+
+The six commands above are what you type. Under the hood there are more checklists  - access, rollback, runbook, sponsor update  - and `@fde` opens one when the situation matches. You do not pick them by name.
+
+Thirty situations, grouped by stage. Not prompts - each one has steps, a file it writes, and a checkpoint with you. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
+
+### Land
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [land](skills/fde/references/land.md) | Interrogate the brief | New client, first meeting, just got the brief |
+| [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
+| [who-decides](skills/fde/references/who-decides.md) | Map decision rights | Need to know who matters |
+| [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
+| [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
+
+### Discover
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [discover](skills/fde/references/discover.md) | Frame the problem | Brief feels wrong, shadow processes |
+| [test-assumptions](skills/fde/references/test-assumptions.md) | Test assumptions | Brief feels too neat |
+| [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
+| [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
+
+### Plan
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
+| [business-case](skills/fde/references/business-case.md) | Build the business case | Defend budget or timeline |
+| [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
+| [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
+
+### Ship
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [ship](skills/fde/references/ship.md) | Deliver the increment | Building, updating, or going live |
+| [what-breaks](skills/fde/references/what-breaks.md) | Assess impact | Touching shared infrastructure |
+| [rescue](skills/fde/references/rescue.md) | Resolve the incident | Down, or they went quiet |
+| [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
+| [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
+
+### Outcome
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [readout](skills/fde/references/readout.md) | Report the outcome | Friday, sponsor update |
+| [demo-prep](skills/fde/references/demo-prep.md) | Prepare the demo | Demo or exec walkthrough |
+| [debrief](skills/fde/references/debrief.md) | Capture the meeting | Just left a meeting |
+| [board-memo](skills/fde/references/board-memo.md) | Brief the board | Justify continued investment |
+| [dashboard](skills/fde/references/dashboard.md) | View the portfolio | All my customers |
+| [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
+| [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
+
+### Close
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [close](skills/fde/references/close.md) | Transfer operations | Wrapping up |
+| [runbook](skills/fde/references/runbook.md) | Write the runbook | They must operate without you |
+| [switch-clients](skills/fde/references/switch-clients.md) | Switch engagements | 2+ clients |
+| [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
+| [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
+
+Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md). AI companion (not a sixth overlay): [eval-pack](skills/fde/references/eval-pack.md).
+
+Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mcp/recipes/)
+
+---
+
+## Why FDEOps?
+
+AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
+
+This is the kit you take on site. `@fde` runs the client work around the code: the brief, their codebase, go-live, promised → measured → accepted. A local command dates every decision. The notes are markdown on your laptop. You confirm; then it is on the record.
+
+---
+
 ## Principles
 
-- **Same six stages** - any scale, new or existing, any industry. Extra notes for your sector
-- **The write-up is the record** - doing the work and writing it down are one action
-- **Ground loop** - name the change, characterise their code, prove it on their staging, go live, log the outcome
-- **Skills, not autonomy** - the kit says what to check; judgment stays yours
-- **Check the brief is the real job** - discover before building the wrong thing
-- **Evidence on every claim** - these files get defended in the room
-- **One customer, one folder** - context never bleeds
+- **Who signs**  - name them in the first days
+- **Brief vs real job**  - check the floor, not only the slide
+- **Back from done**  - sequence from signed-off, not from the ticket
+- **Their staging then live**  - prove it where they operate, then go live
+- **Promised, measured, accepted**  - a number nobody signed is claimed, not delivered
+- **They run it**  - if they cannot operate it without you, you are not done
+- **A dated line, or it did not happen**  - these files get defended in the room
+- **One customer, one folder**  - context never bleeds
+- **The kit says what to check. You still decide.**
 
 ---
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -153,8 +153,8 @@ ok(`router dispatch (${mentioned.length} reference targets verified) + memory co
   }
   if (!routed.size) fail('check.js could not parse the SKILL.md routing table')
 
-  // docs/skills-reference.md is the canonical per-method list: one row per
-  // method inside the six domain tables, ending at the Overlays section.
+  // docs/skills-reference.md is the canonical per-skill list: one row per
+  // skill inside the six stage tables, ending at the Overlays section.
   const reference = read('docs/skills-reference.md')
   const documented = new Set()
   let documentedRows = 0

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -16,11 +16,13 @@
 
 ## First hour
 
-```bash
-node bin/install.js                  # once per machine (skills + hooks)
-cd <client-workspace>
-fde resume --init <engagement-name>  # once per workspace
+Install from the [README Quick Start](../README.md#quick-start) (plugin or `npx skills add suboss87/fdeops --skill fde`). Then in chat:
+
+```text
+@fde this is Acme
 ```
+
+That creates `~/fde-engagements/acme/.fde/` and binds this workspace. Terminal fallback: `npx fdeops resume --init <engagement-name>`. Air-gap disk copy: `node bin/install.js`.
 
 Work in your normal workspace. In the **AI chat**, type `@fde` with what is happening **now**.
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,10 +1,8 @@
-# fdeops usage guide
+# Usage
 
-**What it is:** the engagement layer for **you** (human FDE) + your **AI coding agent** - `@fde` routes skills; `.fde/` holds client-scoped memory on your machine.
+`@fde` is what you type. `.fde/` is the client folder on your laptop. Start at the README: install, name the client, then the command table.
 
 **Terminology:** [README § Who this is for](../README.md#who-this-is-for) - **"agent" = AI software, not a human.**
-
-**Start here:** [README](../README.md) - Commands (lifecycle) → All 30 Skills (catalog) → How Skills Work.
 
 <p align="center"><img alt="A recorded fdeops session: kickoff notes routed into dated memory after you confirm" src="../media/session.gif" width="900" /></p>
 
@@ -16,8 +14,8 @@ Day-to-day reference below.
 
 ## New here? (5 minutes)
 
-1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme` - the AI coding agent binds. Terminal fallback: `fde resume --init <client-name>`
-2. Read **Commands** and **Who this is for** in the README
+1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme`. That creates `~/fde-engagements/acme/.fde/`. Confirm one write. Terminal fallback: `fde resume --init <client-name>`
+2. Read **Quick Start** and **Commands** in the README
 3. Skim [examples/garvey-payments/](../examples/garvey-payments/) Day 1 → Day 10
 4. Optional recon, zero config: `npx fdeops scan` in a repo
 5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what's the outcome)
@@ -30,10 +28,10 @@ You do not pick a skill. **`@fde` routes the AI and loads the right one.**
 
 | You are… | Example message to the **AI coding agent** |
 |----------|---------------------------------------------|
-| Starting | `@fde this is Acme` (binds) then `@fde New embed. First meeting tomorrow. Brief says: …` |
+| Starting | `@fde this is Acme` then `@fde First meeting tomorrow. Brief says: …` |
 | Unsure of real problem | `@fde Workshop done. Ops says they use a spreadsheet nightly.` |
 | Just out of a meeting | `@fde Debrief: <paste your raw notes>` |
-| Ready to code | `@fde` One change they can see by Friday in module X. Going live after Marco signs staging. |
+| Ready to code | `@fde` Change in module X. Prove it on their staging. Going live after Marco signs. |
 | Production broken | `@fde API 500 since 2pm deploy.` |
 | Sponsor went quiet | `@fde VP stopped replying; still building old scope.` |
 | Handing off | `@fde Engagement ends Friday. Need handoff doc.` |

--- a/docs/install.md
+++ b/docs/install.md
@@ -16,7 +16,7 @@ fdeops installs on **your laptop** - where **your AI coding agent** runs. Not on
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Then one chat - name the client; the AI coding agent binds. You never type the CLI:
+Then one chat - name the client. That creates `~/fde-engagements/<client>/.fde/`. You never type the CLI:
 
 ```text
 @fde this is Acme
@@ -47,9 +47,11 @@ Type `@fde` in the AI chat and start working.
 
 | Situation | Install |
 |-----------|---------|
-| Claude Code only | Marketplace plugin (above); run `node bin/install.js` once for hooks on disk |
-| Multiple AI tools or air-gap | Git clone + `node bin/install.js`, then adapters per tool |
-| Quick trial, no install | `npx fdeops scan` (uses **fdeops v3.0.0 or later from npm** - the npm version, not your npm client's version) |
+| Claude Code | `/plugin install fdeops@fdeops`  - skill, slash commands, hooks. CLI via `npx fdeops …`. `node bin/install.js` only if you want a disk copy under `~/.claude/` |
+| Cursor / other agents | `npx skills add suboss87/fdeops --skill fde`, then `npx fdeops adapters <client-workspace>` |
+| Air-gap | `git clone … && node bin/install.js` |
+| Bind (any host, after the skill exists) | Chat: `@fde this is Acme`. Terminal fallback: `npx fdeops resume --init <name>` |
+| Quick trial, no install | `npx fdeops scan` (uses **fdeops v3.0.0 or later from npm**) |
 
 ---
 

--- a/docs/methodology.md
+++ b/docs/methodology.md
@@ -3,23 +3,19 @@
 fdeops implements this methodology as an installable field kit: skills plus `.fde/` artifacts so one **human engineer** can run client work end to end with an **AI coding agent** (not a human “agent” on the team).
 
 ## What Is an FDE?
-Forward Deployed Engineers embed directly with customers, bridging the gap between product capability and enterprise reality. Originated as a discipline at companies deploying engineers directly into customer operations. a16z called it "the hottest job in tech."
+An FDE sits with the customer, in their repo, until their people can run what shipped. FDEOps is the kit for that loop: six stages, a local record, an AI coding agent that does not get to skip who signs, what is live, and whether they accepted.
 
 ## How fdeops talks
 
 fdeops is **conversational** - a senior colleague thinking with you, not a form. Skills teach intent and judgment; they are not scripts to read aloud.
 
-## The FDE Principles Encoded in fdeops
-1. **Trust First:** technology serves people. Earn the right to touch production systems.
-2. **Explore Chaotically:** do things that don't scale; discover what works before encoding.
-3. **Observe Continuously:** real user needs hide in workarounds, not formal requirements.
-4. **Prototype to Learn:** rough demos beat polished wrong answers.
-5. **Bridge Business and Technology:** every decision must be traceable to customer value.
-6. **Map Before Moving:** never modify unknown terrain.
-7. **Embrace Chaos:** real enterprise environments are partially unmappable. Operate anyway.
-8. **Brownfield Safety:** legacy code is fragile; wrap, don't rewrite. Characterise before changing.
-9. **Ship with Rigour:** pre-flight, canary, tested rollback.
-10. **Extract Patterns:** every engagement feeds back into the collective intelligence.
+## The six stages encoded in fdeops
+1. **Land**  - Name who signs done.
+2. **Discover**  - Check the brief is the real job.
+3. **Plan**  - Sequence from done, not from the ticket.
+4. **Ship**  - Seen on their staging, then live. Not one PR to prod.
+5. **Outcome**  - Promised, measured, accepted. A number nobody signed is claimed.
+6. **Close**  - They operate it without you.
 
 ## Before Your First Meeting
 
@@ -35,7 +31,6 @@ The hour before you walk in (or log on) determines the quality of the next two w
 
 **One hypothesis:** Walk in with one falsifiable belief about what the real problem is. You'll probably be wrong. That's the point. It forces you to listen for the correction.
 
-## Further Reading
-- a16z: "Forward Deployed Engineer: The Hottest Job in Tech"
-- Boris Cherny on Lenny's Podcast (Claude Code creation)
-- Palantir FDE operations documentation
+## Further reading
+- [README](../README.md)  - the public map (commands, principles, who this is for)
+- [USAGE.md](./USAGE.md)  - what to type day to day

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -18,7 +18,7 @@ After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same rou
 
 | File | Purpose | Written by |
 |------|---------|------------|
-| `context.md` | Compact state; loaded every session; dated debrief blocks | every phase + the `session-stop` hook (auto-capture) + `fde debrief` |
+| `context.md` | Compact state; loaded every session; dated debrief blocks | every stage + the `session-stop` hook (auto-capture) + `fde debrief` |
 | `brief.md` | Stated problem (hypothesis) | land |
 | `assumptions.md` | Brief claims under test: OPEN / CONFIRMED / DISPROVED | land (seed), test-assumptions, discover |
 | `success.md` | Definition of done + primary value bucket + out of scope | land |
@@ -56,7 +56,7 @@ The rationale is the line a successor cannot reconstruct from the code.
 
 | File | Purpose | Written by |
 |------|---------|------------|
-| `chaos-log.md` | Incidents, root cause | rescue, debug |
+| `chaos-log.md` | Incidents, root cause | rescue |
 | `handoff.md` | Team takeover knowledge | close |
 | `patterns.md` | Reusable patterns | close |
 | `audit.md` | Mid-engagement: real vs assumed | audit |
@@ -73,9 +73,9 @@ The rationale is the line a successor cannot reconstruct from the code.
 ## Rules
 
 1. **`<private>...</private>`** - redacted from CLI, dashboard, and hook-injected context. Nothing inside a block is ever routed into `decisions.md`/`risks.md`/`delivery.md`/`stakeholders.md`; `fde debrief`/`fde ingest` seal it verbatim into `context.md` instead, and hold it out of the agent-facing `.debrief-propose` in an owner-only (`0600`) `.debrief-private` sidecar that only `--apply` reads; a `.debrief-seal` receipt records how many blocks were sealed, so `--apply` refuses rather than silently dropping one if the sidecar disappears. Do not load raw blocks into the model via file tools or paste.
-2. Phases load files **on demand**, not the whole directory.
+2. Stages load files **on demand**, not the whole directory.
 3. **Do not** mix two customers in one `.fde/`.
-4. **Deliverable = memory:** `--init` creates only the core files; phase artifacts (`audit.md`, `chaos-log.md`, `handoff.md`, `evals.md`, …) are created by their phases when they run - formats live in [skills/fde/references/](../skills/fde/references/).
+4. **Deliverable = memory:** `--init` creates only the core files; stage artifacts (`audit.md`, `chaos-log.md`, `handoff.md`, `evals.md`, …) are created by their stages when they run - formats live in [skills/fde/references/](../skills/fde/references/).
 5. Every claim carries its evidence: `(ops lead, Day 5)` · `(churn: 47/90d)` · `(stated, unverified)`.
 6. **Trust signals are tokens:** the latest dated `[signal:green|amber|red]` in `stakeholders.md` drives `fde status` / `fde dashboard`; tokens older than 21 days show as stale. Keyword matching is only the fallback when no token exists.
 7. **Assumptions are not receipts:** `assumptions.md` and `brief.md` are claims. `fde receipts` labels them separately from dated agreements.

--- a/docs/skills-reference.md
+++ b/docs/skills-reference.md
@@ -90,19 +90,18 @@ Each reference is a **skill, not a prompt**: the thinking the agent does, the ar
 
 ## Core path (quick reference)
 
-The skills most engagements actually run through, with what gets written where. This is a shorter cut through the table above. POC, the change on their repo, proof on their staging, go-live, and eval stay on `@fde` - they are not a side pack.
+The six stages stay land → discover → plan → ship → outcome → close. These are the skills most engagements actually run, with what gets written where. POC, the change on their repo, proof on their staging, go-live, and eval stay on `@fde`.
 
-| Phase | Enter when | What it does | Writes |
+| Skill | Enter when | What it does | Writes |
 |-------|-----------|-------------------|--------|
 | [land](../skills/fde/references/land.md) | New customer, first meeting | Interrogates the brief for what's missing; coaches the sponsor conversation; maps stakeholders and sacred data | `brief.md` `success.md` `stakeholders.md` `trust-profile.md` |
 | [discover](../skills/fde/references/discover.md) | Brief feels wrong, real problem unclear | Runs churn/test-gap/"temporary"-archaeology/AI-component scans; hunts the workaround; scores use cases | `reality.md` `terrain.md` |
-| [audit](../skills/fde/references/audit.md) | Taking over half-done work | Reads everything, tests every "this works" claim, finds tribal-knowledge holes via git authorship | `audit.md` `terrain.md` `reality.md` `context.md` |
-| [poc](../skills/fde/references/poc.md) | Direction needs validating | Prototypes the killer assumption same-day; kill criteria; 3-sentence business case | `prototype-log.md` `business-case.md` |
-| [rescue](../skills/fde/references/rescue.md) | Production fire, trust fire, or wrong-brief mid-build | Stabilise -> named unknowns -> minimum safe change; quiet-stakeholder protocol; three-path reset | `chaos-log.md` `risks.md` `decisions.md` |
+| [plan](../skills/fde/references/plan.md) | Scope clear, needs sequencing | Back from done; fragile first; PR-sized tasks; acceptance-criteria gate | `decisions.md` |
+| [ship](../skills/fde/references/ship.md) | Writing or updating on their repo, or ready to deploy | Seen on their staging, then live; intent vs diff, pre-flight/CAB, rollback you have run | `decisions.md` `delivery.md` |
+| [readout](../skills/fde/references/readout.md) | Friday, sponsor update, what's delivered | Promised → measured → accepted | `delivery.md` (ledger); presented via `fde status` |
 | [close](../skills/fde/references/close.md) | Engagement ending | Retrospective with receipts; pattern extraction; the 2am handoff | `retrospectives/` `patterns.md` `handoff.md` |
-| [plan](../skills/fde/references/plan.md) | Scope clear, needs sequencing | Backwards from success; fragile first; PR-sized tasks; acceptance-criteria gate | `decisions.md` |
-| [review](../skills/fde/references/review.md) | Change needs a merge gate | Stage 1 KEEP/JUSTIFY/SPLIT/DROP vs stated intent, then 5-dimension safety; review-fix loop until clean | `decisions.md` |
-| [ship](../skills/fde/references/ship.md) | Writing or updating on their repo, or ready to deploy | One change they can see (greenfield or brownfield), proven on their staging; then intent vs diff, pre-flight/CAB, canary with rollback-on-anomaly | `decisions.md` `delivery.md` |
+
+Also-ran skills on the same loop (not a second map): [audit](../skills/fde/references/audit.md) · [poc](../skills/fde/references/poc.md) · [rescue](../skills/fde/references/rescue.md) · [review](../skills/fde/references/review.md).
 
 ---
 
@@ -120,4 +119,4 @@ The skills most engagements actually run through, with what gets written where. 
 4. On exit (and before a PR) the agent runs a **session digest** - TL;DR, key decisions & why, scope/verification, gotchas, next action - into existing `.fde/` files (not chat transcripts into the product repo); the `session-stop` hook backstops a thin snapshot (hooks resolve the engagement via the workspace registry written by `fde resume --init`).
 5. One customer, one folder. Never merged.
 
-v2's 16 standalone skills were consolidated into the single `@fde` router in v3.
+One `@fde` router. Thirty skills across six stages.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -14,16 +14,16 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 
 | Stage | Skills | What it covers |
 |--------|--------|---------------|
-| **Land** (Engage) | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
-| **Discover** (Diagnose) | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
-| **Plan** (Align) | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
-| **Ship** (Deliver) | ship, what-breaks, rescue, review, rollback | Visible on their staging, then go-live |
-| **Outcome** (Realize) | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
-| **Close** (Transfer) | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
+| **Land** | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
+| **Discover** | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
+| **Plan** | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
+| **Ship** | ship, what-breaks, rescue, review, rollback | Visible on their staging, then go-live |
+| **Outcome** | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
+| **Close** | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 
 Each skill is a workflow, not a prompt: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.
 
-**Field judgment (blended into skills, not a separate pack):** land/discover use **brief interrogation** when the brief is thin; `@fde` enforces **anti-invention gates**; ship/red-team run a **pre-blast challenge** before irreversible moves.
+Brief interrogation, anti-invention, and pre-blast live inside land, discover, ship, and red-team. They are not extra commands.
 
 ## 5 overlays (activate automatically on signal)
 

--- a/examples/garvey-payments/README.md
+++ b/examples/garvey-payments/README.md
@@ -2,20 +2,11 @@
 
 Copy the **structure**, not the company names. These files show what a real week-1 → week-2 arc looks like in `.fde/`.
 
-Follow [README § The basic workflow](../../README.md#the-basic-workflow) while you read.
+This is a **reference copy**. Do not install from this page. Do not init `garvey-payments` unless you are only reading along.
 
-## Setup (your machine)
+Follow [README § Quick Start](../../README.md#quick-start) for *your* client. Your files land at `~/fde-engagements/<your-client>/.fde/`. Then read Day 1 below to see what a first write looks like.
 
-```bash
-cd fdeops && node bin/install.js
-cd <your-client-workspace>
-fde resume --init garvey-payments   # creates the engagement and binds this workspace
-```
-
-Open your workspace for this embed. Type `@fde`.
-
-> Files below live under `~/fde-engagements/garvey-payments/.fde/` after `init`.  
-> This folder in the repo is a **reference copy** for readers.
+> Files below are a **reference copy** of `~/fde-engagements/garvey-payments/.fde/`.
 
 ---
 
@@ -48,11 +39,11 @@ Open your workspace for this embed. Type `@fde`.
 
 ---
 
-### Day 10 - Ship one change
+### Day 10 - Ship
 
 **You:** `@fde Ship thinnest path by Friday. Legacy `payments-eu` module, no tests in repo.`
 
-**AI coding agent should:** route engineering - characterise, one change they can see, `decisions.md` + `delivery.md`.
+**AI coding agent should:** route ship - prove it on their staging, then live; log `decisions.md` + `delivery.md`.
 
 | File | What gets written |
 |------|-------------------|

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.20.0",
+  "version": "3.21.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
-  "version": "3.20.0",
-  "description": "Forward deployed engineering skills for AI coding agents. Your agent forgets the client every morning - the sponsor, the promise, who signed off. FDEOps keeps that as dated markdown on your laptop: one @fde skill, a deterministic local CLI, and hooks that make it automatic. Claude Code plugin and any agent that loads skills.",
+  "version": "3.21.0",
+  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code: who can say yes, what went live, whether they signed off. Dated markdown on your laptop. You confirm each write.",
   "bin": {
     "fdeops": "bin/install.js",
     "fde": "bin/fde.js"

--- a/plugin.json
+++ b/plugin.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.20.0",
-  "description": "Forward deployed engineering skills for AI coding agents: per-client memory in local .fde/ files, one @fde skill. Local-only, no network.",
+  "version": "3.21.0",
+  "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
   "author": {
     "name": "Subash Natarajan",
     "url": "https://github.com/suboss87"

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -127,9 +127,11 @@ When discovery requires a structured session with multiple stakeholders (alignme
 
 **After the room:** Summary in `decisions.md` within 2 hours. Decisions decay - what felt clear at 3pm is debatable by 5pm if unwritten.
 
-## Method - part 4: data estate assessment
+## Method - part 4: data estate and the pipe
 
-When the engagement involves AI, analytics, or data-heavy automation, assess the data estate before scoring use cases:
+Always map the estate before you score a use case - not only when someone said "AI." A path they cannot feed is a discover miss, not a ship surprise.
+
+**Their words first.** In `terrain.md`, write the names the floor uses for the workaround, the sheet, the exception path, and the person who left. Later plan/ship/review sentences use those names. Do not translate their floor into generic product language.
 
 **The 5 questions (ask the data owner, not the sponsor):**
 1. **Where does data live?** - List every source: databases, warehouses, SaaS exports, spreadsheets, S3 buckets, vendor APIs. Map it.
@@ -138,13 +140,15 @@ When the engagement involves AI, analytics, or data-heavy automation, assess the
 4. **What's the quality?** - Sample 100 rows from each critical source. Check: nulls, duplicates, format consistency, semantic correctness. A 60% null rate in a key field = that source is fiction.
 5. **What are the governance constraints?** - PII classification, retention policies, cross-border rules, consent basis. One missed constraint = a compliance stop later.
 
+**The pipe (what talks to what).** For each source that a use case depends on, write: the system it flows from and to, the contract (object, table, file, API), whose credentials, what happens when the vendor 500s or the Monday file does not land, and whether the join the sponsor described actually exists. Their IdP, CRM, and warehouse are delivery work when the path needs them - policy questions in `trust-profile.md` are not a substitute.
+
 **The data readiness matrix:**
 
-| Source | Location | Freshness | Owner | Quality (sample) | Governance | Verdict |
-|--------|----------|-----------|-------|-----------------|------------|---------|
-| _fill per source_ | | | | | | Ready / Needs work / Blocker |
+| Source | Location | Freshness | Owner | Quality (sample) | Governance | Pipe | Verdict |
+|--------|----------|-----------|-------|-----------------|------------|------|---------|
+| _fill per source_ | | | | | | | Ready / Needs work / Blocker |
 
-A use case that depends on a "Blocker" source doesn't get scored - it gets a data remediation conversation first. Write this to `terrain.md` under a `## Data estate` section.
+A use case that depends on a "Blocker" source **or a Blocker pipe** doesn't get scored - it gets a remediation conversation first. `what-breaks` finding an invisible integration at ship is already too late. Write this to `terrain.md` under a `## Data estate` section.
 
 ## When scope is a transformation, not a single problem
 

--- a/skills/fde/references/encode-pattern.md
+++ b/skills/fde/references/encode-pattern.md
@@ -47,6 +47,7 @@ The difference between a 5-year FDE and a 15-year FDE is not talent - it's encod
 | **Specific enough?** | Contains concrete steps, not just principles | "Build trust" / "Communicate well" - too vague to act on |
 | **Repeatable?** | Applies to a class of situations, not just this one | Only worked because of a unique circumstance |
 | **Falsifiable?** | You can tell when the pattern is working or not | No way to measure whether applying it helped |
+| **Monday bag?** | You would refuse the next similar embed without this in your bag - a named move plus an artifact you can drop on day one (pipe questions, CAB dance, eval golden shape, floor-drill script) | "We learned to communicate." Patterns that only live in this client's `.fde/` do not compound |
 
 **4. Classify by stage.** Patterns sort into the same stages as the skills:
 

--- a/skills/fde/references/eval-pack.md
+++ b/skills/fde/references/eval-pack.md
@@ -22,9 +22,9 @@ Intelligence without evidence is token-maxing with a nicer name. An FDE earns tr
 
 **3. Score pass/fail, not vibes.** Run the suite. Record count pass / fail. Failures get a failure-mode tag (missing data, wrong record, format drift, hallucination, retrieval miss, unsafe action, other).
 
-**4. Human-in-the-loop gate.** Name which outcomes require human approve before side effects. If none, write why that is allowed under `trust-profile.md` AI policy - do not invent permission.
+**4. Human-in-the-loop gate.** Name which outcomes require human approve before side effects. Judgement that has a side effect (write, send, transfer, ticket, deploy, pay, page) is **NO-SHIP** without a named human on their side in the loop. Do not write "none - allowed under policy" to bless lights-out write-access. Staging may run a supervised loop with a kill switch, a cost cap, and a golden set from **their** failures. Production stays gated until they have a written policy, a named owner, and dated eval receipts on real traffic.
 
-**5. Ship rule.** Until `evals.md` shows Verdict **SHIP** with a dated run (critical fails = 0) and HITL filled when policy requires it, AI-touching ship stays **fix-first**. Log a one-line eval receipt in `delivery.md` → `## Ship receipts`.
+**5. Ship rule.** Until `evals.md` shows Verdict **SHIP** with a dated run (critical fails = 0) and HITL filled, AI-touching ship stays **fix-first**. Eval fails do not sit in a backlog - they reopen plan (descope, move the judgement, or kill the path). Log a one-line eval receipt in `delivery.md` → `## Ship receipts`. No "probably fine."
 
 ## Artifact - `evals.md`
 
@@ -39,5 +39,5 @@ Present to the FDE: suite size, pass rate, top failure mode, HITL gate, Verdict 
 - No golden set, no AI ship.
 - Pass/fail beats “looks good.”
 - Failure modes are the product - the happy path is table stakes.
-- HITL is a gate, not a slide.
+- HITL is a gate, not a slide. Side effects without a named human on their side are NO-SHIP.
 - Non-AI work does not need this file.

--- a/skills/fde/references/readout.md
+++ b/skills/fde/references/readout.md
@@ -12,15 +12,16 @@
 
 | Block | What to write | Source |
 |-------|---------------|--------|
-| **S - Situation** | Where we are against `success.md`, in their words | success.md, delivery value ledger |
+| **S - Situation** | Where we are against `success.md`, in their words - including whether the floor still uses the old path | success.md, delivery value ledger, reality.md workaround |
 | **C - Complication** | What changed, what is at risk, or what we learned (bad news first) | risks.md, assumptions DISPROVED/OPEN, stakeholders signal |
 | **Q - Question / Ask** | The one decision or help you need from them | decisions.md, access/sign-off needs |
 | **A - Answer** | What you recommend / what happens next week (≤3 bullets) | plan Now lane, delivery promised→measured |
 
 Then add, still on the same page:
 1. **Value this week** - from the value ledger: promised → measured (or "pending") → **accepted by whom**, with evidence citation. A measured number nobody on the customer side has agreed to is written as `claimed`, and the Ask never rests on it - if the whole case for the next phase is a claimed number, the real ask this week is "who signs off that this is real?".
-2. **Kill / defer reminder** - one line from the plan kill list so scope fights stay visible.
-3. **Hostile Q prep** - three questions a skeptical sponsor will ask, with one-line answers from memory.
+2. **Are they using it?** - Situation must say whether the workaround is still open: spreadsheet still running, shadow paste still happening, named operator completed Tuesday's job on the new path without you at the keyboard. A measured metric with the old path still live is `claimed`. That week's Ask is not "fund phase 2." It is "who on their side stops the old way, by when."
+3. **Kill / defer reminder** - one line from the plan kill list so scope fights stay visible.
+4. **Hostile Q prep** - three questions a skeptical sponsor will ask, with one-line answers from memory.
 
 Exec voice: no jargon, no hedging, every claim traceable (`(shipped Tue, delivery.md)`). Draft in the **FDE's voice, for the FDE to send** - never send anything yourself.
 

--- a/skills/fde/references/review.md
+++ b/skills/fde/references/review.md
@@ -1,6 +1,6 @@
 # review - Review the change
 
-**Enter when:** a change needs review before merge - "is this safe," "does it match what we agreed."
+**Enter when:** a change needs review before merge - "is this safe," "does it match what we agreed." Their team commented on the PR: same skill. Comments are to check, not to obey.
 
 **Read first:** `context.md`, `decisions.md`, `trust-profile.md`, `terrain.md`. Not `reality.md`/`stakeholders.md` - irrelevant to reviewing code against agreed scope.
 
@@ -52,7 +52,7 @@ Five dimensions, line-specific ("line 47 fails under concurrent writes - no lock
 
 1. Read the full diff before commenting.
 2. Verdicts: **Stage 1: Pass / Blocked (reason)** · **Stage 2: Pass / Concerns (line-specific)**.
-3. Fix only **real** findings tied to this change - no drive-by refactors. Reject false positives with one sentence why.
+3. Fix only **real** findings tied to this change - no drive-by refactors. Reject false positives with one sentence why. Their comments are to check, not to obey. Restate each against the one-line intent and `trust-profile.md`. One item unclear → ask before changing any of them. If it breaks a signed constraint, a sacred system, or nothing calls it: one-sentence pushback, then wait.
 4. Add or update a test per bug found where possible.
 5. Re-run tests/typechecks - state what ran.
 6. Re-review. Repeat until Pass/Pass or a human must decide scope/product.

--- a/skills/fde/references/runbook.md
+++ b/skills/fde/references/runbook.md
@@ -60,6 +60,7 @@ Rollback: <exact command and expected time>
 |---------|-------|-----------|----------|--------|
 | **Architecture walkthrough** | Why, not what. The decisions, the trade-offs, the things that almost went wrong. | Full team | 60-90 min | Recording + Q&A log |
 | **Operational drill** | Deploy, rollback, incident response. They do it, you watch. | On-call team | 60 min | Drill report with confidence level |
+| **Floor drill** | They run the real job (the exception on the operating map) while you watch, hands off. Then they teach the next person. If they cannot, the runbook is a PDF. | Named operator on the floor | 45-60 min | They used the 2am doc during the drill, or the embed is not closed |
 | **Edge-case handover** | The things that aren't in any document. The workarounds, the fragile spots, the "ask Sarah because she's the only one who knows." | Team lead + 1 | 30 min | Additions to `handoff.md` |
 
 **4. The confidence check.** After the knowledge transfer, score the team's readiness:
@@ -68,11 +69,12 @@ Rollback: <exact command and expected time>
 |------|------------------|----------|
 | Daily operations | | Can they deploy and rollback without help? |
 | Incident response | | Did they complete the drill within acceptable time? |
+| Floor job | | Did the named operator complete Tuesday's real exception without you at the keyboard? |
 | Architecture decisions | | Can they explain why the system is built this way? |
 | AI components (if any) | | Do they know how to monitor, retrain, and disable? |
 | Stakeholder management | | Do they know who to update and how? |
 
-**Average below 3.5 → the handoff is not complete.** Extend if possible; if not, document the gaps and name the risk.
+**Average below 3.5 → the handoff is not complete.** Extend, or tell the sponsor the embed is not closed. Do not document the gap and leave.
 
 **5. The successor brief.** If a new FDE is taking over, write a brief that gets them operational in one hour:
 
@@ -132,7 +134,7 @@ If you see 2+: accelerate the handoff immediately. The longer you stay past usef
 
 - The goal of every engagement is to make yourself replaceable.
 - The 2am document is the real handoff - everything else supports it.
-- Knowledge transfer is three sessions, not a doc dump.
+- Knowledge transfer is four sessions, not a doc dump. The floor drill is the one that matters.
 - A confidence score below 3.5 means the handoff isn't done.
 - The successor brief gets the next FDE operational in one hour or it's too long.
 - Clean exit: no personal credentials left behind, ever.

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -27,7 +27,7 @@ Skip POC only when the killer assumption already lives in the repo (typical brow
 
 **Done means:** the signer in `success.md` can reject this on staging they operate. A green check on your laptop is not delivery. Do not start the next change until this one is rejectable.
 
-If `terrain.md` **Data estate** lists a **Blocker** this change depends on: stop. That is discover, not ship. Do not build a path they cannot feed.
+If `terrain.md` **Data estate** lists a **Blocker** this change depends on (source or pipe): stop. That is discover, not ship. Do not build a path they cannot feed.
 
 ## Method - one change they can see
 
@@ -72,10 +72,12 @@ Read existing code in the area (search before creating)
 
 **Prove it on their staging.** A green check on your laptop is not delivery.
 
-- Run **their** test command, typecheck, or smallest proving path. Write the command and the result in `delivery.md`.
+- Run **their** test command, on **their** CI, with **their** fixtures. Write the command and the result in `delivery.md`. You do not add a runner they will not keep. If you have not run their command in this turn, you cannot write that it passed. Last session's green, "should pass," and "looks correct" are not a receipt.
 - If the signer in `success.md` cannot reject this on a screen they already use, it is not proven.
 - Staging they operate beats a local demo. If you have no staging: `unknown - ask:` who owns an environment, then stop pretending it shipped.
+- **Monday-shaped data.** Staging that is empty, synthetic, or last quarter is not next Tuesday. Before go-live, write what staging is missing (volume, PII, the batch that only runs in prod, the account that only exists in the warehouse) and what that means for the kill test. If the signer cannot reject it on a screen they already operate, with data that looks like next Tuesday, it is not proven.
 - Model in the path: `eval-pack` until `evals.md` says SHIP. Do not skip because "it looked right in chat."
+- A model drafts. A named human on their side ships. No unsupervised loop on their production. If the brief demands lights-out write-access, that is `who-decides` / `hold-scope`, not ship.
 
 The proof is whatever this client already believes, plus one new receipt they can replay.
 
@@ -213,6 +215,8 @@ grep -rnE "(api[_-]?key|secret|password|token)\s*[:=]\s*['\"][^'\"]{8,}" \
 ## Method - the deploy
 
 **Canary:** 1-5% of traffic, ≥10 minutes. Watch error rate, latency, and **the business metric this change affects**. Anything looks wrong → roll back immediately; investigate safely; redeploy when confident. Never investigate during the canary. Then stage up: 5% → 25% → 100%, each confirmed stable.
+
+**Canary receipt** (write it, or the canary did not happen): what was watched, on whose dashboard, for how long, and that the next change did not start in the window. If prod is a CAB console, vendor button, or their pipeline, write the owner and the click path - the host agent does not get to pretend it shipped.
 
 **Programme-scale rollout (transformations)** - different problem from one service:
 1. **Pilot** - one team, one use case; success metrics defined *before* it starts (after = fitting metrics to results).

--- a/templates/.fde/README.md
+++ b/templates/.fde/README.md
@@ -5,7 +5,7 @@
 Create with:
 
 ```bash
-node bin/install.js init <engagement-name>   # from fdeops repo; or npx fdeops@latest init when npm ≥ 3.0.0
+fde resume --init <engagement-name>   # or: npx fdeops resume --init <engagement-name>
 ```
 
 Stays on **your machine** - not in shared git by default.


### PR DESCRIPTION
## Why

Community front door and field gates for 3.21.0. Same six stages. Same 30 skills. Public copy stands on its own.

## What changed

- README is hallway English: client work around the code; Commands table is What you're doing | Type this | Remember. Dual consulting verbs are gone from the front door.
- Quick Start before Commands. First hour: folder exists, one confirmed write, then `/brief`.
- Discover: data estate, the pipe, their words. Ship: run their command in this turn or you cannot write that it passed. Review: their PR comments are to check, not to obey.
- Readout: old path still live = claimed. Runbook: floor drill. Eval-pack: side effect without a named human on their side is NO-SHIP.
- Version bump on the four manifests. Changelog for 3.21.0.

## Checks

- [x] `npm run check` passes (131 tests)
- [x] No client names, `.fde/` exports, credentials, or screenshots with real people

After merge: tag `v3.21.0` from Main to publish. CI still needs `NPM_TOKEN` if you want GitHub Actions to publish.


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/83" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->