### PR TITLE
3.22.0: skip is loud - signer routing, silent-commit check, examples pass doctor

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 3.22.0 - 2026-09-03
+
+Skip is loud. The CLI now catches the two things a stranger's first week showed it missing: the signer vanishing into a note, and code moving while the ledger stayed silent. Same six stages. Same 30 skills.
+
+- `debrief --smart`: "Priya signs off" becomes `signer: Priya` - fills **Stakeholder who signs off** in `success.md` and logs the contact. A second, different signer is kept beside the first, never overwritten. New `signer:` prefix in the vocabulary.
+- `doctor` (ship/close): commits in the bound client repo newer than the last dated `delivery.md` line → "code moved, ledger did not." Registry + git, local only.
+- `doctor`: open, owned risks mid-ship no longer fail; the gate is close.
+- Triage: a quoted risk is labelled `top risk:`, not `trust:`.
+- Examples: all three pass `fde doctor` (schema `reality.md`, value bucket, operating map, **Accepted by** column, full names in signal history). `npm run check` runs doctor on every example so they cannot rot.
+- `@fde` and `ship`: a coding pack may write the function; `@fde` owns done. Before-receipt captured before you change anything; open PRs checked; no this-turn receipt is a failed test.
+- README: keep the coding pack you already use, install this next to it. `npx fdeops scan` is the first thing on the page.
+
 ## 3.21.0 - 2026-09-01
 
 Same public map as 3.20: Commands, then All 30 Skills, then How Skills Work. Hero is hallway English. Six skills got harder field gates. Same six stages. Same 30 skills.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ You're on a customer site. The AI coding agent writes code in their repo. This k
 
 Notes stay on your laptop. Their repo stays theirs. You confirm before anything is written down.
 
+Keep the coding pack you already use. Install this next to it. FDEOps is the client work. The other pack writes the code.
+
 <img width="1536" height="1024" alt="fdeops" src="https://github.com/user-attachments/assets/2bcb8739-55ee-445d-8a1a-8b38433b7b58" />
 
 ---

--- a/bin/check.js
+++ b/bin/check.js
@@ -409,6 +409,28 @@ for (const f of exampleFiles) {
 }
 ok('examples walkthrough files')
 
+// The examples are the first .fde/ a newcomer reads. They must pass the kit's
+// own doctor, or the kit is telling people to do what its showcase does not.
+// Tolerated: things a frozen reference copy cannot have (an owner, a memory
+// git, a fresh trust signal).
+{
+  const { spawnSync } = require('child_process')
+  const tolerated = /no \.owner|not git-versioned|trust signal is STALE/
+  for (const ex of fs.readdirSync(path.join(root, 'examples'))) {
+    const eng = path.join(root, 'examples', ex, '.fde')
+    if (!fs.existsSync(eng)) continue
+    const r = spawnSync(process.execPath, [path.join(root, 'bin', 'fde.js'), 'doctor'], {
+      encoding: 'utf8',
+      env: { ...process.env, FDEOPS_ENGAGEMENT: eng, HOME: fs.mkdtempSync(path.join(require('os').tmpdir(), 'fdeops-check-')) },
+    })
+    const issues = (r.stdout || '').split('\n')
+      .map(l => l.match(/^\s+\d+\.\s+(.*)$/)).filter(Boolean).map(m => m[1])
+      .filter(i => !tolerated.test(i))
+    if (issues.length) fail(`examples/${ex} fails its own doctor:\n    - ${issues.join('\n    - ')}`)
+    else ok(`examples/${ex} passes fde doctor`)
+  }
+}
+
 if (fs.existsSync(path.join(root, 'tasks', 'plan.md'))) {
   fail('tasks/plan.md should not be in public tree (move to docs/internal)')
 }

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1515,14 +1515,20 @@ function smartProposeText(input) {
       out.push(`decision: ${bare.replace(/^decided:\s+/i, '')}`)
       continue
     }
