### PR TITLE
3.22.2: kickoff English fills the signer; --help is help

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 3.22.2 - 2026-09-08
+
+Kickoff English fills the signer. Receipts stop calling a dated line defensible. `--help` is help.
+
+- `debrief --smart`: "Finance controller (Helena) signs off" and "Anand Mehta has final say" become `signer:` lines. RECORD no longer prints `(none)` after a real kickoff sentence.
+- `fde receipts`: header is `ON RECORD (dated):`. Dated is retrieval, not verified customer approval.
+- `fde debrief --help`, `fde prep --help`, `fde log --help`: print usage. They no longer try to read a file named `--help` or prep a meeting called `--help`.
+- Value ledger: "not yet measured" / "pending" is not a claimed number.
+- `fde log decision "AI in scope: …"` (the line scan already prints) turns the eval gate on.
+
 ## 3.22.1 - 2026-09-07
 
 Three engagements run end to end on the published package showed the gates reading a different fieldbook than the CLI writes. Same six stages. Same 30 skills.

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1615,18 +1615,33 @@ function smartProposeText(input) {
 // success.md - that is the line Monday's RECORD reads.
 const SIGNER_VERB = '(?:signs?(?:\\s+off)?|approves|has (?:the )?final say|can say yes|owns the decision|is the (?:sponsor|signer|decision[- ]maker))'
 const SIGNER_NAME = '([A-Z][\\w.\'-]+(?:\\s+[A-Z][\\w.\'-]+){0,3})'
-const NOT_A_PERSON = /^(The|This|That|It|We|They|Staging|Budget|Prod|Production|Nobody|Someone|Everyone|Finance|Legal|Security|Platform|Engineering)\b/
+const NOT_A_PERSON = /^(The|This|That|It|We|They|She|He|Staging|Budget|Prod|Production|Nobody|Someone|Everyone|Finance|Legal|Security|Platform|Engineering)\b/
+const ROLE_TOKEN = /\b(VP|SVP|EVP|CTO|CFO|COO|CEO|CISO|Eng|Engineer|Director|Lead|Head|Manager|Controller|Ops|Legal|Finance|Sponsor)\b/i
+
+function looksLikePersonName(s) {
+  const t = String(s || '').trim()
+  if (!t || NOT_A_PERSON.test(t) || ROLE_TOKEN.test(t)) return false
+  return /^[A-Z][\w.'-]+(?:\s+[A-Z][\w.'-]+){0,2}$/.test(t)
+}
 
 function signerFromLine(text) {
   const t = String(text || '').replace(/^[-*+]\s+/, '').trim()
   if (!t) return ''
-  const paren = t.match(new RegExp('\\(' + SIGNER_NAME + '\\)\\s+' + SIGNER_VERB + '\\b', 'i'))
-  if (paren && !NOT_A_PERSON.test(paren[1])) return paren[1].trim()
+  // "Priya (VP Eng) signs off" → Priya. "Finance controller (Helena) signs off" → Helena.
+  const titled = t.match(new RegExp('\\b' + SIGNER_NAME + '\\s+\\(' + SIGNER_NAME + '\\)\\s+' + SIGNER_VERB + '\\b'))
+  if (titled) {
+    const before = titled[1].trim()
+    const inside = titled[2].trim()
+    if (looksLikePersonName(before) && ROLE_TOKEN.test(inside)) return before
+    if (looksLikePersonName(inside)) return inside
+    if (looksLikePersonName(before)) return before
+  }
+  const paren = t.match(new RegExp('\\(' + SIGNER_NAME + '\\)\\s+' + SIGNER_VERB + '\\b'))
+  if (paren && looksLikePersonName(paren[1])) return paren[1].trim()
   const named = t.match(new RegExp('\\b' + SIGNER_NAME + '\\s+' + SIGNER_VERB + '\\b'))
   if (!named) return ''
   const who = named[1].trim()
-  if (NOT_A_PERSON.test(who)) return ''
-  return who
+  return looksLikePersonName(who) ? who : ''
 }
 
 function setSigner(eng, who) {

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1610,19 +1610,22 @@ function smartProposeText(input) {
   return out.join('\n') + (out.length ? '\n' : '')
 }
 
-// "Priya signs off" is the most expensive sentence in a kickoff and used to land
-// in context.md as a note. signer: fills the success.md line the whole kit
-// keys on, and logs the person as a contact so prep/status can see them.
-const SIGNER_RX = /^(?<who>[A-Z][\w.'-]+(?:\s+[A-Z][\w.'-]+){0,3}(?:\s*\([^)]{1,40}\))?)\s+(?:signs?(?:\s+off)?|approves|has (?:the )?final say|can say yes|owns the decision|is the (?:sponsor|signer|decision[- ]maker))\b/
+// Kickoff English, not only "signer: Priya". "Helena signs off", "Anand Mehta
+// has final say", "Finance controller (Helena) signs off" all have to fill
+// success.md - that is the line Monday's RECORD reads.
+const SIGNER_VERB = '(?:signs?(?:\\s+off)?|approves|has (?:the )?final say|can say yes|owns the decision|is the (?:sponsor|signer|decision[- ]maker))'
+const SIGNER_NAME = '([A-Z][\\w.\'-]+(?:\\s+[A-Z][\\w.\'-]+){0,3})'
+const NOT_A_PERSON = /^(The|This|That|It|We|They|Staging|Budget|Prod|Production|Nobody|Someone|Everyone|Finance|Legal|Security|Platform|Engineering)\b/
 
 function signerFromLine(text) {
-  const t = String(text || '').trim()
-  const m = t.match(SIGNER_RX)
-  if (!m) return ''
-  const who = m.groups.who.trim()
-  // "Staging exists" / "The API is slow" also match "Capital Word + verb"; a
-  // sentence-initial common noun is not a person.
-  if (/^(The|This|That|It|We|They|Staging|Budget|Prod|Production|Nobody|Someone|Everyone)\b/.test(who)) return ''
+  const t = String(text || '').replace(/^[-*+]\s+/, '').trim()
+  if (!t) return ''
+  const paren = t.match(new RegExp('\\(' + SIGNER_NAME + '\\)\\s+' + SIGNER_VERB + '\\b', 'i'))
+  if (paren && !NOT_A_PERSON.test(paren[1])) return paren[1].trim()
+  const named = t.match(new RegExp('\\b' + SIGNER_NAME + '\\s+' + SIGNER_VERB + '\\b'))
+  if (!named) return ''
+  const who = named[1].trim()
+  if (NOT_A_PERSON.test(who)) return ''
   return who
 }
 
