### PR TITLE
3.22.0 review fixes: silent-commit dates, signer compare, memory label

### DIFF
--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1576,16 +1576,28 @@ function setSigner(eng, who) {
   const p = path.join(eng, 'success.md')
   let md = readEng(eng, 'success.md')
   if (!md) md = '# Success definition\n\n'
+  const norm = (s) => String(s).replace(/\s+/g, ' ').trim().toLowerCase()
   const line = /^\*\*Stakeholder who signs off:\*\*\s*(.*)$/m
   const m = md.match(line)
   if (m && !m[1].trim()) {
     md = md.replace(line, `**Stakeholder who signs off:** ${who}`)
-  } else if (m && m[1].trim().toLowerCase().includes(who.toLowerCase())) {
-    return false
   } else if (m) {
+    // Whole-name compare against the primary and every "also named" line under
+    // it: "Sam" must not vanish inside "Samantha", and re-applying must not
+    // stack duplicates.
+    const start = md.indexOf(m[0]) + m[0].length
+    const alsoNamed = []
+    for (const l of md.slice(start).split('\n').slice(1)) {
+      const a = l.match(/^- also named:\s*(.+)$/)
+      if (!a) break
+      alsoNamed.push(a[1])
+    }
+    const known = [m[1], ...alsoNamed].map(norm)
+    if (known.includes(norm(who))) return false
     // A second, different name is a fact worth keeping next to the first, not
     // a silent overwrite - who signs is exactly the thing people argue about.
-    md = md.replace(line, `$&\n- also named: ${who}`)
+    const block = [m[0], ...alsoNamed.map(a => `- also named: ${a}`)].join('\n')
+    md = md.replace(block, `${block}\n- also named: ${who}`)
   } else {
     md = md.replace(/\n*$/, `\n\n**Stakeholder who signs off:** ${who}\n`)
   }
@@ -2236,16 +2248,28 @@ function findDuplicateOpenRisks(eng) {
 // the CLI can catch "we shipped code and told the record nothing" without AI:
 // registry gives the workspace(s) bound to this engagement, git gives commits
 // newer than the last dated delivery line. Local reads only.
-function latestDatedLine(md) {
-  const dates = (stripTemplateNoise(md).match(/\b\d{4}-\d{2}-\d{2}\b/g) || []).sort()
-  return dates.length ? dates[dates.length - 1] : ''
+// Only dates that stamp an entry count: a ledger row's Date cell, a dated
+// bullet, a dated heading. "trial night 2026-06-02" inside a Measured cell is a
+// promise, not a receipt - and a future promise must not hide today's commits.
+function latestDeliveryDate(md) {
+  const today = new Date().toISOString().slice(0, 10)
+  let latest = ''
+  for (const raw of stripTemplateNoise(md).split('\n')) {
+    const t = raw.trim()
+    const m = t.match(/^[-*]\s*\[(\d{4}-\d{2}-\d{2})\]/) ||
+      t.match(/^#{1,6}\s+(\d{4}-\d{2}-\d{2})\b/) ||
+      t.match(/^\|\s*(\d{4}-\d{2}-\d{2})\s*\|/)
+    if (!m || m[1] > today) continue
+    if (m[1] > latest) latest = m[1]
+  }
+  return latest
 }
 
 function silentCommitIssues(eng) {
   const slug = path.basename(path.dirname(eng))
   const workspaces = readRegistry().filter(r => r.slug === slug).map(r => r.workspace)
   if (!workspaces.length) return []
-  const lastDelivery = latestDatedLine(readClean(eng, 'delivery.md'))
+  const lastDelivery = latestDeliveryDate(readClean(eng, 'delivery.md'))
   const out = []
   for (const ws of workspaces) {
     let st
@@ -2254,7 +2278,13 @@ function silentCommitIssues(eng) {
     // The memory folder is itself a git repo; never lint it as the client repo.
     if (path.resolve(ws) === path.resolve(eng) || path.resolve(ws) === path.dirname(path.resolve(eng))) continue
     if (sh('git rev-parse --is-inside-work-tree', ws) !== 'true') continue
-    const since = lastDelivery ? `--since="${lastDelivery} 23:59:59"` : "--since='30 days ago'"
+    // Memory git knows the exact moment delivery.md last changed; dates in the
+    // file are day-grained and would miss a commit made later the same day.
+    // No dated line at all = no receipt; the template's init commit does not count.
+    const stamp = lastDelivery ? sh('git log -1 --format=%cI -- delivery.md', eng) : ''
+    const since = stamp ? `--since="${stamp}"`
+      : lastDelivery ? `--since="${lastDelivery} 23:59:59"`
+        : "--since='30 days ago'"
     const commits = sh(`git log ${since} --format=%h -- .`, ws).split('\n').filter(Boolean).length
     if (!commits) continue
     const where = path.basename(ws)

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -2283,9 +2283,12 @@ function silentCommitIssues(eng) {
     // file are day-grained and would miss a commit made later the same day.
     // Pickaxe on the entry text, not the file: a later status edit to
     // delivery.md must not become the cutoff and hide commits before it.
-    const stamp = entry.line
+    const raw = entry.line
       ? sh(`git log -1 --format=%cI -S${JSON.stringify(entry.line)} -- delivery.md`, eng)
       : ''
+    // git --since is inclusive at second grain; a commit in the same second as
+    // the receipt is the receipt's own work, not a silent one.
+    const stamp = raw && !Number.isNaN(Date.parse(raw)) ? new Date(Date.parse(raw) + 1000).toISOString() : ''
     const since = stamp ? `--since="${stamp}"`
       : lastDelivery ? `--since="${lastDelivery} 23:59:59"`
         : "--since='30 days ago'"

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -2251,16 +2251,16 @@ function findDuplicateOpenRisks(eng) {
 // Only dates that stamp an entry count: a ledger row's Date cell, a dated
 // bullet, a dated heading. "trial night 2026-06-02" inside a Measured cell is a
 // promise, not a receipt - and a future promise must not hide today's commits.
-function latestDeliveryDate(md) {
+function latestDeliveryEntry(md) {
   const today = new Date().toISOString().slice(0, 10)
-  let latest = ''
+  let latest = { date: '', line: '' }
   for (const raw of stripTemplateNoise(md).split('\n')) {
     const t = raw.trim()
     const m = t.match(/^[-*]\s*\[(\d{4}-\d{2}-\d{2})\]/) ||
-      t.match(/^#{1,6}\s+(\d{4}-\d{2}-\d{2})\b/) ||
+      t.match(/^#{1,6}\s+\[?(\d{4}-\d{2}-\d{2})(?:\]|\b)/) ||
       t.match(/^\|\s*(\d{4}-\d{2}-\d{2})\s*\|/)
     if (!m || m[1] > today) continue
-    if (m[1] > latest) latest = m[1]
+    if (m[1] >= latest.date) latest = { date: m[1], line: t }
   }
   return latest
 }
@@ -2269,7 +2269,8 @@ function silentCommitIssues(eng) {
   const slug = path.basename(path.dirname(eng))
   const workspaces = readRegistry().filter(r => r.slug === slug).map(r => r.workspace)
   if (!workspaces.length) return []
-  const lastDelivery = latestDeliveryDate(readClean(eng, 'delivery.md'))
+  const entry = latestDeliveryEntry(readClean(eng, 'delivery.md'))
+  const lastDelivery = entry.date
   const out = []
   for (const ws of workspaces) {
     let st
@@ -2278,10 +2279,13 @@ function silentCommitIssues(eng) {
     // The memory folder is itself a git repo; never lint it as the client repo.
     if (path.resolve(ws) === path.resolve(eng) || path.resolve(ws) === path.dirname(path.resolve(eng))) continue
     if (sh('git rev-parse --is-inside-work-tree', ws) !== 'true') continue
-    // Memory git knows the exact moment delivery.md last changed; dates in the
+    // Memory git knows the exact moment that entry was written; dates in the
     // file are day-grained and would miss a commit made later the same day.
-    // No dated line at all = no receipt; the template's init commit does not count.
-    const stamp = lastDelivery ? sh('git log -1 --format=%cI -- delivery.md', eng) : ''
+    // Pickaxe on the entry text, not the file: a later status edit to
+    // delivery.md must not become the cutoff and hide commits before it.
+    const stamp = entry.line
+      ? sh(`git log -1 --format=%cI -S${JSON.stringify(entry.line)} -- delivery.md`, eng)
+      : ''
     const since = stamp ? `--since="${stamp}"`
       : lastDelivery ? `--since="${lastDelivery} 23:59:59"`
         : "--since='30 days ago'"

--- a/bin/lib/trust.js
+++ b/bin/lib/trust.js
@@ -196,7 +196,7 @@ function createTrustApi(deps) {
     const reason = (trustReason || mem.warn) ? (trustReason || mem.warn) : topRisk
     // What the triage line is actually quoting. A risk bullet printed under
     // "trust:" read as a stakeholder problem that did not exist.
-    const reasonKind = trustReason ? 'trust' : mem.warn ? 'memory' : topRisk ? 'risk' : ''
+    const reasonKind = mem.warn && trustReason === mem.warn ? 'memory' : trustReason ? 'trust' : mem.warn ? 'memory' : topRisk ? 'risk' : ''
     const openRisks = countOpenRisks(eng)
     const nextAction = nextActionLine(ctx)
     let updated = 'never', ageDays = Infinity

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3240,6 +3240,49 @@ test('debrief signer: does not overwrite a different signer already on record', 
   const md = fs.readFileSync(path.join(eng, 'success.md'), 'utf8')
   assert.match(md, /signs off:\*\* Denise/)
   assert.match(md, /also named: Randy/)
+
+  // Re-applying the same secondary signer is idempotent; a name that is a
+  // substring of another ("Sam" in "Samantha") is still its own person.
+  assert.equal(runFde(sandbox, ['debrief'], { input: 'signer: Randy\nsigner: Samantha\nsigner: Sam\n' }).status, 0)
+  const again = fs.readFileSync(path.join(eng, 'success.md'), 'utf8')
+  assert.equal((again.match(/also named: Randy/g) || []).length, 1)
+  assert.match(again, /also named: Samantha/)
+  assert.match(again, /^- also named: Sam$/m)
+})
+
+test('doctor silent-commit check ignores future promise dates inside a ledger row', () => {
+  const sandbox = makeSandbox('future-date')
+  const ws = sandbox.workspace
+  const git = (args) => spawnSync('git', ['-C', ws, ...args], {
+    encoding: 'utf8',
+    env: { ...process.env, GIT_AUTHOR_NAME: 't', GIT_AUTHOR_EMAIL: 't@t.t', GIT_COMMITTER_NAME: 't', GIT_COMMITTER_EMAIL: 't@t.t' },
+  })
+  assert.equal(git(['init', '-q']).status, 0)
+  assert.equal(runFde(sandbox, ['resume', '--init', 'futureco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'phase', 'ship']).status, 0)
+  const eng = engagementPath(sandbox, 'futureco')
+  fillOperatingMap(eng)
+  // Row dated today, Measured cell promises a trial next year.
+  assert.equal(runFde(sandbox, [
+    'log', 'delivery', 'retry | cost-save | one night | pending - trial 2099-01-01 | pending | staging run | flag off',
+  ]).status, 0)
+  fs.writeFileSync(path.join(ws, 'b.js'), 'b\n')
+  assert.equal(git(['add', '-A']).status, 0)
+  assert.equal(git(['commit', '-qm', 'feat: after the receipt']).status, 0)
+  const doctor = runFde(sandbox, ['doctor'])
+  assert.match(doctor.stdout, /code moved, ledger did not/)
+})
+
+test('triage prints unreadable memory once, under memory, not trust', () => {
+  const sandbox = makeSandbox('triage-memory')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'memco']).status, 0)
+  const eng = engagementPath(sandbox, 'memco')
+  fs.writeFileSync(path.join(eng, 'stakeholders.md'), Buffer.from([0x23, 0x20, 0x00, 0xff, 0x00]))
+  const out = runFde(sandbox, ['resume'])
+  const trustLines = out.stdout.split('\n').filter(l => /^\s+trust: /.test(l))
+  const memoryLines = out.stdout.split('\n').filter(l => /^\s+memory: /.test(l))
+  assert.equal(trustLines.length, 0, out.stdout)
+  assert.equal(memoryLines.length, 1, out.stdout)
 })
 
 test('doctor flags commits in the bound repo after the last delivery line', () => {

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3271,6 +3271,14 @@ test('doctor silent-commit check ignores future promise dates inside a ledger ro
   assert.equal(git(['commit', '-qm', 'feat: after the receipt']).status, 0)
   const doctor = runFde(sandbox, ['doctor'])
   assert.match(doctor.stdout, /code moved, ledger did not/)
+
+  // A later committed status note on delivery.md is not a receipt: the cutoff
+  // stays at the dated entry, so the commit above is still reported.
+  fs.appendFileSync(path.join(eng, 'delivery.md'), '\nStatus: waiting on security ticket.\n')
+  assert.equal(spawnSync('git', ['-C', eng, 'add', 'delivery.md']).status, 0)
+  assert.equal(spawnSync('git', ['-C', eng, '-c', 'user.name=t', '-c', 'user.email=t@t.t', 'commit', '-qm', 'status note']).status, 0)
+  const later = runFde(sandbox, ['doctor'])
+  assert.match(later.stdout, /code moved, ledger did not/)
 })
 
 test('triage prints unreadable memory once, under memory, not trust', () => {

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3266,6 +3266,9 @@ test('doctor silent-commit check ignores future promise dates inside a ledger ro
   assert.equal(runFde(sandbox, [
     'log', 'delivery', 'retry | cost-save | one night | pending - trial 2099-01-01 | pending | staging run | flag off',
   ]).status, 0)
+  // git timestamps are second-grained; a commit in the receipt's own second is
+  // treated as the receipt's work. Step clearly past it.
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1500)
   fs.writeFileSync(path.join(ws, 'b.js'), 'b\n')
   assert.equal(git(['add', '-A']).status, 0)
   assert.equal(git(['commit', '-qm', 'feat: after the receipt']).status, 0)


### PR DESCRIPTION
## Summary
Fixes the three review findings on #86 before v3.22.0 is tagged.

- Silent-commit check: only entry dates count (ledger Date cell, dated bullet, dated heading); a future promise inside a Measured cell no longer hides today's commits. Uses the memory-git timestamp of the last delivery write so a commit later the same day is still caught.
- `signer:`: whole-name compare against the primary and every "also named" line. Re-applying is idempotent; "Sam" is not swallowed by "Samantha".
- Triage: an unreadable-memory warning prints once, under `memory:`, never under `trust:`.

## Test plan
- [x] `npm run check`: 137/137, all checks OK
- [x] 3 regression tests added (future date in ledger row, duplicate/substring signers, memory label)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/87" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->