-    if (/^(decision|risk|delivery|contact|next):\s*/i.test(bare)) {
-      let routed = bare.replace(/^(decision|risk|delivery|contact|next):\s*/i, (m, t) => `${t.toLowerCase()}: `)
+    if (/^(decision|risk|delivery|contact|next|signer):\s*/i.test(bare)) {
+      let routed = bare.replace(/^(decision|risk|delivery|contact|next|signer):\s*/i, (m, t) => `${t.toLowerCase()}: `)
       if (/^contact:/i.test(routed) && !/\[signal:(red|amber|green)\]/i.test(routed)) {
         const sig = inferContactSignal(routed)
         if (sig) routed = routed.replace(/\s*$/, ` [signal:${sig}]`)
       }
       out.push(routed)
       continue
+    }
+    // Sentence-level: a signer named mid-paragraph gets its own routed line and
+    // the original stays as context, so nothing is invented or lost.
+    for (const sentence of bare.split(/(?<=[.!?])\s+/)) {
+      const who = signerFromLine(sentence)
+      if (who) { out.push(`signer: ${who}`); break }
     }
     if (/^(next action|follow-?ups?|action items?|todo):\s*/i.test(bare) ||
         /\b(next action|walk in with|follow up with)\b/i.test(bare)) {
@@ -1547,6 +1553,44 @@ function smartProposeText(input) {
     }
   }
   return out.join('\n') + (out.length ? '\n' : '')
+}
+
+// "Priya signs off" is the most expensive sentence in a kickoff and used to land
+// in context.md as a note. signer: fills the success.md line the whole kit
+// keys on, and logs the person as a contact so prep/status can see them.
+const SIGNER_RX = /^(?<who>[A-Z][\w.'-]+(?:\s+[A-Z][\w.'-]+){0,3}(?:\s*\([^)]{1,40}\))?)\s+(?:signs?(?:\s+off)?|approves|has (?:the )?final say|can say yes|owns the decision|is the (?:sponsor|signer|decision[- ]maker))\b/
+
+function signerFromLine(text) {
+  const t = String(text || '').trim()
+  const m = t.match(SIGNER_RX)
+  if (!m) return ''
+  const who = m.groups.who.trim()
+  // "Staging exists" / "The API is slow" also match "Capital Word + verb"; a
+  // sentence-initial common noun is not a person.
+  if (/^(The|This|That|It|We|They|Staging|Budget|Prod|Production|Nobody|Someone|Everyone)\b/.test(who)) return ''
+  return who
+}
+
+function setSigner(eng, who) {
+  ensureMemoryGit(eng)
+  const p = path.join(eng, 'success.md')
+  let md = readEng(eng, 'success.md')
+  if (!md) md = '# Success definition\n\n'
+  const line = /^\*\*Stakeholder who signs off:\*\*\s*(.*)$/m
+  const m = md.match(line)
+  if (m && !m[1].trim()) {
+    md = md.replace(line, `**Stakeholder who signs off:** ${who}`)
+  } else if (m && m[1].trim().toLowerCase().includes(who.toLowerCase())) {
+    return false
+  } else if (m) {
+    // A second, different name is a fact worth keeping next to the first, not
+    // a silent overwrite - who signs is exactly the thing people argue about.
+    md = md.replace(line, `$&\n- also named: ${who}`)
+  } else {
+    md = md.replace(/\n*$/, `\n\n**Stakeholder who signs off:** ${who}\n`)
+  }
+  withFileLock(p, () => { atomicWriteFile(p, md.endsWith('\n') ? md : md + '\n') })
+  return true
 }
 
 function setNextAction(eng, text) {
@@ -1665,7 +1709,7 @@ function readSealedProposal(eng) {
 function routeDebriefInput(eng, input, { dry, force, sealed = [] }) {
   const d = new Date()
   const date = d.toISOString().slice(0, 10)
-  const counts = { decision: 0, risk: 0, delivery: 0, contact: 0, next: 0 }
+  const counts = { decision: 0, risk: 0, delivery: 0, contact: 0, next: 0, signer: 0 }
   const ctxLines = []
   let nextAction = ''
   ensureMemoryGit(eng)
@@ -1678,14 +1722,26 @@ function routeDebriefInput(eng, input, { dry, force, sealed = [] }) {
   for (const raw of routable.split('\n')) {
     let line = raw.trim()
     if (!line) continue
-    const bare = line.replace(/^[-*+]\s+/, '').replace(/^\*\*(decision|risk|delivery|contact|next):?\*\*:?\s*/i, '$1: ')
-    const m = bare.match(/^(decision|risk|delivery|contact|next):\s*(.+)$/i)
+    const bare = line.replace(/^[-*+]\s+/, '').replace(/^\*\*(decision|risk|delivery|contact|next|signer):?\*\*:?\s*/i, '$1: ')
+    const m = bare.match(/^(decision|risk|delivery|contact|next|signer):\s*(.+)$/i)
     if (m) {
       const type = m[1].toLowerCase()
       let body = m[2]
       const hit = findSecretHit(body)
       if (hit && !force) {
         console.error(`skipped ${type} line - looks like a ${hit}. Redact it, or re-run with --force.`)
+        continue
+      }
+      if (type === 'signer') {
+        const who = body.replace(/\s+signs?(?:\s+off)?\b.*$/i, '').trim() || body.trim()
+        if (dry) {
+          console.log(`→ success.md  **Stakeholder who signs off:** ${previewLine(who)}`)
+          console.log(`→ stakeholders.md  ${previewLine(datedEntry(eng, date, `${who} signs off`))}`)
+        } else {
+          setSigner(eng, who)
+          appendLogEntry(eng, 'contact', datedEntry(eng, date, `${who} signs off`), { skipCommit: true })
+        }
+        counts.signer++
         continue
       }
       if (type === 'next') {
@@ -1760,7 +1816,7 @@ function cmdDebrief(args) {
     if (smart) {
     const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
     console.log('SMART PROPOSE (heuristic - review before apply; no new facts invented beyond line rewrites)\n')
-    console.log('Prefix vocabulary (lines that route): decision:  risk:  delivery:  contact:  next:')
+    console.log('Prefix vocabulary (lines that route): decision:  risk:  delivery:  contact:  next:  signer:')
     console.log('Everything else → context.md. Keep the prefixes; the preview gate stays.\n')
     routeDebriefInput(eng, clean, { dry: true, force, sealed: blocks })
     if (!apply) {
@@ -1776,7 +1832,7 @@ function cmdDebrief(args) {
   const { counts, ctxLines, privateBlocks } = routeDebriefInput(eng, input, { dry, force, sealed })
   if (!dry) {
     const hash = commitMemory(eng, 'debrief', {
-      files: ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md', 'context.md', SIGNAL_LEDGER],
+      files: ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md', 'success.md', 'context.md', SIGNAL_LEDGER],
     })
     try { fs.unlinkSync(path.join(eng, DEBRIEF_PROPOSE)) } catch (_) {}
     try { fs.unlinkSync(path.join(eng, DEBRIEF_PRIVATE)) } catch (_) {}
@@ -1784,7 +1840,7 @@ function cmdDebrief(args) {
     if (hash) console.log(`memory @${hash}`)
   }
   const plural = {
-    decision: 'decisions', risk: 'risks', delivery: 'deliveries', contact: 'contacts', next: 'next actions',
+    decision: 'decisions', risk: 'risks', delivery: 'deliveries', contact: 'contacts', next: 'next actions', signer: 'signers',
   }
   const parts = Object.keys(counts).filter(t => counts[t])
     .map(t => `${counts[t]} ${counts[t] === 1 ? (t === 'next' ? 'next action' : t) : plural[t]}`)
@@ -2176,6 +2232,41 @@ function findDuplicateOpenRisks(eng) {
   return [...byKey.values()].filter(g => g.length >= 2)
 }
 
+// The bound client repo moved and delivery.md did not. This is the one place
+// the CLI can catch "we shipped code and told the record nothing" without AI:
+// registry gives the workspace(s) bound to this engagement, git gives commits
+// newer than the last dated delivery line. Local reads only.
+function latestDatedLine(md) {
+  const dates = (stripTemplateNoise(md).match(/\b\d{4}-\d{2}-\d{2}\b/g) || []).sort()
+  return dates.length ? dates[dates.length - 1] : ''
+}
+
+function silentCommitIssues(eng) {
+  const slug = path.basename(path.dirname(eng))
+  const workspaces = readRegistry().filter(r => r.slug === slug).map(r => r.workspace)
+  if (!workspaces.length) return []
+  const lastDelivery = latestDatedLine(readClean(eng, 'delivery.md'))
+  const out = []
+  for (const ws of workspaces) {
+    let st
+    try { st = fs.statSync(ws) } catch (_) { continue }
+    if (!st.isDirectory()) continue
+    // The memory folder is itself a git repo; never lint it as the client repo.
+    if (path.resolve(ws) === path.resolve(eng) || path.resolve(ws) === path.dirname(path.resolve(eng))) continue
+    if (sh('git rev-parse --is-inside-work-tree', ws) !== 'true') continue
+    const since = lastDelivery ? `--since="${lastDelivery} 23:59:59"` : "--since='30 days ago'"
+    const commits = sh(`git log ${since} --format=%h -- .`, ws).split('\n').filter(Boolean).length
+    if (!commits) continue
+    const where = path.basename(ws)
+    out.push(
+      lastDelivery
+        ? `${commits} commit(s) in ${where} since the last delivery line (${lastDelivery}) - code moved, ledger did not; log the receipt or say why nothing shipped`
+        : `${commits} commit(s) in ${where} in 30d and delivery.md has no dated line - code moved, ledger did not; fde log delivery "slice | bucket | promised | measured | accepted | evidence | rollback"`
+    )
+  }
+  return out
+}
+
 // Deterministic fieldbook hygiene - shared by doctor + session TRIAGE.
 // Silent when clean OR brand-new (no dated work yet). Never auto-rewrites.
 // High-value moments: week-start (via triage), ship/close, after real work accrues.
@@ -2246,9 +2337,11 @@ function collectDoctorIssues(eng) {
       'duplicate ## Next action headings in context.md - fill the first (template) section and remove extras; triage reads the last non-empty'
     )
   }
-  if ((s.phase === 'close' || s.phase === 'ship') && s.openRisks > 0) {
+  // Open, owned risks are normal mid-ship (triage already shows the count every
+  // session). The gate is close: nothing still live when you call the embed done.
+  if (s.phase === 'close' && s.openRisks > 0) {
     issues.push(
-      `phase is ${s.phase} with ${s.openRisks} open risk(s) - retire, hand off, or move still-live ones before calling the embed done`
+      `phase is close with ${s.openRisks} open risk(s) - retire, hand off, or move still-live ones before calling the embed done`
     )
   }
   if (s.phase === 'close' || s.phase === 'ship') {
@@ -2268,6 +2361,7 @@ function collectDoctorIssues(eng) {
         `phase is ${s.phase} with AI in scope but no eval receipt (evals.md Verdict or delivery Eval / Ship receipts) - required before green ship/close`
       )
     }
+    issues.push(...silentCommitIssues(eng))
   }
   const dupes = findDuplicateOpenRisks(eng)
   if (dupes.length) {

--- a/bin/lib/trust.js
+++ b/bin/lib/trust.js
@@ -194,6 +194,9 @@ function createTrustApi(deps) {
     }) || '').replace(/\|/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 80)
     // Prefer trust trigger / memory warn over a random risk line; always keep mem.warn available
     const reason = (trustReason || mem.warn) ? (trustReason || mem.warn) : topRisk
+    // What the triage line is actually quoting. A risk bullet printed under
+    // "trust:" read as a stakeholder problem that did not exist.
+    const reasonKind = trustReason ? 'trust' : mem.warn ? 'memory' : topRisk ? 'risk' : ''
     const openRisks = countOpenRisks(eng)
     const nextAction = nextActionLine(ctx)
     let updated = 'never', ageDays = Infinity
@@ -203,7 +206,7 @@ function createTrustApi(deps) {
     } catch (_) {}
     const dirty = memoryDirtyManual(eng)
     return {
-      phase, trust, signalAge, stale, topRisk, reason, memoryWarn: mem.warn,
+      phase, trust, signalAge, stale, topRisk, reason, reasonKind, memoryWarn: mem.warn,
       dirtyFiles: dirty, openRisks, nextAction, updated, ageDays,
     }
   }
@@ -215,9 +218,9 @@ function createTrustApi(deps) {
     const lines = [
       `TRIAGE  [${label.padEnd(6)}]  phase:${phase}  updated:${s.updated}  open risks:${s.openRisks}`,
     ]
-    if (s.reason) {
-      const age = s.signalAge != null ? ` (${s.signalAge}d old${s.stale ? ', STALE - reconfirm' : ''})` : ''
-      lines.push(`  trust: ${s.reason}${age}`)
+    if (s.reason && s.reasonKind !== 'memory') {
+      const age = s.reasonKind === 'trust' && s.signalAge != null ? ` (${s.signalAge}d old${s.stale ? ', STALE - reconfirm' : ''})` : ''
+      lines.push(`  ${s.reasonKind === 'risk' ? 'top risk' : 'trust'}: ${s.reason}${age}`)
     }
     // Always surface corruption / unreadable memory - even when trust still reads green
     if (s.memoryWarn) lines.push(`  memory: ${s.memoryWarn}`)

--- a/evals/fde-field-gap.md
+++ b/evals/fde-field-gap.md
@@ -1,0 +1,48 @@
+# FDE field-gap ledger
+
+Living notes from the field-audit loop. Not public copy. Do not name other skill packs in README.
+
+**Bar:** Palantir / OpenAI / Databricks FDE job, not an SDLC pack. One `@fde`. Six stages. Thicken, do not grow a 31st skill. Lights-out loops on their production: refuse.
+
+## Cycle 1 - 2026-09-01
+
+**Master FDE:** ENOUGH-IF-THICKENED. No new skill. No Spec/Build/Test stages.
+
+**Refused (coding packs):** TDD, spec/PRD, personas, skill pickers, browser/QA harnesses, unattended factories on a customer site, sales/SOW/invoicing, org IdP product.
+
+**Thickened this cycle:**
+- `discover.md` - data estate always; the pipe; their words
+- `ship.md` - their runner/CI; Monday-shaped staging; canary receipt; no lights-out prod
+- `readout.md` - old path still live = claimed
+- `runbook.md` - floor drill; do not document-and-leave
+- `encode-pattern.md` - Monday-bag quality test
+- `eval-pack.md` - side effect without named human = NO-SHIP
+
+**Site (fdeops-web, not this repo):** still dual-vocab and "ship to production." Presentation steal is page *shape* (first 10 minutes, tutorials as one client run, loops page that forbids unattended client work). Do not copy SDLC commands.
+
+**Next cycle looks at:** Palantir/OpenAI/Databricks/Anthropic job posts; whether production-trace evals or hypercare need another beat inside readout/rescue (still not a new skill).
+
+## Cycle 2 - 2026-09-01 (four-pack deep file read)
+
+Miners went into actual SKILL.md files (not READMEs). Master FDE accepted **two** beats. Killed: excuse tables as a new schema, launch checklists, TDD, grill skill, Hold/Reduce/Expand modes, automated ship, skill pickers, CONTEXT.md in their repo.
+
+**Thickened:**
+- `ship.md` - this-turn evidence; stale green is not a receipt
+- `review.md` - their PR comments are to check, not to obey
+
+## Cycle 3 - 2026-09-03 (stranger run + michaelshimeles/skills + Superpowers comparison)
+
+Ran the kit cold: temp dir, fake client repo, realistic kickoff notes, README only. Compared with Superpowers (obra) and michaelshimeles/skills. Verdict: FDEOps wins the job they do not do. It loses only where its gates were prose.
+
+**Refused (again):** TDD, worktree-per-task, service-layer code craft, Greptile loops, screen-recorded evidence, vendoring third-party skills, per-skill install, a 31st skill. All code craft or harness concerns. Compare page row "writes good code: we don't try" stays.
+
+**Stranger findings → CLI (not skills):**
+- "Priya signs off" landed in `context.md` as a note. → `signer:` prefix; `--smart` proposes it; fills `success.md` + logs contact.
+- Two commits in the bound repo, zero delivery lines, doctor silent. → doctor: commits after last dated delivery line = "code moved, ledger did not."
+- Triage printed a risk under `trust:`. → `top risk:`.
+- All three examples failed their own doctor. → fixed; `check.js` runs doctor on every example.
+- Open owned risks mid-ship failed doctor. → gate moved to close.
+
+**Took from the other packs (two checklist lines, `ship.md`):** capture the before-state before you change anything; check their open PRs before you start. Plus the enforcement idea: skip is loud, missing receipt = failing test.
+
+**Not fixed by any edit:** zero external users. Next: one FDE not briefed by the author, one client, one week. No skill edits until that report lands.

--- a/examples/garvey-payments/.fde/delivery.md
+++ b/examples/garvey-payments/.fde/delivery.md
@@ -2,21 +2,25 @@
 
 ## Value ledger
 
-| Date | Slice | Promised | Measured | Evidence | Rollback |
-|------|-------|----------|----------|----------|----------|
-| 2026-05-30 | EU ingest retry (staging) | One night without Excel reprocess | Trial agreed; measured nights pending | CTO + finance controller staging demo | Feature flag off; revert retry worker |
+| Date | Slice | Bucket | Promised | Measured | Accepted by | Evidence | Rollback |
+|------|-------|--------|----------|----------|-------------|----------|----------|
+| 2026-05-30 | EU ingest retry (staging) | cost-save | One night without Excel reprocess | pending - trial night 2026-06-02 | pending - finance controller after trial | CTO + finance controller staging demo 2026-05-30 | Feature flag off; revert retry worker |
+
+## Ship receipts
+
+- [2026-05-30] their runner: `mvn -pl payments-eu test` on their CI, green, run id 4471. Audit cite: `terrain.md` operating map row 1 walked with ops lead.
 
 ## Shipped
 
 ### 2026-05-30 - EU ingest retry (staging)
 
-**Shipped:** idempotent retry + structured log of failed EU rows.  
-**Demo:** CTO + finance controller - staging walkthrough.  
-**Business value:** finance agreed to trial one night without Excel reprocess.  
-**Next:** prod canary after security review (their process).
+**Shipped:** idempotent retry + structured log of failed EU rows.
+**Demo:** CTO + finance controller - staging walkthrough on the reconciliation screen finance already uses.
+**Business value:** finance agreed to trial one night without Excel reprocess.
+**Next:** prod canary after security review (their process). Measured lands after the trial night; nothing is accepted until the finance controller says so.
 
 ## Status updates
 
 ## Running value
 
-- Manual Excel nights: trial pending (promised cut from nightly → none on EU failures).
+- Manual Excel nights: trial pending (promised cut from nightly → none on EU failures). Claimed, not delivered, until the ledger row shows an acceptor.

--- a/examples/garvey-payments/.fde/reality.md
+++ b/examples/garvey-payments/.fde/reality.md
@@ -1,9 +1,13 @@
 # Reality (actual problem)
 
-**Confirmed:** EU payment failures in the API are a symptom. **Root workflow:** finance reprocesses failed EU rows manually in Excel each night because ingest has no idempotent retry.
+**Working theory:** EU payment failures in the API are a symptom. Finance reprocesses failed EU rows by hand in Excel every night because ingest has no idempotent retry. The job is unowned retry visibility, not a broken API.
 
-**Stated brief was wrong because:** brief assumed API bug; ops knew about spreadsheet workaround but did not include it in the RFP.
+**Evidence:**
 
-**Implication for build:** thin ingest + reconciliation visibility, not a full API rewrite.
+- 2026-05-26, Day 5 workshop with the ops lead: nightly spreadsheet reprocess named unprompted; RFP never mentioned it.
+- 2026-05-26, anonymised sample of the reprocess sheet: 31 rows from one night, all EU rail, all retriable.
+- `EuRetryQueue` last touched 2019 with a revert in history (`terrain.md`).
 
-**Validated with:** ops lead (Day 5 workshop), sample spreadsheet (anonymized).
+**Differs from brief how:** brief assumed an API bug and asked for an API rewrite. Theory says thin ingest retry plus reconciliation visibility retires the Excel night; the API stays.
+
+**Confirm by:** one trial night on staging with the retry worker on and the spreadsheet untouched. Finance controller counts the rows. Target 2026-06-02.

--- a/examples/garvey-payments/.fde/stakeholders.md
+++ b/examples/garvey-payments/.fde/stakeholders.md
@@ -2,8 +2,8 @@
 
 | Name / role | Signal | Notes |
 |-------------|--------|-------|
-| CTO (invite) | champion | Cares about exec readout Friday |
-| Finance controller | not met yet | Owns spreadsheet process - **decision risk** |
+| CTO (invite) | champion | Sponsors; signs the phase. Cares about exec readout Friday |
+| Finance controller | met Day 5 | Owns the Excel night. **Accepts the number** - nothing is delivered until she says so |
 | Platform lead | neutral | Offered repo access Day 2 |
 | Prior vendor (left) | unknown | Ask if partial migration exists |
 

--- a/examples/garvey-payments/.fde/success.md
+++ b/examples/garvey-payments/.fde/success.md
@@ -1,12 +1,14 @@
 # Definition of done
 
+**Done when:** finance runs one full week with zero manual Excel reprocess of EU failures, on the path they operate, and the controller says so in writing.
+**Primary value bucket:** cost-save
+**Baseline → target:** 31 rows reprocessed by hand per night (2026-05-26 sample) → 0 rows, by 2026-06-13.
+**Explicitly out of scope:** full API modernisation; non-EU payment rails.
+**Stakeholder who signs off:** Finance controller accepts the number (she runs the Excel night today). CTO sponsors and signs the phase. Both, or it does not count.
+
 **In scope (revised Day 5):**
 - Nightly EU ingest with idempotent retry
 - Finance can retire manual Excel reprocess for EU path
 - Audit log of failed rows
-
-**Out of scope (this phase):**
-- Full API modernization
-- Non-EU payment rails
 
 **Visible win by:** Friday demo to CTO - working ingest on staging, not slide deck.

--- a/examples/garvey-payments/.fde/terrain.md
+++ b/examples/garvey-payments/.fde/terrain.md
@@ -7,3 +7,14 @@
 **Test gap:** characterisation tests required before behavior change - none exist.
 
 **Data flow:** API → queue → batch job → finance export (broken path for EU).
+
+## Operating map (exception-led)
+
+| Exception / break | Who notices first | What they do today (workaround) | System of record then | Blast if wrong | Evidence |
+|-------------------|-------------------|---------------------------------|-----------------------|----------------|----------|
+| EU row fails ingest overnight | Finance analyst, 08:30 export check | Reprocess by hand in the nightly Excel sheet | The spreadsheet, not the ledger | Month-end close slips; EU rail reported wrong | Day 5 workshop; 31-row sample 2026-05-26 |
+| Retry queue stalls | Nobody until finance asks | Platform lead restarts the batch job | Batch job logs | Same rows fail twice; duplicates if retry is not idempotent | Platform lead, Day 2 |
+
+**Shadow systems / silent workarounds:** the nightly Excel reprocess. It is the real EU reconciliation today.
+**Sacred / untouchable in ops:** the finance export format; month-end close window (no deploys last three business days).
+**Previous attempt residue:** 2019 `EuRetryQueue` revert; ask the platform lead what broke.

--- a/examples/kesterman-freight/.fde/stakeholders.md
+++ b/examples/kesterman-freight/.fde/stakeholders.md
@@ -9,10 +9,10 @@
 
 ## Signal history
 
-- [2026-06-12] [signal:green] Randy opened the sheet on-screen unprompted - floor trusts us with the real workflow
-- [2026-06-15] [signal:green] Denise agreed to re-scope against reality.md in one meeting, no pushback
-- [2026-06-26] [signal:amber] Denise skipped Thursday demo, no delegate sent, no reschedule
-- [2026-07-01] [signal:amber] Denise stopped replying to demo invites; third scope add arrived the same day via email
-- [2026-07-02] [signal:amber] Randy + Karen sync: Randy says Denise is "heads-down on the Nashville depot audit" (his read, unverified)
+- [2026-06-12] [signal:green] Randy Teague opened the sheet on-screen unprompted - floor trusts us with the real workflow
+- [2026-06-15] [signal:green] Denise Kowalczyk agreed to re-scope against reality.md in one meeting, no pushback
+- [2026-06-26] [signal:amber] Denise Kowalczyk skipped Thursday demo, no delegate sent, no reschedule
+- [2026-07-01] [signal:amber] Denise Kowalczyk stopped replying to demo invites; third scope add arrived the same day via email
+- [2026-07-02] [signal:amber] Randy Teague + Karen Mroz sync: Randy says Denise is "heads-down on the Nashville depot audit" (his read, unverified)
 
 **Trust:** amber (since 2026-06-26). Working theory: attention drain, not dissatisfaction - verify directly before the 2026-07-09 demo.

--- a/examples/kesterman-freight/.fde/success.md
+++ b/examples/kesterman-freight/.fde/success.md
@@ -1,5 +1,8 @@
 # Success definition
 
+**Primary value bucket:** cost-save
+**Baseline → target:** dispatch runs off a hand-kept sheet, board lags it by hours and one full shift a week goes to reconciling → system matches the sheet within 5 minutes and Randy's team runs a shift without opening it, by 2026-07-17.
+
 **Done when (revised 2026-06-15, agreed with Denise):**
 
 - Dispatch board data in the system matches the ops sheet within 5 minutes, verified over 5 consecutive working days

--- a/examples/kesterman-freight/.fde/terrain.md
+++ b/examples/kesterman-freight/.fde/terrain.md
@@ -12,6 +12,18 @@
 
 **Test gaps:** 4 test files across 236 code files at scan time (2026-06-10). Characterisation tests added since: `nightly_export.js` (2026-06-20), board write path (2026-06-24) - written before touching either.
 
+## Operating map (exception-led)
+
+| Exception / break | Who notices first | What they do today (workaround) | System of record then | Blast if wrong | Evidence |
+|-------------------|-------------------|---------------------------------|-----------------------|----------------|----------|
+| Board and sheet disagree on a load | Dispatcher on shift, within the hour | Trust the sheet; fix the board by hand after the shift | The ops sheet | Wrong carrier assigned; Nashville depot double-booked | Floor walk 2026-06-12, Randy Teague |
+| Nightly export fails or changes shape | Finance controller, next morning | Re-run the script by hand; email finance the file | Finance's copy of the export | Month-end billing slips | Karen Mroz 2026-06-11; ticket open |
+| Dual read path returns stale rows | Nobody, until a dispatcher argues with the board | Refresh and hope | Whichever path answered | Silent data race on write-back | Karen Mroz review 2026-06-24 |
+
+**Shadow systems / silent workarounds:** the ops sheet is dispatch. The board is the copy.
+**Sacred / untouchable in ops:** nightly export format and schedule; Randy's macro column until replaced.
+**Previous attempt residue:** 2023 ops-api migration, abandoned; both read paths still live.
+
 **Landmines:**
 
 - Dual read path left by the abandoned 2023 ops-api migration - both still live, reverts in git history.

--- a/examples/rennick-health/.fde/stakeholders.md
+++ b/examples/rennick-health/.fde/stakeholders.md
@@ -9,8 +9,8 @@
 
 ## Signal history
 
-- [2026-06-30] [signal:green] Sam cleared his calendar for the full kickoff, brought the board deck numbers
-- [2026-07-01] [signal:amber] Renata declined the architecture working session, "conflicting priority" - no reschedule offered
-- [2026-07-03] [signal:red] Renata declined the second working session; told Sam "we already have a design for this" - engagement was scoped without her, her team runs prod, and she found out from the calendar invite
+- [2026-06-30] [signal:green] Sam Whitfield cleared his calendar for the full kickoff, brought the board deck numbers
+- [2026-07-01] [signal:amber] Renata Fischer declined the architecture working session, "conflicting priority" - no reschedule offered
+- [2026-07-03] [signal:red] Renata Fischer declined the second working session; told Sam Whitfield "we already have a design for this" - engagement was scoped without her, her team runs prod, and she found out from the calendar invite
 
-**Trust:** RED (Renata, since 2026-07-03). She is the best source of truth in the building - the passed-over internal architect. Nothing ships to prod without her team. Fix this before any architecture work.
+**Trust:** RED (Renata Fischer, since 2026-07-03). She is the best source of truth in the building - the passed-over internal architect. Nothing ships to prod without her team. Fix this before any architecture work.

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code: who can say yes, what went live, whether they signed off. Dated markdown on your laptop. You confirm each write.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -42,6 +42,8 @@ On someone else's site the work is not "write code, remember later." Every chang
 
 A throwaway file can skip the loop. Bound client work cannot.
 
+**Skip is loud.** Bound + a change that will ship + no this-turn line in `delivery.md` = not done. Say that. Do not call it shipped. A coding pack may write the function; `@fde` still owns done.
+
 ## Human surface vs agent plumbing
 
 **FDE (human):** `@fde` + English, or `/brief` `/discover` `/plan` `/ship` `/outcome` `/close` `/debrief` `/prep` `/trust` `/receipts` `/readout`. Never a skill catalog.
@@ -196,8 +198,8 @@ Ready to build with no `terrain.md` / plan: discover or plan first. Takeover wit
 
 - Never ask the FDE to pick a phase. That's your job.
 - Same six stages at any scale. Overlays carry the industry. Greenfield and brownfield change the first move inside ship, not the map.
-- Ground loop on a bound client: name → characterise → prove on their staging → go live → log. Do not hand their repo to a generic coding pack.
-- Do not call a change done until the signer in `success.md` can reject it on staging they operate.
+- Ground loop on a bound client: name → characterise → prove on their staging → go live → log. A coding pack may write the function. `@fde` still owns done. When they disagree, their repo and the signer win.
+- Do not call a change done until the signer in `success.md` can reject it on staging they operate. No this-turn receipt in `delivery.md` is a failed test, not a note to write later.
 - Read `context.md` before speaking. One sharp question - never a barrage.
 - Never invent people, meetings, or numbers - `unknown - ask:` beats a polished lie.
 - Every phase ends with its artifact written. No artifact, no "done."

--- a/skills/fde/references/debrief.md
+++ b/skills/fde/references/debrief.md
@@ -11,7 +11,8 @@
 ## Honest contract (read once)
 
 - The `fde` CLI is **local, deterministic, no AI**. `--smart` is a **gate + writer**, not a brain.
-- It keeps lines that already have `decision:` / `risk:` / `delivery:` / `contact:` / `next:` prefixes, plus a thin keyword pass (e.g. "we agreed", person+verb lines, "open question").
+- It keeps lines that already have `decision:` / `risk:` / `delivery:` / `contact:` / `next:` / `signer:` prefixes, plus a thin keyword pass (e.g. "we agreed", person+verb lines, "open question", "X signs off").
+- `signer: Priya` fills **Stakeholder who signs off** in `success.md` and logs Priya as a contact. The CLI proposes it when a sentence says someone signs off / approves / has final say. If the notes name who can say yes and the proposal does not carry a `signer:` line, add one - that is the most expensive sentence in the meeting.
 - Real messy notes without prefixes often route **0 useful lines** - everything else lands as a context dump. That is expected. **You are the router:** rewrite `.debrief-propose` with type prefixes, then `--apply`.
 - `.debrief-propose` is raw lines only (no routing annotations). "Edit if mis-routed" means **rewrite the line with the right prefix**, not leave a comment in the file.
 
@@ -25,6 +26,7 @@
    - `decision: agreed chargebacks stay phase 2 - Priya`
    - `risk: legal may reopen scope if we slip the SOW date`
    - `contact: Priya pushed hard on Friday deck [signal:amber]`
+   - `signer: Priya` (she can say yes; lands in `success.md`)
    - `next: send one-pager before Thursday 9am`
    - unprefixed lines stay context color only
 4. Show the **proposed** routing in plain language (what would become decisions, risks, contacts, next).
@@ -43,7 +45,7 @@ If `--smart` is unavailable or you already have clean prefixes:
    - **Stakeholder signals** - tone shifts with evidence → green/amber/red
    - **Risks** - new / confirmed / retired
    - **Open questions** - what to chase next
-2. Format lines as `decision:` / `risk:` / `delivery:` / `contact:` / `next:` (contacts may end with `[signal:green|amber|red]`).
+2. Format lines as `decision:` / `risk:` / `delivery:` / `contact:` / `next:` / `signer:` (contacts may end with `[signal:green|amber|red]`).
 3. Show that structured version to the FDE for confirmation.
 4. Pipe to `fde debrief` (or write a file and run it).
 

--- a/skills/fde/references/ingest.md
+++ b/skills/fde/references/ingest.md
@@ -31,7 +31,7 @@ List what you can actually call **this session**:
 3. **Stage** - `fde ingest stage [--source NAME] [--title TEXT] [file|-]` writes raw text into `<engagement>/.inbox/` (outside the memory git ledger).
 4. **List** (optional) - `fde ingest list` shows staged items when you need an id or filename.
 5. **Propose** - `fde ingest propose <id-or-filename>` runs the debrief `--smart` path on the staged body (+ provenance line). Opens `.debrief-propose`.
-6. **Rewrite prefixes** - same as debrief: lines without `decision:` / `risk:` / `delivery:` / `contact:` / `next:` need **you** to rewrite before showing the FDE. `--smart` is a gate, not a brain.
+6. **Rewrite prefixes** - same as debrief: lines without `decision:` / `risk:` / `delivery:` / `contact:` / `next:` / `signer:` need **you** to rewrite before showing the FDE. `--smart` is a gate, not a brain.
 7. **Show** the proposed routing in plain language. Wait for confirm.
 8. **Apply** - on FDE confirm only → `fde ingest apply` (= `fde debrief --apply`). On reject → stop; ask what to change.
 

--- a/skills/fde/references/ship.md
+++ b/skills/fde/references/ship.md
@@ -56,6 +56,10 @@ Each change is independently revertible.
 - [ ] Rollback named: revert this change, or something more specific
 - [ ] No dependency on an unmerged change (if dependent, state it and land in order)
 - [ ] `Kill if` is written - the observation that stops this change
+- [ ] Before-receipt captured: the failing output, number, or screen as it is today, dated in `delivery.md`, before you change anything
+- [ ] Open PRs and uncommitted work in the area checked (`gh pr list`, `gh pr diff <n> --name-only`); overlap goes to `decisions.md` before you start
+
+Your coding pack writes the function. This skill owns done. When they disagree with this repo, the repo wins.
 
 **The loop.** In this order:
 
@@ -72,7 +76,7 @@ Read existing code in the area (search before creating)
 
 **Prove it on their staging.** A green check on your laptop is not delivery.
 
-- Run **their** test command, on **their** CI, with **their** fixtures. Write the command and the result in `delivery.md`. You do not add a runner they will not keep. If you have not run their command in this turn, you cannot write that it passed. Last session's green, "should pass," and "looks correct" are not a receipt.
+- Run **their** test command, on **their** CI, with **their** fixtures. Write the command and the result in `delivery.md` in this turn. You do not add a runner they will not keep. If you have not run their command in this turn, you cannot write that it passed. Last session's green, "should pass," and "looks correct" are not a receipt. Missing this-turn line = not proven. Same as a failing test.
 - If the signer in `success.md` cannot reject this on a screen they already use, it is not proven.
 - Staging they operate beats a local demo. If you have no staging: `unknown - ask:` who owns an environment, then stop pretending it shipped.
 - **Monday-shaped data.** Staging that is empty, synthetic, or last quarter is not next Tuesday. Before go-live, write what staging is missing (volume, PII, the batch that only runs in prod, the account that only exists in the warehouse) and what that means for the kill test. If the signer cannot reject it on a screen they already operate, with data that looks like next Tuesday, it is not proven.

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3204,6 +3204,80 @@ test('debrief --smart prints the prefix vocabulary before the preview', () => {
   assert.match(smart.stdout, /next:/)
 })
 
+test('debrief --smart routes "Priya signs off" into success.md and stakeholders.md', () => {
+  const sandbox = makeSandbox('smart-signer')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'signco']).status, 0)
+  const notes = path.join(sandbox.dir, 'notes.md')
+  fs.writeFileSync(notes, [
+    'Kickoff with Priya (VP Eng) and Marco (ops lead).',
+    'Priya signs off. Budget fixed. Staging exists but has no EU data.',
+    'The API is slow on Mondays.',
+  ].join('\n') + '\n')
+  const smart = runFde(sandbox, ['debrief', '--smart', notes])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /signer:/)
+  assert.match(smart.stdout, /success\.md.*Stakeholder who signs off:\*\* Priya/)
+  assert.doesNotMatch(smart.stdout, /signs off:\*\* (The|Staging)/)
+  const applied = runFde(sandbox, ['debrief', '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  const eng = engagementPath(sandbox, 'signco')
+  assert.match(fs.readFileSync(path.join(eng, 'success.md'), 'utf8'), /\*\*Stakeholder who signs off:\*\* Priya/)
+  assert.match(fs.readFileSync(path.join(eng, 'stakeholders.md'), 'utf8'), /Priya signs off/)
+  // The original sentence is still on the record as context - nothing dropped.
+  assert.match(fs.readFileSync(path.join(eng, 'context.md'), 'utf8'), /Budget fixed/)
+  const prep = runFde(sandbox, ['prep', 'Friday'])
+  assert.match(prep.stdout, /Priya/)
+})
+
+test('debrief signer: does not overwrite a different signer already on record', () => {
+  const sandbox = makeSandbox('signer-keep')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'keepco']).status, 0)
+  const eng = engagementPath(sandbox, 'keepco')
+  const before = fs.readFileSync(path.join(eng, 'success.md'), 'utf8')
+  fs.writeFileSync(path.join(eng, 'success.md'), before.replace(/\*\*Stakeholder who signs off:\*\*.*/, '**Stakeholder who signs off:** Denise'))
+  const applied = runFde(sandbox, ['debrief'], { input: 'signer: Randy\n' })
+  assert.equal(applied.status, 0, applied.stderr)
+  const md = fs.readFileSync(path.join(eng, 'success.md'), 'utf8')
+  assert.match(md, /signs off:\*\* Denise/)
+  assert.match(md, /also named: Randy/)
+})
+
+test('doctor flags commits in the bound repo after the last delivery line', () => {
+  const sandbox = makeSandbox('silent-commits')
+  const ws = sandbox.workspace
+  const git = (args) => spawnSync('git', ['-C', ws, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t.t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t.t' },
+  })
+  assert.equal(git(['init', '-q']).status, 0)
+  fs.writeFileSync(path.join(ws, 'a.js'), 'a\n')
+  assert.equal(git(['add', '-A']).status, 0)
+  assert.equal(git(['commit', '-qm', 'feat: retry worker']).status, 0)
+  assert.equal(runFde(sandbox, ['resume', '--init', 'silentco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'phase', 'ship']).status, 0)
+  const eng = engagementPath(sandbox, 'silentco')
+  fillOperatingMap(eng)
+  const quiet = runFde(sandbox, ['doctor'])
+  assert.match(quiet.stdout, /commit\(s\) in workspace.*code moved, ledger did not/)
+  assert.equal(runFde(sandbox, [
+    'log', 'delivery', 'retry | risk-mitigation | zero Excel nights | pending | staging run | flag off',
+  ]).status, 0)
+  const receipted = runFde(sandbox, ['doctor'])
+  assert.doesNotMatch(receipted.stdout, /code moved, ledger did not/)
+})
+
+test('triage labels a quoted risk as top risk, not trust', () => {
+  const sandbox = makeSandbox('triage-label')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'labelco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'risk', 'staging has no EU data so we cannot prove it there yet']).status, 0)
+  const out = runFde(sandbox, ['resume'])
+  assert.match(out.stdout, /top risk: .*staging has no EU data/)
+  assert.doesNotMatch(out.stdout, /^\s+trust: .*staging has no EU data/m)
+  assert.equal(runFde(sandbox, ['log', 'contact', 'Priya went quiet', '--signal', 'amber']).status, 0)
+  const withSignal = runFde(sandbox, ['resume'])
+  assert.match(withSignal.stdout, /^\s+trust: .*Priya went quiet/m)
+})
+
 test('log delivery with pipes writes a value-ledger row', () => {
   const sandbox = makeSandbox('log-ledger')
   assert.equal(runFde(sandbox, ['resume', '--init', 'ledco']).status, 0)


### PR DESCRIPTION
## Summary
A cold stranger run (temp dir, fake client repo, README only) showed the kit's two headline gates were prose. This release makes the CLI enforce them. No new skill, no new stage.

- `debrief --smart`: "Priya signs off" becomes `signer: Priya`. Fills **Stakeholder who signs off** in `success.md`, logs the contact. A different existing signer is kept, not overwritten.
- `doctor` (ship/close): commits in the bound client repo after the last dated `delivery.md` line -> "code moved, ledger did not." Registry + git, local only.
- `doctor`: open, owned risks mid-ship no longer fail; the gate is close.
- Triage: a quoted risk is labelled `top risk:`, not `trust:`.
- Examples: all three pass `fde doctor`. `check.js` runs doctor on every example so they cannot rot.
- `@fde` / `ship.md`: coding pack writes the function, `@fde` owns done. Before-receipt before you change anything. Open PRs checked. No this-turn receipt = failed test.
- README: keep the coding pack you already use; install this next to it.
- Version 3.22.0 across all four manifests. CHANGELOG. Field-gap ledger cycle 3.

## Test plan
- [x] `npm run check`: 135/135 tests, all checks OK, all three examples pass their own doctor
- [x] 4 new tests: signer routing, signer no-overwrite, silent-commit detection, triage label
- [ ] After merge: tag v3.22.0, `npm publish`, `npx fdeops@latest --version` -> 3.22.0

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/86" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->