### PR TITLE
feat: restore catalog README and first-principles field gates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,13 @@
 
 ## 3.21.0 - 2026-09-01
 
-The public map is hallway English. Ship and review got harder field gates. Same six stages. Same 30 skills.
+Same public map as 3.20: Commands, then All 30 Skills, then How Skills Work. Hero is hallway English. Six skills got harder field gates. Same six stages. Same 30 skills.
 
-- README hero: the client work around the code. Commands table: What you're doing | Type this | Remember. Dual consulting verbs are gone from the front door.
-- Quick Start before Commands. First hour: folder exists, one confirmed write, then `/brief`. Do not start coding.
+- README hero: the client work around the code that still gets you fired if you skip it. Catalog and project tree stay on the front door.
 - Discover: data estate always; the pipe; their words in `terrain.md`.
 - Ship: run their command in this turn or you cannot write that it passed. Monday-shaped staging. No unsupervised loop on their production.
 - Review: their PR comments are to check, not to obey.
-- Readout: old path still live = claimed. Runbook: floor drill, do not document-and-leave. Eval-pack: side effect without a named human on their side is NO-SHIP.
+- Readout: old path still live = claimed. Runbook: named operator runs Tuesday's job from the 2am doc, hands off. Eval-pack: side effect without a named human on their side is NO-SHIP.
 
 ## 3.20.0 - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@
 Same public map as 3.20: Commands, then All 30 Skills, then How Skills Work. Hero is hallway English. Six skills got harder field gates. Same six stages. Same 30 skills.
 
 - README hero: the client work around the code that still gets you fired if you skip it. Catalog and project tree stay on the front door.
-- Discover: data estate always; the pipe; their words in `terrain.md`.
+- Discover: data estate always; the pipe; their words in `terrain.md`. Parts of the problem before scan (no solutions).
+- Test-assumptions: kind FACT / CONVENTION / UNKNOWN before blast radius.
+- Three-options: assemble from surviving blocks, not three speeds of the same plan.
+- POC: write pass/fail lines before you build.
 - Ship: run their command in this turn or you cannot write that it passed. Monday-shaped staging. No unsupervised loop on their production.
 - Review: their PR comments are to check, not to obey.
 - Readout: old path still live = claimed. Runbook: named operator runs Tuesday's job from the 2am doc, hands off. Eval-pack: side effect without a named human on their side is NO-SHIP.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,12 @@
 # FDEOps
 
-**The client work around the code the AI coding agent writes in their repo.**
+**Forward deployed engineering skills for AI coding agents.**
 
-You're on site. The AI coding agent writes code in their repo. This is everything around that code that still gets you fired if you skip it: the brief, who can say yes, their staging then live, whether they signed off, whether they can run it after you leave. Notes stay on your laptop. Their repo stays theirs. You confirm before anything is written down.
+You're on a customer site. The AI coding agent writes code in their repo. This kit is the work around that code: the brief, who can say yes, proof on their staging then live, whether they signed off, whether they can run it after you leave.
+
+Notes stay on your laptop. Their repo stays theirs. You confirm before anything is written down.
 
 <img width="1536" height="1024" alt="fdeops" src="https://github.com/user-attachments/assets/2bcb8739-55ee-445d-8a1a-8b38433b7b58" />
-
----
-
-## Commands
-
-One command per stage. Skills load automatically.
-
-Six commands map to the embed. Each one loads `@fde`, which opens the skill for that moment: a thin brief pulls land, a wrong brief pulls discover, a Friday number pulls readout. Sprint or programme. Greenfield or brownfield. Any industry. You never pick from 30 names.
-
-| Work | Command | Stage | Principle |
-|------|---------|-------|-----------|
-| Engage | `/brief` | Land | Name who signs done |
-| Diagnose | `/discover` | Discover | Check the brief is the real job |
-| Align | `/plan` | Plan | Work backwards from success |
-| Deliver | `/ship` | Ship | Seen on their staging, then live |
-| Realize | `/outcome` | Outcome | Promised, measured, accepted |
-| Transfer | `/close` | Close | They operate it without you |
-
-Also:
-
-| Work | Command | Principle |
-|------|---------|-----------|
-| Diagnose trust | `/trust` | Process gap, or they stopped trusting you |
-| Find the receipt | `/receipts` | A dated line, or it did not happen |
-| Capture the meeting | `/debrief` | Notes into the record |
-| Prepare the meeting | `/prep` | One page from the record |
-| Report the outcome | `/readout` | Promised, measured, accepted |
-
-Skills also activate on English: naming a client, running a POC, changing their checkout, going live, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. Bound client work cannot.
 
 ---
 
@@ -43,50 +16,52 @@ Skills also activate on English: naming a client, running a POC, changing their 
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Then one chat. Name the client. The AI coding agent binds.
+Then one chat. Name the client:
 
 ```text
-@fde this is Acme
+@fde this is client01
 ```
 
-Paste kickoff notes in the same thread. `@fde` routes; you confirm judgment. Same folder every time: `~/fde-engagements/<client>/.fde/`. Workflow: [docs/USAGE.md](docs/USAGE.md).
+That creates `~/fde-engagements/client01/.fde/` on your laptop. Paste kickoff notes in the same thread. `@fde` picks what to check. You still decide.
+
+Day to day: [docs/USAGE.md](docs/USAGE.md).
 
 <details>
-<summary><b>Claude Code (recommended)</b></summary>
+<summary><b>Claude Code</b></summary>
 
 ```text
 /plugin marketplace add suboss87/fdeops
 /plugin install fdeops@fdeops
 ```
 
-Hooks load where you left off. Slash commands match the map above.
+Hooks resume where you left off. Slash commands match the table below.
 
 </details>
 
 <details>
 <summary><b>Cursor</b></summary>
 
+After the skill install, in the **client repo** you have open (pointer, not a second pack):
+
 ```bash
-npx skills add suboss87/fdeops --skill fde
+npx fdeops adapters .
 ```
 
-Or `npx fdeops adapters .`. See [adapters/](adapters/README.md).
+See [adapters/](adapters/README.md).
 
 </details>
 
 <details>
-<summary><b>Other agents</b></summary>
+<summary><b>Air-gap, PATH, override</b></summary>
 
 ```bash
-npx skills add suboss87/fdeops --skill fde
+git clone https://github.com/suboss87/fdeops.git && node bin/install.js
 ```
 
-Gemini, Copilot, Codex, local LLMs: [adapters/](adapters/README.md). Air-gapped: `git clone https://github.com/suboss87/fdeops.git && node bin/install.js`.
-
-Fallback if the agent cannot bind:
+If the agent cannot create the folder:
 
 ```bash
-npx fdeops resume --init acme   # ~/fde-engagements/acme + bind this checkout
+npx fdeops resume --init client01   # ~/fde-engagements/client01
 ```
 
 Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](docs/install.md). Try the loop: `npx fdeops demo`.