@@ -2134,7 +2137,7 @@ function cmdReceipts(args) {
     agreed.map(h => (h.match(/^\s*([^:]+):/) || [])[1]).filter(f => f && dirtySet.has(f))
   )]
   if (agreed.length) {
-    console.log('ON RECORD (dated - defensible):')
+    console.log('ON RECORD (dated):')
     agreed.forEach(h => {
       const file = (h.match(/^\s*([^:]+):/) || [])[1]
       console.log(h + (file && dirtySet.has(file) ? '  ⚠ dirty file' : ''))
@@ -2620,7 +2623,7 @@ function hasValueBucket(eng) {
 // "pending review", "TBD.", "n/a (blocked)" and "..." are all the same thing an
 // FDE means by an empty cell - nagging about them teaches people to ignore doctor.
 const PENDING_CELL_RE =
-  /^(?:pending|tbd|to ?be ?(?:measured|confirmed|determined)|n\s*\/\s*a|na|none|unknown|not measured|\?+|\.{2,}|…|-+|-+|-+)(?:[^\w].*)?$/i
+  /^(?:pending|tbd|to ?be ?(?:measured|confirmed|determined)|n\s*\/\s*a|na|none|unknown|not(?:\s+yet)?\s+measured|unmeasured|awaiting|\?+|\.{2,}|…|-+)(?:[^\w].*)?$/i
 
 function parseValueLedger(eng) {
   // Last section with actual rows, not merely the last non-empty one: a template
@@ -2704,7 +2707,7 @@ function engagementTouchesAI(eng) {
   ].join('\n'))
   // No bare "prompt": "prompt response" / "prompt payment" is ordinary delivery
   // English and would fail every non-AI ship on a missing eval receipt.
-  return /\b(llm|rag|embedding|model card|model output|model drift|agentic|openai|anthropic|vector database|vector db|fine-tun\w*|hallucinat\w*)\b|\bmodel inference\b|\binference (?:api|endpoint|server|engine)\b|\b(?:system|model|user)\s+prompts?\b|\bprompt (?:engineering|injection|template)/i.test(blob)
+  return /\bAI in scope\b|\b(llm|rag|embedding|model card|model output|model drift|agentic|openai|anthropic|vector database|vector db|fine-tun\w*|hallucinat\w*)\b|\bmodel inference\b|\binference (?:api|endpoint|server|engine)\b|\b(?:system|model|user)\s+prompts?\b|\bprompt (?:engineering|injection|template)/i.test(blob)
 }
 
 // The repo says AI even when the record does not. Read-only, capped, local: the
@@ -3618,6 +3621,10 @@ function printUsage() {
 }
 
 const [cmd, ...args] = process.argv.slice(2)
+if (args.includes('--help') || args.includes('-h') || cmd === 'help' || cmd === '--help' || cmd === '-h') {
+  printUsage()
+  process.exit(0)
+}
 switch (cmd) {
   case 'demo': cmdDemo(args); break
   case 'scan': cmdScan(); break

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -135,7 +135,7 @@ fde doctor                        # check the fieldbook for gaps
 fde prep "sponsor sync"           # walk-in brief from existing memory
 fde log decision "…"
 fde log contact "…" --signal amber
-fde receipts "descope"            # dated agreements (ON RECORD)
+fde receipts "descope"            # dated lines (ON RECORD)
 fde dashboard --all               # every client, sorted by trust
 fde status [--all]                # value ledger, then trust
 fde vault [--redacted] [--out D]  # derived Obsidian vault of the whole portfolio (disposable)

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code: who can say yes, what went live, whether they signed off. Dated markdown on your laptop. You confirm each write.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.22.1",
+  "version": "3.22.2",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
   "author": {
     "name": "Subash Natarajan",

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -3251,6 +3251,17 @@ test('debrief --smart routes kickoff English "Helena signs off" and "has final s
   assert.match(success, /also named: Anand Mehta/)
 })
 
+test('debrief --smart keeps Priya, not the role in parentheses', () => {
+  const sandbox = makeSandbox('signer-role')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'roleco']).status, 0)
+  const notes = path.join(sandbox.dir, 'notes.md')
+  fs.writeFileSync(notes, 'Priya (VP Eng) signs off.\nshe signs off.\n')
+  const smart = runFde(sandbox, ['debrief', '--smart', notes])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /signs off:\*\* Priya/)
+  assert.doesNotMatch(smart.stdout, /signs off:\*\* (VP|she|She)/)
+})
+
 test('subcommand --help prints usage, not a meeting or a missing file', () => {
   const sandbox = makeSandbox('help-flag')
   assert.equal(runFde(sandbox, ['resume', '--init', 'helpco']).status, 0)

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -701,7 +701,7 @@ test('demo runs the real CLI on a fake client, leaks no private block, and stays
   // the value promise: notes routed, memory reloaded cold, receipts dated
   assert.match(r.stdout, /ENGAGEMENT READY/)
   assert.match(r.stdout, /debrief routed/)
-  assert.match(r.stdout, /ON RECORD \(dated - defensible\)/)
+  assert.match(r.stdout, /ON RECORD \(dated\):/)
   assert.match(r.stdout, /MEETING PREP/)
   assert.match(r.stdout, /fieldbook-current\.html/)
   // no fabricated transcript: the record on disk holds what the demo printed
@@ -3227,6 +3227,64 @@ test('debrief --smart routes "Priya signs off" into success.md and stakeholders.
   assert.match(fs.readFileSync(path.join(eng, 'context.md'), 'utf8'), /Budget fixed/)
   const prep = runFde(sandbox, ['prep', 'Friday'])
   assert.match(prep.stdout, /Priya/)
+})
+
+test('debrief --smart routes kickoff English "Helena signs off" and "has final say"', () => {
+  const sandbox = makeSandbox('kickoff-signer')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'kickco']).status, 0)
+  const notes = path.join(sandbox.dir, 'notes.md')
+  fs.writeFileSync(notes, [
+    'Finance controller (Helena) signs off. Budget fixed.',
+    'Anand Mehta has final say.',
+    'The API is slow on Mondays.',
+  ].join('\n') + '\n')
+  const smart = runFde(sandbox, ['debrief', '--smart', notes])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /signs off:\*\* Helena/)
+  assert.match(smart.stdout, /signs off:\*\* Anand Mehta/)
+  assert.doesNotMatch(smart.stdout, /signs off:\*\* (The|Finance|Staging)/)
+  const applied = runFde(sandbox, ['debrief', '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  const eng = engagementPath(sandbox, 'kickco')
+  const success = fs.readFileSync(path.join(eng, 'success.md'), 'utf8')
+  assert.match(success, /\*\*Stakeholder who signs off:\*\* Helena/)
+  assert.match(success, /also named: Anand Mehta/)
+})
+
+test('subcommand --help prints usage, not a meeting or a missing file', () => {
+  const sandbox = makeSandbox('help-flag')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'helpco']).status, 0)
+  for (const args of [['--help'], ['debrief', '--help'], ['prep', '--help'], ['log', '--help']]) {
+    const r = runFde(sandbox, args)
+    assert.equal(r.status, 0, `${args.join(' ')}: ${r.stderr}`)
+    assert.match(r.stdout, /fde - deterministic core/)
+    assert.doesNotMatch(r.stdout, /cannot read/)
+    assert.doesNotMatch(r.stdout, /MEETING PREP/)
+  }
+})
+
+test('receipts header is dated, not defensible', () => {
+  const sandbox = makeSandbox('receipts-dated')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'recco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'decision', 'sheet remains system of record until Denise signs']).status, 0)
+  const r = runFde(sandbox, ['receipts', 'Denise'])
+  assert.match(r.stdout, /ON RECORD \(dated\):/)
+  assert.doesNotMatch(r.stdout, /defensible/)
+})
+
+test('log delivery "not yet measured" is not a claimed number', () => {
+  const sandbox = makeSandbox('pending-measure')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'pendco']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'phase', 'ship']).status, 0)
+  const eng = engagementPath(sandbox, 'pendco')
+  fillOperatingMap(eng)
+  const logged = runFde(sandbox, [
+    'log', 'delivery',
+    'retry | cost-save | one night | not yet measured | pending | staging | flag off',
+  ])
+  assert.equal(logged.status, 0, logged.stderr)
+  const doctor = runFde(sandbox, ['doctor'])
+  assert.doesNotMatch(doctor.stdout, /measured but not accepted/)
 })
 
 test('debrief signer: does not overwrite a different signer already on record', () => {


### PR DESCRIPTION
## Summary
Three stranger-simulations (payments, healthcare, freight) showed kickoff English never filled the signer, `--help` was not help, and receipts called an unsigned line defensible. This release fixes those, nothing else.

- `debrief --smart`: "Finance controller (Helena) signs off" and "Anand Mehta has final say" fill `success.md`.
- `fde receipts`: `ON RECORD (dated):` — dated retrieval, not verified approval.
- `fde <cmd> --help` prints usage (no file named `--help`, no meeting named `--help`).
- Ledger "not yet measured" / "pending" is not a claimed number.
- Scan's own `AI in scope:` log line turns the eval gate on.

## Test plan
- [x] `npm run check` — 156/156
- [ ] After merge: tag v3.22.2, npm publish (NPM_TOKEN is already a repo secret)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/90" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->