@@ -95,13 +70,34 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](doc
 
 ---
 
+## Commands
+
+One command per stage. Skills load automatically.
+
+Six stages, same order every job: Land, Discover, Plan, Ship, Outcome, Close.
+
+| What you're doing | Command | Stage |
+|-------------------|---------|-------|
+| First days. Get the brief. Name who signs. | `/brief` | Land |
+| Check the brief is the real job. | `/discover` | Discover |
+| Sequence from done, not from the ticket. | `/plan` | Plan |
+| Prove it on their staging, then go live. | `/ship` | Ship |
+| What you promised, measured, and who accepted. | `/outcome` | Outcome |
+| Hand it over. They run it without you. | `/close` | Close |
+
+Same `@fde`, when you need them: `/debrief` (notes into the record), `/prep` (one page before you walk in), `/trust` (process gap, or they stopped trusting you), `/receipts` (a dated line, or it did not happen), `/readout` (Friday page for the sponsor; not a seventh stage).
+
+You can also just say it: naming a client, a POC, changing their checkout, going live, asking what was agreed. A typo in a repo that is not a client job can skip this. A named client, a POC, or go-live cannot.
+
+---
+
 ## All 30 Skills
 
-The catalog. 30 skills spanning the embed. Not prompts - structured workflows with steps, an artifact, and a checkpoint. Type English or a slash command. `@fde` activates the right skill. You never pick one by name.
+Thirty situations, grouped by stage. Not prompts - each one has steps, a file it writes, and a checkpoint with you. Type English or a slash command. `@fde` opens the matching skill. You never pick one by name.
 
 Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 
-### Land - Engage
+### Land
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -111,7 +107,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
 | [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
 
-### Discover - Diagnose
+### Discover
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -120,7 +116,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
 | [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
 
-### Plan - Align
+### Plan
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -129,7 +125,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
 | [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
 
-### Ship - Deliver
+### Ship
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -139,7 +135,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
 | [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
 
-### Outcome - Realize
+### Outcome
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -151,7 +147,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
 | [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
 
-### Close - Transfer
+### Close
 
 | Skill | What it does | Use when |
 |--------|--------------|----------|
@@ -161,7 +157,7 @@ Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 | [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
 | [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
 
-Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) · [eval-pack](skills/fde/references/eval-pack.md)
+Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md). AI companion (not a sixth overlay): [eval-pack](skills/fde/references/eval-pack.md).
 
 Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mcp/recipes/)
 
@@ -169,33 +165,84 @@ Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mc
 
 ## How Skills Work
 
-One skill. One reference file per situation. One folder per client.
+One `@fde`. One file per situation. One folder per client.
 
 ```
-  /brief   or   "@fde this is Acme"
-           │
-           ▼
-  skills/fde/SKILL.md          hosts load this one file
+  "@fde this is client01"      creates ~/fde-engagements/client01/.fde/
+  /brief  or  English          the AI coding agent loads skills/fde/SKILL.md
            │  routes. you never pick a skill by name
            ▼
-  references/land.md           one skill, then stop
+  references/<one>.md          one skill, then stop
            │
            ▼
   fde CLI (local)              dates, gates, redacts. no network
            │  after you confirm
            ▼
-  ~/fde-engagements/<client>/.fde/
+  ~/fde-engagements/client01/.fde/
 ```
 
-**One skill routes.** Hosts load `@fde`. It reads the situation and opens one `references/*.md`. Slash commands and English both land here. You never pick a skill by name.
+**A dated line, or it did not happen.** Promised → measured → accepted. If it is not in `.fde/`, it is not on the record.
 
-**Evidence, not memory.** Promised → measured → accepted. A dated line in `.fde/`, or it did not happen. Nothing is done on vibes.
+**Confirm, then it is written.** The CLI stays on your laptop: git and files, no network. The AI coding agent runs the command. You say yes. Then it is in the folder.
 
-**Confirm before write.** Local CLI: git and files, no network. `.fde/` on your laptop. The AI coding agent runs the command. You confirm. Then it is on the record.
+**The record is on your laptop.** Change hosts, install `@fde` on the new one, keep talking. The notes are not inside any vendor.
 
-**Progressive disclosure.** `SKILL.md` is the entry. One skill file loads when routed. Writes and status cost zero model tokens.
+One skill hosts load: `skills/fde/SKILL.md`. It opens one file in `skills/fde/references/` and stops. Slash commands live in `.claude/commands/`. The local CLI is `bin/fde.js` (git + files, no network). Layout: [docs/REPO_LAYOUT.md](docs/REPO_LAYOUT.md).
 
-Change hosts, install `@fde` on the new one, bind if needed, keep talking. The record is not inside any vendor.
+---
+
+## Engagement memory (`.fde/`)
+
+One folder per client. Plain markdown. Grep it, copy it, take it into a meeting.
+
+| File | Holds |
+|------|-------|
+| `context.md` | Where you are |
+| `brief.md` / `success.md` | What they asked; what “done” is and who signs |
+| `reality.md` / `terrain.md` | The real problem; the map |
+| `stakeholders.md` | `[signal:green\|amber\|red]` |
+| `trust-profile.md` | Sacred data, AI policy, approval chain |
+| `decisions.md` / `risks.md` / `delivery.md` | Dated choices; live risks; what shipped and how it rolls back |
+
+Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
+
+---
+
+## Who this is for
+
+You sit with a customer's team. An AI coding agent writes in their repo. You need a record of the brief, who can say yes, what went live, and whether they signed off.
+
+If you ship your own company's product from HQ, with no customer team that has to run it after you leave, you do not need this kit.
+
+---
+
+## Your data stays yours
+
+The **CLI** is local: git + files, no network, no telemetry. The **host model** sees `.fde/` the agent loads (usually a bounded `context.md`) and any client code you open. It must not see `<private>` blocks - redacted from CLI, dashboard, and hooks; do not paste them or open them with file tools. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
+
+[PRIVACY.md](PRIVACY.md) · [SECURITY.md](SECURITY.md)
+
+---
+
+## Why FDEOps?
+
+AI coding agents are built for a repo, not for a client. Left alone they skip who signs, whether the brief is true, and whether anyone accepted the number. Monday they start from the ticket again.
+
+This is the kit you take on site. `@fde` runs the client work around the code. A local command dates every decision. The notes are markdown on your laptop. You confirm; then it is on the record.
+
+---
+
+## Principles
+
+- **Who signs** - name them in the first days
+- **Brief vs real job** - check the floor, not only the slide
+- **Back from done** - sequence from signed-off, not from the ticket
+- **Their staging then live** - prove it where they operate, then go live
+- **Promised, measured, accepted** - a number nobody signed is claimed, not delivered
+- **They run it** - if they cannot operate it without you, you are not done
+- **A dated line, or it did not happen** - these files get defended in the room
+- **One customer, one folder** - context never bleeds
+- **The kit says what to check. You still decide.**
 
 ---
 
@@ -258,65 +305,12 @@ fdeops/
 ├── bin/                                   # local CLI: git + files, no network
 ├── hooks/                                 # session-start / session-stop / pre-compact
 ├── adapters/                              # Cursor, Gemini, Copilot, Codex pointers
-├── templates/.fde/                        # memory files created on bind
+├── templates/.fde/                        # memory files created on first client
 ├── examples/                              # fictional walkthroughs
 ├── mcp/                                   # optional ingest + source recipes
 ├── evals/                                 # routing checks
 └── docs/                                  # usage, schema, install
 ```
-
----
-
-## Why FDEOps?
-
-AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
-
-FDEOps is the catalog you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, their codebase, go-live, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
-
----
-
-## Engagement memory (`.fde/`)
-
-One folder per client. Plain markdown. Grep it, copy it, defend it.
-
-| File | Holds |
-|------|-------|
-| `context.md` | Where you are |
-| `brief.md` / `success.md` | What they asked; what “done” is and who signs |
-| `reality.md` / `terrain.md` | The real problem; the map |
-| `stakeholders.md` | `[signal:green\|amber\|red]` |
-| `trust-profile.md` | Sacred data, AI policy, approval chain |
-| `decisions.md` / `risks.md` / `delivery.md` | Dated choices; live risks; what shipped and how it rolls back |
-
-Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
-
----
-
-## Who this is for
-
-You embed with a customer and an AI coding agent. Take this on the ground. Discovery through signed outcome lives in `@fde`. One `.fde/` per client so they do not blur.
-
-If you only write code in your own repo with no client record to defend, you do not need this kit.
-
----
-
-## Your data stays yours
-
-Local only - `git` + files, no network, no telemetry. Plain markdown. The model sees client code only when you point the AI coding agent at it. `<private>` is redacted from CLI, dashboard, and hooks. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
-
-[PRIVACY.md](PRIVACY.md) · [SECURITY.md](SECURITY.md)
-
----
-
-## Principles
-
-- **Same six stages** - any scale, new or existing, any industry. Extra notes for your sector
-- **The write-up is the record** - doing the work and writing it down are one action
-- **Ground loop** - name the change, characterise their code, prove it on their staging, go live, log the outcome
-- **Skills, not autonomy** - the kit says what to check; judgment stays yours
-- **Check the brief is the real job** - discover before building the wrong thing
-- **Evidence on every claim** - these files get defended in the room
-- **One customer, one folder** - context never bleeds
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,54 +8,82 @@ You're on site. The AI coding agent writes code in their repo. This is everythin
 
 ---
 
+## Commands
+
+One command per stage. Skills load automatically.
+
+Six commands map to the embed. Each one loads `@fde`, which opens the skill for that moment: a thin brief pulls land, a wrong brief pulls discover, a Friday number pulls readout. Sprint or programme. Greenfield or brownfield. Any industry. You never pick from 30 names.
+
+| Work | Command | Stage | Principle |
+|------|---------|-------|-----------|
+| Engage | `/brief` | Land | Name who signs done |
+| Diagnose | `/discover` | Discover | Check the brief is the real job |
+| Align | `/plan` | Plan | Work backwards from success |
+| Deliver | `/ship` | Ship | Seen on their staging, then live |
+| Realize | `/outcome` | Outcome | Promised, measured, accepted |
+| Transfer | `/close` | Close | They operate it without you |
+
+Also:
+
+| Work | Command | Principle |
+|------|---------|-----------|
+| Diagnose trust | `/trust` | Process gap, or they stopped trusting you |
+| Find the receipt | `/receipts` | A dated line, or it did not happen |
+| Capture the meeting | `/debrief` | Notes into the record |
+| Prepare the meeting | `/prep` | One page from the record |
+| Report the outcome | `/readout` | Promised, measured, accepted |
+
+Skills also activate on English: naming a client, running a POC, changing their checkout, going live, asking what was agreed. A throwaway one-liner in an unbound repo can skip `@fde`. Bound client work cannot.
+
+---
+
 ## Quick Start
 
-**Claude Code**
+```bash
+npx skills add suboss87/fdeops --skill fde
+```
+
+Then one chat. Name the client. The AI coding agent binds.
+
+```text
+@fde this is Acme
+```
+
+Paste kickoff notes in the same thread. `@fde` routes; you confirm judgment. Same folder every time: `~/fde-engagements/<client>/.fde/`. Workflow: [docs/USAGE.md](docs/USAGE.md).
+
+<details>
+<summary><b>Claude Code (recommended)</b></summary>
 
 ```text
 /plugin marketplace add suboss87/fdeops
 /plugin install fdeops@fdeops
 ```
 
-**Cursor and other agents**
+Hooks load where you left off. Slash commands match the map above.
+
+</details>
+
+<details>
+<summary><b>Cursor</b></summary>
 
 ```bash
 npx skills add suboss87/fdeops --skill fde
 ```
 
-Then one chat. Name the client. That's you on this job.
-
-```text
-@fde this is Acme
-```
-
-That creates `~/fde-engagements/acme/.fde/` on your laptop. Paste kickoff notes in the same thread. It picks what to check. You still decide.
-
-**You are done with the first hour when** that folder exists and you have confirmed one write. Next: `/brief`. Do not start coding yet.
-
-Workflow after that: [docs/USAGE.md](docs/USAGE.md).
-
-<details>
-<summary><b>Cursor: pointer in the client repo</b></summary>
-
-After the skill install, in the **client repo** you open in Cursor (pointer, not a second skill pack):
-
-```bash
-npx fdeops adapters .
-```
-
-Adapters do not replace the skill install. See [adapters/](adapters/README.md).
+Or `npx fdeops adapters .`. See [adapters/](adapters/README.md).
 
 </details>
 
 <details>
-<summary><b>Air-gap, PATH, override</b></summary>
+<summary><b>Other agents</b></summary>
 
 ```bash
-git clone https://github.com/suboss87/fdeops.git && node bin/install.js
+npx skills add suboss87/fdeops --skill fde
 ```
 
-Fallback if the agent cannot create the folder:
+Gemini, Copilot, Codex, local LLMs: [adapters/](adapters/README.md). Air-gapped: `git clone https://github.com/suboss87/fdeops.git && node bin/install.js`.
+
+Fallback if the agent cannot bind:
 
 ```bash
 npx fdeops resume --init acme   # ~/fde-engagements/acme + bind this checkout
@@ -67,37 +95,90 @@ Requires Node.js >= 18. Override: `FDEOPS_ENGAGEMENT`. See [docs/install.md](doc
 
 ---
 
-## Commands
+## All 30 Skills
 
-One command per stage. Skills load automatically.
+The catalog. 30 skills spanning the embed. Not prompts - structured workflows with steps, an artifact, and a checkpoint. Type English or a slash command. `@fde` activates the right skill. You never pick one by name.
 
-Six commands. That's the job. Same six stages every time: Land, Discover, Plan, Ship, Outcome, Close.
+Full detail: [docs/skills-reference.md](docs/skills-reference.md).
 
-| What you're doing | Type this | Remember |
-|-------------------|-----------|----------|
-| First days. Get the brief. Name who signs. | `/brief` | Who signs |
-| The brief they handed you may not be the real job. | `/discover` | Brief vs real job |
-| Sequence from done, not from the ticket. | `/plan` | Back from done |
-| Prove it on their staging, then go live. | `/ship` | Their staging then live |
-| What you promised, what you measured, who accepted. | `/outcome` | Promised, measured, accepted |
-| Hand it over. They run it without you. | `/close` | They run it |
+### Land - Engage
 
-After your first loop, same `@fde`: `/debrief` (notes into the record), `/prep` (one page before you walk in), `/trust` (process gap, or they stopped trusting you), `/receipts` (a dated line, or it did not happen). `/readout` is the Friday page for the sponsor; it is not a seventh stage.
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [land](skills/fde/references/land.md) | Interrogate the brief | New client, first meeting, just got the brief |
+| [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
+| [who-decides](skills/fde/references/who-decides.md) | Map decision rights | Need to know who matters |
+| [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
+| [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
 
-You can also just say it in the chat: naming a client, a POC, changing their checkout, going live, asking what was agreed. A typo in a repo that isn't a client job can skip this. Named client, POC, go-live cannot.
+### Discover - Diagnose
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [discover](skills/fde/references/discover.md) | Frame the problem | Brief feels wrong, shadow processes |
+| [test-assumptions](skills/fde/references/test-assumptions.md) | Test assumptions | Brief feels too neat |
+| [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
+| [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
+
+### Plan - Align
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
+| [business-case](skills/fde/references/business-case.md) | Build the business case | Defend budget or timeline |
+| [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
+| [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
+
+### Ship - Deliver
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [ship](skills/fde/references/ship.md) | Deliver the increment | Building, updating, or going live |
+| [what-breaks](skills/fde/references/what-breaks.md) | Assess impact | Touching shared infrastructure |
+| [rescue](skills/fde/references/rescue.md) | Resolve the incident | Down, or they went quiet |
+| [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
+| [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
+
+### Outcome - Realize
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [readout](skills/fde/references/readout.md) | Report the outcome | Friday, sponsor update |
+| [demo-prep](skills/fde/references/demo-prep.md) | Prepare the demo | Demo or exec walkthrough |
+| [debrief](skills/fde/references/debrief.md) | Capture the meeting | Just left a meeting |
+| [board-memo](skills/fde/references/board-memo.md) | Brief the board | Justify continued investment |
+| [dashboard](skills/fde/references/dashboard.md) | View the portfolio | All my customers |
+| [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
+| [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
+
+### Close - Transfer
+
+| Skill | What it does | Use when |
+|--------|--------------|----------|
+| [close](skills/fde/references/close.md) | Transfer operations | Wrapping up |
+| [runbook](skills/fde/references/runbook.md) | Write the runbook | They must operate without you |
+| [switch-clients](skills/fde/references/switch-clients.md) | Switch engagements | 2+ clients |
+| [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
+| [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
+
+Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md) · [eval-pack](skills/fde/references/eval-pack.md)
+
+Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mcp/recipes/)
 
 ---
 
 ## How Skills Work
 
-One `@fde`. One file per situation. One folder per client.
+One skill. One reference file per situation. One folder per client.
 
 ```
-  "@fde this is Acme"          creates ~/fde-engagements/<client>/.fde/
-  /brief  or  English          the AI coding agent loads skills/fde/SKILL.md
+  /brief   or   "@fde this is Acme"
+           │
+           ▼
+  skills/fde/SKILL.md          hosts load this one file
            │  routes. you never pick a skill by name
            ▼
-  references/<one>.md          one skill, then stop
+  references/land.md           one skill, then stop
            │
            ▼
   fde CLI (local)              dates, gates, redacts. no network
@@ -106,13 +187,91 @@ One `@fde`. One file per situation. One folder per client.
   ~/fde-engagements/<client>/.fde/
 ```
 
-**A dated line, or it did not happen.** Promised → measured → accepted. If it is not in `.fde/`, it is not on the record.
+**One skill routes.** Hosts load `@fde`. It reads the situation and opens one `references/*.md`. Slash commands and English both land here. You never pick a skill by name.
 
-**Confirm, then it is written.** The CLI stays on your laptop: git and files, no network. The AI coding agent runs the command. You say yes. Then it is in the folder.
+**Evidence, not memory.** Promised → measured → accepted. A dated line in `.fde/`, or it did not happen. Nothing is done on vibes.
 
-**The record is on your laptop.** Change hosts, install `@fde` on the new one, keep talking. The notes are not inside any vendor.
+**Confirm before write.** Local CLI: git and files, no network. `.fde/` on your laptop. The AI coding agent runs the command. You confirm. Then it is on the record.
 
-One skill hosts load: `skills/fde/SKILL.md`. It opens one file in `skills/fde/references/` and stops. Slash commands live in `.claude/commands/`. The local CLI is `bin/fde.js` (git + files, no network). Layout for contributors: [docs/REPO_LAYOUT.md](docs/REPO_LAYOUT.md).
+**Progressive disclosure.** `SKILL.md` is the entry. One skill file loads when routed. Writes and status cost zero model tokens.
+
+Change hosts, install `@fde` on the new one, bind if needed, keep talking. The record is not inside any vendor.
+
+---
+
+## Project Structure
+
+```
+fdeops/
+├── skills/fde/                            # the one skill hosts load
+│   ├── SKILL.md                           #   router
+│   └── references/                        #   30 skills + overlays (you never pick)
+│       ├── land.md                        #   Land
+│       ├── audit.md
+│       ├── who-decides.md
+│       ├── earn-trust.md
+│       ├── hold-scope.md
+│       ├── discover.md                    #   Discover
+│       ├── test-assumptions.md
+│       ├── score-use-cases.md
+│       ├── poc.md
+│       ├── plan.md                        #   Plan
+│       ├── business-case.md
+│       ├── three-options.md
+│       ├── pick-three.md
+│       ├── ship.md                        #   Ship
+│       ├── what-breaks.md
+│       ├── rescue.md
+│       ├── review.md
+│       ├── rollback.md
+│       ├── readout.md                      #   Outcome
+│       ├── demo-prep.md
+│       ├── debrief.md
+│       ├── board-memo.md
+│       ├── dashboard.md
+│       ├── ingest.md
+│       ├── connect.md
+│       ├── close.md                       #   Close
+│       ├── runbook.md
+│       ├── switch-clients.md
+│       ├── encode-pattern.md
+│       ├── red-team.md
+│       ├── ai.md                          #   overlays (on signal)
+│       ├── artifacts.md
+│       ├── eval-pack.md
+│       ├── fintech.md
+│       ├── healthcare.md
+│       └── gov.md
+├── .claude/commands/                      # slash commands (each loads @fde)
+│   ├── brief.md
+│   ├── discover.md
+│   ├── plan.md
+│   ├── ship.md
+│   ├── outcome.md
+│   ├── close.md
+│   ├── trust.md
+│   ├── receipts.md
+│   ├── debrief.md
+│   ├── prep.md
+│   └── readout.md
+├── .claude-plugin/                        # Claude Code marketplace
+├── bin/                                   # local CLI: git + files, no network
+├── hooks/                                 # session-start / session-stop / pre-compact
+├── adapters/                              # Cursor, Gemini, Copilot, Codex pointers
+├── templates/.fde/                        # memory files created on bind
+├── examples/                              # fictional walkthroughs
+├── mcp/                                   # optional ingest + source recipes
+├── evals/                                 # routing checks
+└── docs/                                  # usage, schema, install
+```
+
+---
+
+## Why FDEOps?
+
+AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
+
+FDEOps is the catalog you take on site. One `@fde` skill runs the embed from discovery to signed outcome: POC, their codebase, go-live, eval when a model judges, promised → measured → accepted. A local CLI dates every decision. `.fde/` is markdown on your laptop. You confirm; then it is on the record.
 
 ---
 
@@ -135,111 +294,29 @@ Schema: [docs/schema.md](docs/schema.md). Local HTML: `npx fdeops dashboard`.
 
 ## Who this is for
 
-You sit with a customer's team. An AI coding agent writes in their repo. You need a record of the brief, who can say yes, what went live, and whether they signed off.
+You embed with a customer and an AI coding agent. Take this on the ground. Discovery through signed outcome lives in `@fde`. One `.fde/` per client so they do not blur.
 
-If you ship your own company's product from HQ, with no customer team that has to run it after you leave, you do not need this kit.
+If you only write code in your own repo with no client record to defend, you do not need this kit.
 
 ---
 
 ## Your data stays yours
 
-The **CLI** is local: git + files, no network, no telemetry. The **host model** sees `.fde/` the agent loads (usually a bounded `context.md`) and any client code you open. It must not see `<private>` blocks  - redacted from CLI, dashboard, and hooks; do not paste them or open them with file tools. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
+Local only - `git` + files, no network, no telemetry. Plain markdown. The model sees client code only when you point the AI coding agent at it. `<private>` is redacted from CLI, dashboard, and hooks. Nothing is written until you confirm. `~/fde-engagements` is in `$HOME`; iCloud/Dropbox is an NDA incident waiting.
 
 [PRIVACY.md](PRIVACY.md) · [SECURITY.md](SECURITY.md)
 
 ---
 
-## The rest of the kit
-
-The six commands above are what you type. Under the hood there are more checklists  - access, rollback, runbook, sponsor update  - and `@fde` opens one when the situation matches. You do not pick them by name.
-
-Thirty situations, grouped by stage. Not prompts - each one has steps, a file it writes, and a checkpoint with you. Full detail: [docs/skills-reference.md](docs/skills-reference.md).
-
-### Land
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [land](skills/fde/references/land.md) | Interrogate the brief | New client, first meeting, just got the brief |
-| [audit](skills/fde/references/audit.md) | Verify inherited claims | Taking over, previous consultant left |
-| [who-decides](skills/fde/references/who-decides.md) | Map decision rights | Need to know who matters |
-| [earn-trust](skills/fde/references/earn-trust.md) | Earn access | Need access or credibility |
-| [hold-scope](skills/fde/references/hold-scope.md) | Hold scope | "Also can you…", timeline unchanged |
-
-### Discover
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [discover](skills/fde/references/discover.md) | Frame the problem | Brief feels wrong, shadow processes |
-| [test-assumptions](skills/fde/references/test-assumptions.md) | Test assumptions | Brief feels too neat |
-| [score-use-cases](skills/fde/references/score-use-cases.md) | Score use cases | Everything is P0 |
-| [poc](skills/fde/references/poc.md) | Validate the solution | POC, spike, need to de-risk |
-
-### Plan
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [plan](skills/fde/references/plan.md) | Sequence the work | What order, what is done |
-| [business-case](skills/fde/references/business-case.md) | Build the business case | Defend budget or timeline |
-| [three-options](skills/fde/references/three-options.md) | Generate options | "What should we do?" |
-| [pick-three](skills/fde/references/pick-three.md) | Prioritize three | Everything is urgent |
-
-### Ship
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [ship](skills/fde/references/ship.md) | Deliver the increment | Building, updating, or going live |
-| [what-breaks](skills/fde/references/what-breaks.md) | Assess impact | Touching shared infrastructure |
-| [rescue](skills/fde/references/rescue.md) | Resolve the incident | Down, or they went quiet |
-| [review](skills/fde/references/review.md) | Review the change | Before merge, scope creep |
-| [rollback](skills/fde/references/rollback.md) | Rehearse rollback | "We can always revert" |
-
-### Outcome
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [readout](skills/fde/references/readout.md) | Report the outcome | Friday, sponsor update |
-| [demo-prep](skills/fde/references/demo-prep.md) | Prepare the demo | Demo or exec walkthrough |
-| [debrief](skills/fde/references/debrief.md) | Capture the meeting | Just left a meeting |
-| [board-memo](skills/fde/references/board-memo.md) | Brief the board | Justify continued investment |
-| [dashboard](skills/fde/references/dashboard.md) | View the portfolio | All my customers |
-| [ingest](skills/fde/references/ingest.md) | Ingest sources | Transcript, Notion, Slack |
-| [connect](skills/fde/references/connect.md) | Connect a source | Connect Granola |
-
-### Close
-
-| Skill | What it does | Use when |
-|--------|--------------|----------|
-| [close](skills/fde/references/close.md) | Transfer operations | Wrapping up |
-| [runbook](skills/fde/references/runbook.md) | Write the runbook | They must operate without you |
-| [switch-clients](skills/fde/references/switch-clients.md) | Switch engagements | 2+ clients |
-| [encode-pattern](skills/fde/references/encode-pattern.md) | Encode the pattern | It will apply again |
-| [red-team](skills/fde/references/red-team.md) | Challenge the plan | "Poke holes in this" |
-
-Overlays (on signal, not on request): [ai](skills/fde/references/ai.md) · [artifacts](skills/fde/references/artifacts.md) · [fintech](skills/fde/references/fintech.md) · [healthcare](skills/fde/references/healthcare.md) · [gov](skills/fde/references/gov.md). AI companion (not a sixth overlay): [eval-pack](skills/fde/references/eval-pack.md).
-
-Optional pull: you add the source MCP; we **pull** on request. [mcp/recipes/](mcp/recipes/)
-
----
-
-## Why FDEOps?
-
-AI coding agents are built for a repo, not for a client. Left alone they skip who signs done, whether the brief is true, and whether anyone accepted the number. Monday morning they start from the ticket again.
-
-This is the kit you take on site. `@fde` runs the client work around the code: the brief, their codebase, go-live, promised → measured → accepted. A local command dates every decision. The notes are markdown on your laptop. You confirm; then it is on the record.
-
----
-
 ## Principles
 
-- **Who signs**  - name them in the first days
-- **Brief vs real job**  - check the floor, not only the slide
-- **Back from done**  - sequence from signed-off, not from the ticket
-- **Their staging then live**  - prove it where they operate, then go live
-- **Promised, measured, accepted**  - a number nobody signed is claimed, not delivered
-- **They run it**  - if they cannot operate it without you, you are not done
-- **A dated line, or it did not happen**  - these files get defended in the room
-- **One customer, one folder**  - context never bleeds
-- **The kit says what to check. You still decide.**
+- **Same six stages** - any scale, new or existing, any industry. Extra notes for your sector
+- **The write-up is the record** - doing the work and writing it down are one action
+- **Ground loop** - name the change, characterise their code, prove it on their staging, go live, log the outcome
+- **Skills, not autonomy** - the kit says what to check; judgment stays yours
+- **Check the brief is the real job** - discover before building the wrong thing
+- **Evidence on every claim** - these files get defended in the room
+- **One customer, one folder** - context never bleeds
 
 ---
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,8 +1,10 @@
-# Usage
+# fdeops usage guide
 
-`@fde` is what you type. `.fde/` is the client folder on your laptop. Start at the README: install, name the client, then the command table.
+**What it is:** the engagement layer for **you** (human FDE) + your **AI coding agent** - `@fde` routes skills; `.fde/` holds client-scoped memory on your machine.
 
 **Terminology:** [README § Who this is for](../README.md#who-this-is-for) - **"agent" = AI software, not a human.**
+
+**Start here:** [README](../README.md) - Commands (lifecycle) → All 30 Skills (catalog) → How Skills Work.
 
 <p align="center"><img alt="A recorded fdeops session: kickoff notes routed into dated memory after you confirm" src="../media/session.gif" width="900" /></p>
 
@@ -14,8 +16,8 @@ Day-to-day reference below.
 
 ## New here? (5 minutes)
 
-1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme`. That creates `~/fde-engagements/acme/.fde/`. Confirm one write. Terminal fallback: `fde resume --init <client-name>`
-2. Read **Quick Start** and **Commands** in the README
+1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme` - the AI coding agent binds. That creates `~/fde-engagements/acme/.fde/`. Terminal fallback: `fde resume --init <client-name>`
+2. Read **Commands**, **All 30 Skills**, and **Who this is for** in the README
 3. Skim [examples/garvey-payments/](../examples/garvey-payments/) Day 1 → Day 10
 4. Optional recon, zero config: `npx fdeops scan` in a repo
 5. Then: `@fde` + the actual situation (brief wrong, they went quiet, when did we agree, what's the outcome)
@@ -28,10 +30,10 @@ You do not pick a skill. **`@fde` routes the AI and loads the right one.**
 
 | You are… | Example message to the **AI coding agent** |
 |----------|---------------------------------------------|
-| Starting | `@fde this is Acme` then `@fde First meeting tomorrow. Brief says: …` |
+| Starting | `@fde this is Acme` (binds) then `@fde New embed. First meeting tomorrow. Brief says: …` |
 | Unsure of real problem | `@fde Workshop done. Ops says they use a spreadsheet nightly.` |
 | Just out of a meeting | `@fde Debrief: <paste your raw notes>` |
-| Ready to code | `@fde` Change in module X. Prove it on their staging. Going live after Marco signs. |
+| Ready to code | `@fde` One change they can see by Friday in module X. Going live after Marco signs staging. |
 | Production broken | `@fde API 500 since 2pm deploy.` |
 | Sponsor went quiet | `@fde VP stopped replying; still building old scope.` |
 | Handing off | `@fde Engagement ends Friday. Need handoff doc.` |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -4,7 +4,7 @@
 
 **Terminology:** [README § Who this is for](../README.md#who-this-is-for) - **"agent" = AI software, not a human.**
 
-**Start here:** [README](../README.md) - Commands (lifecycle) → All 30 Skills (catalog) → How Skills Work.
+**Start here:** [README](../README.md) - Quick Start → Commands → All 30 Skills.
 
 <p align="center"><img alt="A recorded fdeops session: kickoff notes routed into dated memory after you confirm" src="../media/session.gif" width="900" /></p>
 
@@ -16,7 +16,7 @@ Day-to-day reference below.
 
 ## New here? (5 minutes)
 
-1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is Acme` - the AI coding agent binds. That creates `~/fde-engagements/acme/.fde/`. Terminal fallback: `fde resume --init <client-name>`
+1. Install from the README (plugin or `npx skills add suboss87/fdeops --skill fde`), then in chat: `@fde this is client01`. That creates `~/fde-engagements/client01/.fde/`. Terminal fallback: `fde resume --init <client-name>`
 2. Read **Commands**, **All 30 Skills**, and **Who this is for** in the README
 3. Skim [examples/garvey-payments/](../examples/garvey-payments/) Day 1 → Day 10
 4. Optional recon, zero config: `npx fdeops scan` in a repo
@@ -30,7 +30,7 @@ You do not pick a skill. **`@fde` routes the AI and loads the right one.**
 
 | You are… | Example message to the **AI coding agent** |
 |----------|---------------------------------------------|
-| Starting | `@fde this is Acme` (binds) then `@fde New embed. First meeting tomorrow. Brief says: …` |
+| Starting | `@fde this is client01` then `@fde First meeting tomorrow. Brief says: …` |
 | Unsure of real problem | `@fde Workshop done. Ops says they use a spreadsheet nightly.` |
 | Just out of a meeting | `@fde Debrief: <paste your raw notes>` |
 | Ready to code | `@fde` One change they can see by Friday in module X. Going live after Marco signs staging. |
@@ -68,7 +68,7 @@ When a transcript or email is too large to paste, or lives in Granola/Slack/Noti
 
 **Daily without MCP:** paste to `@fde` or `fde ingest stage` a file. That is the complete product.
 
-**Optional pull:** `@fde I want to connect Granola` (or Slack / Notion). You add **that** source MCP; FDEOps does not bundle it and does not push back. Then `@fde pull today's Acme transcript`. The agent fetches text and runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply).
+**Optional pull:** `@fde I want to connect Granola` (or Slack / Notion). You add **that** source MCP; FDEOps does not bundle it and does not push back. Then `@fde pull today's client01 transcript`. The agent fetches text and runs `fde ingest` in this bound workspace (stage → propose → you confirm → apply).
 
 **Directly (zero tokens, you already have the file):**
 
@@ -99,7 +99,7 @@ That writes a `[signal:amber]` token into `stakeholders.md`. The **latest dated 
 
 **You do not need these for daily work.** Chat with `@fde`; the agent runs them. Use the terminal for one-time setup, air-gapped machines, or automation.
 
-**Humans - once / occasional** (prefer chat: `@fde this is Acme`):
+**Humans - once / occasional** (prefer chat: `@fde this is client01`):
 
 ```bash
 npx fdeops resume --init <client>   # fallback: create + bind this workspace from the terminal

--- a/docs/install.md
+++ b/docs/install.md
@@ -19,7 +19,7 @@ npx skills add suboss87/fdeops --skill fde
 Then one chat - name the client. That creates `~/fde-engagements/<client>/.fde/`. You never type the CLI:
 
 ```text
-@fde this is Acme
+@fde this is client01
 ```
 
 Claude Code (hooks before you type; slash commands on the README map):
@@ -50,7 +50,7 @@ Type `@fde` in the AI chat and start working.
 | Claude Code | `/plugin install fdeops@fdeops`  - skill, slash commands, hooks. CLI via `npx fdeops …`. `node bin/install.js` only if you want a disk copy under `~/.claude/` |
 | Cursor / other agents | `npx skills add suboss87/fdeops --skill fde`, then `npx fdeops adapters <client-workspace>` |
 | Air-gap | `git clone … && node bin/install.js` |
-| Bind (any host, after the skill exists) | Chat: `@fde this is Acme`. Terminal fallback: `npx fdeops resume --init <name>` |
+| Bind (any host, after the skill exists) | Chat: `@fde this is client01`. Terminal fallback: `npx fdeops resume --init <name>` |
 | Quick trial, no install | `npx fdeops scan` (uses **fdeops v3.0.0 or later from npm**) |
 
 ---

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -20,7 +20,7 @@ After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same rou
 |------|---------|------------|
 | `context.md` | Compact state; loaded every session; dated debrief blocks | every stage + the `session-stop` hook (auto-capture) + `fde debrief` |
 | `brief.md` | Stated problem (hypothesis) | land |
-| `assumptions.md` | Brief claims under test: OPEN / CONFIRMED / DISPROVED | land (seed), test-assumptions, discover |
+| `assumptions.md` | Brief claims under test: Kind FACT / CONVENTION / UNKNOWN; OPEN / CONFIRMED / DISPROVED | land (seed), test-assumptions, discover |
 | `success.md` | Definition of done + primary value bucket + out of scope | land |
 | `stakeholders.md` | Champions, resistance, `[signal:green\|amber\|red]` trust tokens | land (updated continuously), `fde log contact --signal`, `fde debrief` |
 | `trust-profile.md` | Sacred data, AI policy (`<private>` tags) | land, overlays |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -14,16 +14,16 @@ The full map is below; per-skill details live in [skills-reference.md](./skills-
 
 | Stage | Skills | What it covers |
 |--------|--------|---------------|
-| **Land** | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
-| **Discover** | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
-| **Plan** | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
-| **Ship** | ship, what-breaks, rescue, review, rollback | Visible on their staging, then go-live |
-| **Outcome** | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
-| **Close** | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
+| **Land** (Engage) | land, audit, who-decides, earn-trust, hold-scope | First days: access, credibility, scope |
+| **Discover** (Diagnose) | discover, test-assumptions, score-use-cases, poc | Finding the real problem behind the brief |
+| **Plan** (Align) | plan, business-case, three-options, pick-three | Sequencing work, getting sponsor alignment |
+| **Ship** (Deliver) | ship, what-breaks, rescue, review, rollback | Visible on their staging, then go-live |
+| **Outcome** (Realize) | readout, demo-prep, debrief, board-memo, dashboard, ingest, connect | Get the number accepted; dated receipts |
+| **Close** (Transfer) | close, runbook, switch-clients, encode-pattern, red-team | They can run it without you |
 
 Each skill is a workflow, not a prompt: the thinking the agent does, the artifact it drafts into `.fde/` under `~/fde-engagements/`, and the checkpoint with the human FDE.
 
-Brief interrogation, anti-invention, and pre-blast live inside land, discover, ship, and red-team. They are not extra commands.
+**Field judgment (blended into skills, not a separate pack):** land/discover use **brief interrogation** when the brief is thin; `@fde` enforces **anti-invention gates**; ship/red-team run a **pre-blast challenge** before irreversible moves.
 
 ## 5 overlays (activate automatically on signal)
 

--- a/examples/garvey-payments/.fde/assumptions.md
+++ b/examples/garvey-payments/.fde/assumptions.md
@@ -1,7 +1,7 @@
 # Assumptions
 
-| # | Assumption | Blast radius | How we test | Status | Evidence |
-|---|------------|--------------|-------------|--------|----------|
-| 1 | EU payment failures are an API bug | CRITICAL | Workshop with ops + inspect nightly process | DISPROVED | ops lead Day 5: Excel reprocess is the real workflow |
-| 2 | Finance will drop Excel if ingest retries work | LOAD-BEARING | One-night trial without Excel after staging demo | TESTING | CTO + finance agreed trial (delivery 2026-05-30) |
-| 3 | Q3 audit needs full API rewrite | CRITICAL | Map audit controls to ingest + reconciliation visibility | DISPROVED | thin ingest + visibility covers the control; rewrite out of scope |
+| # | Assumption | Kind | Blast radius | How we test | Status | Evidence |
+|---|------------|------|--------------|-------------|--------|----------|
+| 1 | EU payment failures are an API bug | CONVENTION | CRITICAL | Workshop with ops + inspect nightly process | DISPROVED | ops lead Day 5: Excel reprocess is the real workflow |
+| 2 | Finance will drop Excel if ingest retries work | UNKNOWN | LOAD-BEARING | One-night trial without Excel after staging demo | TESTING | CTO + finance agreed trial (delivery 2026-05-30) |
+| 3 | Q3 audit needs full API rewrite | CONVENTION | CRITICAL | Map audit controls to ingest + reconciliation visibility | DISPROVED | thin ingest + visibility covers the control; rewrite out of scope |

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -129,8 +129,8 @@ Work names (engage, diagnose, align, deliver, realize, transfer) are the same ma
 
 | You hear | Skill | Reference |
 |----------|-------|-----------|
-| Diagnose, don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate, catalog the data | discover | `references/discover.md` |
-| The brief feels too neat, assumptions untested, "we just need…", test assumptions | test-assumptions | `references/test-assumptions.md` |
+| Diagnose, don't know the real problem, brief feels wrong, shadow processes, frame discovery, understand the problem space, data not ready, data estate, catalog the data, parts of the problem, decompose | discover | `references/discover.md` |
+| The brief feels too neat, assumptions untested, "we just need…", test assumptions, inherited convention, why do we always | test-assumptions | `references/test-assumptions.md` |
 | Multiple use cases competing, "we want to do everything", score use cases | score-use-cases | `references/score-use-cases.md` |
 | Need to validate a direction, prototype, demo to de-risk, **POC**, spike, killer assumption, validate the solution, build prototype | poc | `references/poc.md` |
 
@@ -140,7 +140,7 @@ Work names (engage, diagnose, align, deliver, realize, transfer) are the same ma
 |----------|-------|-----------|
 | Align, break this down, what order, sequence the build, plan the roadmap, create user stories, write the tasks | plan | `references/plan.md` |
 | Sponsor needs justification, need to defend budget or timeline, build the business case | business-case | `references/business-case.md` |
-| Significant decision, multiple approaches, "what should we do?", generate solutions, generate options | three-options | `references/three-options.md` |
+| Significant decision, multiple approaches, "what should we do?", generate solutions, generate options, not the playbook, from the surviving facts | three-options | `references/three-options.md` |
 | 20 things are "urgent," need to pick the 3 that matter, prioritize three | pick-three | `references/pick-three.md` |
 
 ### Ship

--- a/skills/fde/references/discover.md
+++ b/skills/fde/references/discover.md
@@ -54,6 +54,16 @@ Tests on **Question** - rewrite until all five hold:
 
 Cannot write the Question → keep interrogating. Do not `fde scan`. Every later output of this phase aims at that Question. Sub-questions go to the operating map or `assumptions.md`, not into the Question.
 
+## Parts of the problem (decompose only)
+
+After the Question is locked, and **before** `fde scan` or any option: write what the problem is made of. No advice, no playbook, no solution.
+
+If the stated brief hides a deeper job, name that deeper job in one sentence and **wait**. Do not silently replace their problem with yours.
+
+In `terrain.md` under `## Parts`, list the smallest useful pieces that still change what you examine next. Typical cuts: people, process step, system, data, time, cost. For each piece: what it contains, and how it connects to the Question. Stop when a further split would not change where you dig.
+
+Do not mark pieces as facts or assumptions here. That is `test-assumptions`. Do not assemble options here. That is `three-options`.
+
 ## Method - part 1: the codebase (you do this work)
 
 **First move: `fde scan`** - it runs everything below deterministically in seconds (churn×tests, "temporary" archaeology, AI components, secrets redacted, previous attempts). Your job is then **interpretation**: read its output against the brief, follow the hotspots into the code, and connect the technical findings to the human signals in part 2.

--- a/skills/fde/references/land.md
+++ b/skills/fde/references/land.md
@@ -99,12 +99,12 @@ If `stakeholders.md` already has a `## Signal history` section (it does from the
 
 **`trust-profile.md`** - sacred data (`<private>` tagged), fears heard, AI policy, approval chain. Sensitive: skip for status reads; use CLI/redacted surfaces; never paste raw `<private>` into prompts or subagents.
 
-**`assumptions.md`** - seed every unverified claim from the brief (and the day-1 hypothesis) as rows with blast radius CRITICAL / LOAD-BEARING / CONVENIENCE and status `OPEN`. Do not wait for test-assumptions - land makes the register exist. Example:
+**`assumptions.md`** - seed every unverified claim from the brief (and the day-1 hypothesis) as rows with Kind `UNKNOWN` (or `CONVENTION` if they said "we always"), blast radius CRITICAL / LOAD-BEARING / CONVENIENCE, and status `OPEN`. Do not wait for test-assumptions - land makes the register exist. Example:
 
 ```markdown
-| # | Assumption | Blast radius | How we test | Status | Evidence |
-|---|------------|--------------|-------------|--------|----------|
-| 1 | <claim from brief> | CRITICAL | <cheapest falsifying test> | OPEN | (stated, unverified) |
+| # | Assumption | Kind | Blast radius | How we test | Status | Evidence |
+|---|------------|------|--------------|-------------|--------|----------|
+| 1 | <claim from brief> | UNKNOWN | CRITICAL | <cheapest falsifying test> | OPEN | (stated, unverified) |
 ```
 
 One falsifiable hypothesis about the real problem also goes at the bottom of `brief.md` - discover / test-assumptions will test it.

--- a/skills/fde/references/poc.md
+++ b/skills/fde/references/poc.md
@@ -8,7 +8,9 @@ A green check on synthetic data is not a validated solution. The person who can 
 
 ## Method (you do this work)
 
-**0. Name the killer assumption.** With the FDE: "What's the belief that kills the project if it's wrong?" Prototype **that** - not the pretty demo.
+**0. Name the killer assumption.** With the FDE: "What's the belief that kills the project if it's wrong?" Prototype **that** - not the pretty demo. If `three-options` just ran: the cheapest test is for the recommended option first, unless they pick another.
+
+**0b. Pass / fail before you build.** For the test you will run, write three lines in `prototype-log.md` first: what you will actually do (who you talk to, what you show, on whose screen); the result that **kills** this option; the result that keeps it alive. What you would learn either way. If every option's test would fail, name which `assumptions.md` block to reopen - do not invent a fourth playbook.
 
 **1. Pick by score when several use cases compete.** Use the scoring model from `discover.md` - (Value × Data readiness) / Complexity. If discover already scored, reuse; never re-score independently.
 
@@ -37,6 +39,7 @@ Tell the FDE: did the riskiest assumption hold · what the customer's reaction a
 ## Principles
 
 - Speed of learning beats code quality. Never more than a day.
+- Write pass/fail before you build. A demo with no kill line is a show.
 - Show it rough. Polish misleads.
 - Prototype the killer assumption, not the demo.
 - Kill fast; log the learning.

--- a/skills/fde/references/runbook.md
+++ b/skills/fde/references/runbook.md
@@ -134,7 +134,7 @@ If you see 2+: accelerate the handoff immediately. The longer you stay past usef
 
 - The goal of every engagement is to make yourself replaceable.
 - The 2am document is the real handoff - everything else supports it.
-- Knowledge transfer is four sessions, not a doc dump. The floor drill is the one that matters.
+- Knowledge transfer is four sessions, not a doc dump. The floor drill is the named operator completing Tuesday's real job from the 2am doc, hands off. If they cannot, do not close.
 - A confidence score below 3.5 means the handoff isn't done.
 - The successor brief gets the next FDE operational in one hour or it's too long.
 - Clean exit: no personal credentials left behind, ever.

--- a/skills/fde/references/test-assumptions.md
+++ b/skills/fde/references/test-assumptions.md
@@ -8,7 +8,7 @@ Every engagement is built on assumptions. Most are invisible until they're wrong
 
 ## Method (you do this work)
 
-**1. Extract the assumptions.** Read `brief.md` and `reality.md` line by line. Every statement that isn't backed by evidence is an assumption. Common hiding places:
+**1. Extract the assumptions.** Read `brief.md`, `reality.md`, and `terrain.md` `## Parts` line by line. Every statement that isn't backed by evidence is an assumption. Treat every "obvious" block as a convention until a receipt proves it. Common hiding places:
 
 | Where assumptions hide | Example | The real question |
 |----------------------|---------|-------------------|
@@ -19,7 +19,17 @@ Every engagement is built on assumptions. Most are invisible until they're wrong
 | **The data claim** | "We have good data for this" | Defined how? Validated when? By whom? Sample checked? |
 | **The "just"** | "We just need to add a feature" | On what system? With what dependencies? What breaks? |
 
-**2. Classify each assumption by blast radius:**
+**2. Kind first, then blast radius.** For each row, classify:
+
+| Kind | Meaning |
+|------|---------|
+| **FACT** | A dated receipt, a measurement, or the repo. You can point at it. |
+| **CONVENTION** | How they have always done it. The playbook. "We just…" |
+| **UNKNOWN** | No evidence either way. |
+
+Order the list load-bearing first. For each CONVENTION or UNKNOWN, one line: what breaks if it is wrong, and what opens if you **invert** it (stop obeying it). A FACT with no receipt is UNKNOWN - do not promote it to protect the brief.
+
+Then classify blast radius:
 
 ```
 CRITICAL - if wrong, the engagement fails or the approach changes fundamentally
@@ -55,11 +65,11 @@ Evidence first, then the question. Let them reach the conclusion.
 **`assumptions.md`** - this IS the register (create if land did not). Keep one live table; do not only bury results in `reality.md`:
 
 ```markdown
-| # | Assumption | Blast radius | How we test | Status | Evidence |
-|---|------------|--------------|-------------|--------|----------|
-| 1 | API is the bottleneck | CRITICAL | p95 instrumentation 24h | DISPROVED | 80% wait in DB layer (Day N) |
-| 2 | Team will adopt new tool | LOAD-BEARING | 3 individual interviews | CONFIRMED | 2/3 describe a use case unprompted |
-| 3 | Data clean enough for ML | CRITICAL | 200-record sample | PARTIAL → OPEN follow-up | 12% nulls on key field; cleaning task added |
+| # | Assumption | Kind | Blast radius | How we test | Status | Evidence |
+|---|------------|------|--------------|-------------|--------|----------|
+| 1 | API is the bottleneck | CONVENTION | CRITICAL | p95 instrumentation 24h | DISPROVED | 80% wait in DB layer (Day N) |
+| 2 | Team will adopt new tool | UNKNOWN | LOAD-BEARING | 3 individual interviews | CONFIRMED | 2/3 describe a use case unprompted |
+| 3 | Data clean enough for ML | UNKNOWN | CRITICAL | 200-record sample | PARTIAL → OPEN follow-up | 12% nulls on key field; cleaning task added |
 ```
 
 Status values: `OPEN` · `TESTING` · `CONFIRMED` · `DISPROVED` · `PARKED`. A CRITICAL row still `OPEN` blocks plan.
@@ -85,6 +95,7 @@ Result: acked in 40 minutes, by Marco, not finance. Assumption DISPROVED, and th
 ## Principles
 
 - Every "just" is an assumption. Every "should" is an assumption.
+- Kind before blast radius. A FACT with no receipt is UNKNOWN.
 - Kill the riskiest, cheapest-to-test assumption first.
 - Evidence first, then the question. Let the customer reach the conclusion.
 - A brief with zero disproved assumptions wasn't audited - it was accepted.

--- a/skills/fde/references/three-options.md
+++ b/skills/fde/references/three-options.md
@@ -2,7 +2,7 @@
 
 **Enter when:** a significant technical or strategic decision needs to be made, the FDE is asked "what should we do?", the team is stuck between approaches, or a fork in the engagement requires the sponsor's input.
 
-**Read first:** `reality.md`, `terrain.md`, `success.md`, `context.md`. Load `business-case.md` if the decision has cost implications.
+**Read first:** `reality.md`, `terrain.md`, `assumptions.md`, `success.md`, `context.md`. Load `business-case.md` if the decision has cost implications.
 
 One option is a request for trust. Two options is a false choice. Three options is a conversation between professionals. The FDE who presents three genuine options earns the decision-maker's respect - and their protection when things get hard.
 
@@ -12,24 +12,30 @@ One option is a request for trust. Two options is a false choice. Three options 
 
 > "Decision: approach for the payment migration. Decided by: CTO. Needed by: Friday. Deferral cost: blocks the next sprint and delays the pilot by two weeks."
 
-**2. Generate three genuine options.** Not "good / medium / bad" - three approaches with real trade-offs:
+**2. Generate three genuine options from what survived.** Read `assumptions.md` (CONFIRMED / DISPROVED) and `terrain.md` `## Parts`. The playbook is unavailable. Assemble from those blocks only.
 
-| Option archetype | Description | When it fits |
-|-----------------|-------------|-------------|
-| **Conservative** | Lowest risk, smallest change, longest timeline | When trust is thin or the system is fragile |
-| **Pragmatic** | Balanced risk/reward, proven patterns, moderate timeline | When the team is competent and the deadline is real |
-| **Ambitious** | Highest reward, most change, highest risk | When the sponsor has appetite and the team has capacity |
+Not "good / medium / bad." Not three speeds of the same plan (Conservative / Pragmatic / Ambitious of one architecture). Three approaches that differ in **structure** - rearrange the same surviving parts.
 
-Each option must be one the FDE would genuinely recommend under different circumstances. If you can't defend an option, replace it - padding is visible.
+Each option must be one the FDE would genuinely recommend under different circumstances. If you cannot defend an option, replace it - padding is visible.
+
+For each option, name:
+- which surviving blocks it is built from
+- which CONVENTION it refuses to obey
+- its single biggest point of failure
+- any new building block, labelled as a new assumption (`UNKNOWN` in `assumptions.md`) - do not smuggle one in as a fact
+
+If all three are the same system at different risk levels, you wrote the playbook. Start over.
 
 **3. Structure each option identically.** Same dimensions, same format - so comparison is instant:
 
 ```markdown
-### Option A: <name> (Conservative)
+### Option A: <name>
+- **Blocks:** <which surviving assumptions / parts it is built from>
+- **Convention refused:** <the "we just…" it will not obey>
 - **What:** <the approach in one paragraph>
 - **Timeline:** <estimate with basis>
 - **Cost:** <effort, infrastructure, external>
-- **Risk:** <what could go wrong and the mitigation>
+- **Biggest failure:** <the single point that kills this option>
 - **Trade-off:** <what you give up by choosing this>
 - **Best when:** <the condition that makes this the right choice>
 ```
@@ -85,6 +91,7 @@ Recommendation: pragmatic, conditional - *if* Raj is on the design, otherwise sa
 ## Principles
 
 - Three options, never one. One option is a request for trust; three is a real decision.
+- Assemble from surviving blocks. Three speeds of the same plan is the playbook - start over.
 - Each option must be genuinely defensible - no straw men.
 - Same structure for each option. Comparison should take 30 seconds.
 - Recommend one. State why. Accept the override gracefully.

--- a/templates/.fde/assumptions.md
+++ b/templates/.fde/assumptions.md
@@ -2,9 +2,10 @@
 
 <!-- Brief claims that are not yet evidence. Land seeds; test-assumptions / discover update. -->
 
-| # | Assumption | Blast radius | How we test | Status | Evidence |
-|---|------------|--------------|-------------|--------|----------|
+| # | Assumption | Kind | Blast radius | How we test | Status | Evidence |
+|---|------------|------|--------------|-------------|--------|----------|
 
+**Kind:** `FACT` · `CONVENTION` · `UNKNOWN`  
 **Blast radius:** `CRITICAL` · `LOAD-BEARING` · `CONVENIENCE`  
 **Status:** `OPEN` · `TESTING` · `CONFIRMED` · `DISPROVED` · `PARKED`
 


### PR DESCRIPTION
## Why

PR #83 squash-merged without the catalog README restore. This lands that front door plus the first-principles beats so Main matches what we signed off.

## What changed

- README is Commands, All 30 Skills, How Skills Work, Project Structure. Hero stays the client work that gets you fired if you skip it.
- Discover: parts of the problem before scan (no solutions).
- Test-assumptions: Kind FACT / CONVENTION / UNKNOWN before blast radius.
- Three-options: assemble from surviving blocks, not three speeds of the same plan.
- POC: pass/fail lines before you build.

## Checks

- [x] `npm run check` passes
- [x] No client names, `.fde/` exports, credentials, or screenshots with real people


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/84" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->