### PR TITLE
3.23.0: one-screen debrief REVIEW

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
-  "version": "3.22.2",
+  "version": "3.23.0",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/.claude/commands/debrief.md
+++ b/.claude/commands/debrief.md
@@ -10,7 +10,7 @@ Run `fde debrief --smart` (fallback: `npx --yes fdeops debrief --smart`). `--sma
 
 Rewrite the propose output: add type prefixes where the record needs them. Strip noise; keep their words for quotes and decisions.
 
-Present the routing in plain language: what lands where in `.fde/`, what changed, what is still open. One screen, not a transcript dump.
+Present the REVIEW block first: decided, asked, open, next, signer. Confirm once. File routing stays underneath. Not a transcript dump.
 
 Only run `fde debrief --apply` (fallback: `npx --yes fdeops debrief --apply`) after the human confirms. Never auto-apply.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.23.0 - 2026-09-09
+
+Follow-up you can confirm in two minutes. No state machine.
+
+- `debrief --smart` / ingest propose: a one-screen REVIEW first (decided, asked, open, next, signer). File-routing still prints underneath. Confirm once, then `--apply`.
+- Optional `[approved: Name YYYY-MM-DD]` on a decision line. RECORD marks missing approval as `(unconfirmed)`. The CLI does not infer a yes from prose.
+- `doctor`: a dated decision after the last committed delivery line, or a signer change while a measured number is still unaccepted, asks for a review. No dependency graph.
+
 ## 3.22.2 - 2026-09-08
 
 Kickoff English fills the signer. Receipts stop calling a dated line defensible. `--help` is help.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ One chat. Name the client:
 @fde this is client01
 ```
 
-That creates `~/fde-engagements/client01/.fde/` on your laptop. Paste kickoff notes in the same thread. `@fde` picks what to check. You still decide.
+That creates `~/fde-engagements/client01/.fde/` on your laptop. Paste kickoff notes in the same thread. `@fde` picks what to check. You still decide. After a meeting you get one screen: what changed, new asks, open questions, next actions. Confirm once.
 
 Day to day: [docs/USAGE.md](docs/USAGE.md).
 

--- a/bin/check.js
+++ b/bin/check.js
@@ -636,6 +636,11 @@ if (apManifest.$schema !== AP_PLUGIN_SCHEMA) {
   fail(`version mismatch package.json ${pkg.version} vs plugin.json ${apManifest.version}`)
 } else ok('agent plugins manifest')
 
+const ingestPkg = JSON.parse(read('mcp/fdeops-ingest/package.json'))
+if (ingestPkg.version !== pkg.version) {
+  fail(`version mismatch package.json ${pkg.version} vs mcp/fdeops-ingest ${ingestPkg.version}`)
+} else ok('ingest package version aligned')
+
 const apMcp = JSON.parse(read('mcp.json'))
 const apServers = apMcp.mcpServers || {}
 if (apMcp.$schema !== AP_MCP_SCHEMA) {

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -58,6 +58,26 @@ function sh(cmd, cwd) {
   } catch (_) { return '' }
 }
 
+// Hex hashes only - never a shell. True when olderHash is an ancestor of newerHash.
+function gitIsAncestor(eng, olderHash, newerHash) {
+  if (!olderHash || !newerHash || olderHash === newerHash) return false
+  if (!/^[0-9a-f]{7,64}$/i.test(olderHash) || !/^[0-9a-f]{7,64}$/i.test(newerHash)) return false
+  try {
+    execFileSync('git', ['merge-base', '--is-ancestor', olderHash, newerHash], {
+      cwd: eng, stdio: 'ignore', timeout: 15000,
+    })
+    return true
+  } catch (_) { return false }
+}
+
+function gitLogHash(eng, args) {
+  try {
+    return execFileSync('git', ['log', '-1', '--format=%H', ...args], {
+      cwd: eng, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15000,
+    }).trim()
+  } catch (_) { return '' }
+}
+
 function slugify(name) {
   return String(name).toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'engagement'
 }
@@ -1781,6 +1801,101 @@ function writeProposal(eng, text) {
   return { proposePath, clean, blocks }
 }
 
+function approvedStamp(text) {
+  const m = String(text || '').match(/\[approved:\s*([^\]]+)\]/i)
+  return m ? m[1].trim() : ''
+}
+
+function stripApprovedStamp(text) {
+  return String(text || '').replace(/\s*\[approved:\s*[^\]]+\]/i, '').trim()
+}
+
+// One screen a human can confirm in two minutes. The file-by-file routing
+// still prints after this - agents edit prefixes; people read this.
+function printDebriefReview(text) {
+  const buckets = { decided: [], asked: [], open: [], next: [], signer: [] }
+  for (const raw of String(text || '').split('\n')) {
+    const line = raw.trim().replace(/^[-*+]\s+/, '')
+    if (!line) continue
+    const m = line.match(/^(decision|risk|delivery|contact|next|signer):\s*(.+)$/i)
+    if (!m) continue
+    const type = m[1].toLowerCase()
+    const body = m[2]
+    if (type === 'decision') {
+      const who = approvedStamp(body)
+      const core = previewLine(stripApprovedStamp(body), 90)
+      buckets.decided.push(who ? `${core}  (approved ${who})` : `${core}  (unconfirmed)`)
+    } else if (type === 'delivery') {
+      buckets.asked.push(previewLine(body, 100))
+    } else if (type === 'risk') {
+      buckets.open.push(previewLine(body, 100))
+    } else if (type === 'next') {
+      buckets.next.push(previewLine(body, 100))
+    } else if (type === 'signer') {
+      buckets.signer.push(previewLine(body, 80))
+    }
+  }
+  console.log('REVIEW (one screen - confirm once, then apply)\n')
+  const order = [
+    ['decided', buckets.decided],
+    ['asked', buckets.asked],
+    ['open', buckets.open],
+    ['next', buckets.next],
+    ['signer', buckets.signer],
+  ]
+  let any = false
+  for (const [label, items] of order) {
+    if (!items.length) continue
+    any = true
+    console.log(`  ${label}:`)
+    for (const item of items) console.log(`    - ${item}`)
+  }
+  if (!any) console.log('  (nothing prefixed yet - edit .debrief-propose, then apply)')
+  console.log('')
+}
+
+function latestDatedDecision(md) {
+  let latest = { date: '', line: '' }
+  for (const raw of String(md || '').split('\n')) {
+    const t = raw.trim()
+    const m = t.match(/^[-*]\s*\[(\d{4}-\d{2}-\d{2})\]/)
+    if (!m) continue
+    if (m[1] >= latest.date) latest = { date: m[1], line: t }
+  }
+  return latest
+}
+
+function formatDecisionRecord(line) {
+  const raw = String(line || '').trim().replace(/^[-*]\s*/, '')
+  const who = approvedStamp(raw)
+  const core = stripApprovedStamp(raw)
+  const stamp = who ? `(approved ${who})` : '(unconfirmed)'
+  return previewLine(`${core}  ${stamp}`, 110)
+}
+
+function changeReviewIssues(eng) {
+  const issues = []
+  const del = latestDeliveryEntry(readClean(eng, 'delivery.md'))
+  const dec = latestDatedDecision(readClean(eng, 'decisions.md'))
+  const delHash = del.line
+    ? sh(`git log -1 --format=%H -S${JSON.stringify(del.line)} -- delivery.md`, eng)
+    : ''
+  if (del.date && dec.date && dec.date > del.date && delHash) {
+    issues.push(
+      'a decision landed after the last delivery line - review whether what you are shipping still matches'
+    )
+  }
+  if (claimedValueRows(eng).claimed && delHash) {
+    const sigHash = gitLogHash(eng, ['-GStakeholder who signs off|also named:', '--', 'success.md'])
+    if (sigHash && gitIsAncestor(eng, delHash, sigHash)) {
+      issues.push(
+        'the signer line changed while a measured number is still unaccepted - pending acceptance may need a new yes'
+      )
+    }
+  }
+  return issues
+}
+
 function readSealCount(eng) {
   try {
     const n = parseInt(fs.readFileSync(path.join(eng, DEBRIEF_SEAL), 'utf8').trim(), 10)
@@ -1904,7 +2019,9 @@ function cmdDebrief(args) {
     if (smart) {
     const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
     console.log('SMART PROPOSE (heuristic - review before apply; no new facts invented beyond line rewrites)\n')
+    printDebriefReview(clean)
     console.log('Prefix vocabulary (lines that route): decision:  risk:  delivery:  contact:  next:  signer:')
+    console.log('Optional on a decision: [approved: Name YYYY-MM-DD]. Missing means unconfirmed.')
     console.log('Everything else → context.md. Keep the prefixes; the preview gate stays.\n')
     routeDebriefInput(eng, clean, { dry: true, force, sealed: blocks })
     if (!apply) {
@@ -2046,6 +2163,7 @@ function cmdIngest(args) {
     }
     const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
     console.log(`INGEST PROPOSE from ${path.basename(item)} (via:${source})\n`)
+    printDebriefReview(clean)
     routeDebriefInput(eng, clean, { dry: true, force: false, sealed: blocks })
     console.log(`\nproposal saved → ${proposePath}`)
     console.log('confirm:  fde ingest apply')
@@ -2516,6 +2634,7 @@ function collectDoctorIssues(eng) {
   }
   const reality = parseReality(readClean(eng, 'reality.md'), 220)
   if (reality.missing) issues.push(reality.missing)
+  issues.push(...changeReviewIssues(eng))
   return issues
 }
 
@@ -2768,7 +2887,7 @@ function hygieneTriageLines(eng) {
   const top = issues[0].replace(/\s+/g, ' ').trim().slice(0, 72)
   return [
     `  hygiene: ${issues.length} issue(s) - ${top}${issues[0].length > 72 ? '…' : ''}`,
-    '    → say "@fde clean up the fieldbook" when ready (agent runs fde doctor; nothing auto-rewrites)',
+    '    → say "@fde clean up the fieldbook" when ready (agent runs fde doctor; nothing auto-rewrites), or: fde doctor',
   ]
 }
 
@@ -2798,7 +2917,7 @@ function recordDigest(eng) {
   }
   const decisions = readClean(eng, 'decisions.md').split('\n')
     .filter(l => /^-\s*\[\d{4}-\d{2}-\d{2}\]/.test(l.trim())).slice(-2)
-  for (const d of decisions) lines.push(`  decided: ${d.trim().replace(/^-\s*/, '').slice(0, 110)}`)
+  for (const d of decisions) lines.push(`  decided: ${formatDecisionRecord(d)}`)
   return ['RECORD (read-only - success, delivery, decisions)', ...lines]
 }
 
@@ -3614,7 +3733,7 @@ function printUsage() {
   fde log phase <phase>    set engagement phase (land|discover|plan|ship|outcome|close)
   fde log --undo           remove the last CLI log/debrief entry from memory
   fde debrief [file]       meeting notes → memory (prefixed lines; --dry-run; --force)
-  fde debrief --smart      heuristic propose (prints decision:/risk:/delivery:/contact:/next:); --apply after confirm
+  fde debrief --smart      heuristic propose; REVIEW first (decided/asked/open/next/signer); --apply after one confirm
   fde ingest stage …       stage raw pull into <engagement>/.inbox/ (not .fde/)
   fde ingest list          list staged inbox items
   fde ingest propose <id>  smart-propose a staged item → .debrief-propose (confirm before apply)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -112,7 +112,7 @@ npx fdeops dashboard                # optional local HTML view of the fieldbook
 
 | You say | Agent runs |
 |---------|------------|
-| Debrief these notes | `fde debrief --smart …` → agent rewrites propose with prefixes if needed → you confirm → `--apply` |
+| Debrief these notes | `fde debrief --smart …` → REVIEW (decided / asked / open / next / signer) → you confirm once → `--apply` |
 | Make sure we're up to date / pull from Granola or email | Capability check → source MCP fetch → `fde ingest stage` → propose → confirm → apply |
 | Connect Granola / Notion / a new MCP / what can you pull | Guided `mcp.json` + [mcp/recipes/](../mcp/recipes/); save/reload in host; test stage only |
 | Prep me for the sponsor meeting | `fde prep "…"` |
@@ -126,7 +126,7 @@ npx fdeops dashboard                # optional local HTML view of the fieldbook
 ```bash
 fde triage                        # short status (also injected by session hooks)
 fde debrief notes.md              # if notes already use decision: / risk: / … prefixes
-fde debrief --smart notes.md      # heuristic propose (not AI); agent prefixes → --apply after confirm
+fde debrief --smart notes.md      # REVIEW first, then file routing; confirm once → --apply
 fde ingest stage [--source NAME] [--title TEXT] [file|-]  # raw pull → .inbox/
 fde ingest list                   # staged items
 fde ingest propose <id>           # → .debrief-propose (same smart path)

--- a/docs/schema.md
+++ b/docs/schema.md
@@ -38,7 +38,9 @@ After confirm, `fde ingest apply` writes thin dated facts into `.fde/` (same rou
 ### Decision entries
 
 `fde log decision "<text>"` appends a dated one-liner, which is enough for most
-choices. When the reasoning is the part that has to survive the engagement,
+choices. Optional `[approved: Name YYYY-MM-DD]` on that line is the only customer-yes
+the CLI treats as approval; without it, Monday's RECORD prints `(unconfirmed)`. Do not infer
+approval from "agreed" or a name in the prose. When the reasoning is the part that has to survive the engagement,
 write the long form under `## Decision log` instead:
 
 ```markdown

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.22.2",
+  "version": "3.23.0",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.22.2",
+  "version": "3.23.0",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code: who can say yes, what went live, whether they signed off. Dated markdown on your laptop. You confirm each write.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.22.2",
+  "version": "3.23.0",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
   "author": {
     "name": "Subash Natarajan",

--- a/skills/fde/SKILL.md
+++ b/skills/fde/SKILL.md
@@ -28,7 +28,7 @@ A one-line typo or compile error in a file that will not ship. On a bound client
 | **When did we agree?** | Don't argue from memory. Search the record. | `fde receipts <term>` | - |
 | **What's the outcome?** | A number nobody signed is claimed, not delivered. | `fde status` | `references/readout.md` |
 
-After a meeting: `fde debrief --smart` → confirm → `--apply`. Walk-in: `fde prep`. Friday: `fde status`.
+After a meeting: `fde debrief --smart` → one REVIEW screen (decided / asked / open / next / signer) → confirm once → `--apply`. Walk-in: `fde prep`. Friday: `fde status`.
 
 ## Ground loop
 
@@ -65,7 +65,7 @@ Writes need a bind (`FDEOPS_ENGAGEMENT` or registry). Never install fdeops on in
 |----------|---------|
 | where are we | `fde resume` |
 | day-1 look at the repo | `fde scan` |
-| debrief / pasted notes | `fde debrief --smart` → you rewrite prefixes → confirm → `--apply`. `--smart` is a gate, not a brain. `references/debrief.md` |
+| debrief / pasted notes | `fde debrief --smart` → REVIEW → confirm once → `--apply`. `--smart` is a gate, not a brain. `references/debrief.md` |
 | prep me for … | `fde prep "<label>"` |
 | when did we agree | `fde receipts <term>` |
 | sponsor update / the outcome | `fde status` |

--- a/skills/fde/references/debrief.md
+++ b/skills/fde/references/debrief.md
@@ -24,12 +24,13 @@
 2. Run `fde debrief --smart <notes.md>` (or `npx fdeops debrief --smart …`).
 3. Open `.debrief-propose`. If lines lack type prefixes, **rewrite them** before showing the FDE, e.g.:
    - `decision: agreed chargebacks stay phase 2 - Priya`
+   - `decision: freeze the API [approved: Priya 2026-09-08]` (optional; missing means unconfirmed)
    - `risk: legal may reopen scope if we slip the SOW date`
    - `contact: Priya pushed hard on Friday deck [signal:amber]`
    - `signer: Priya` (she can say yes; lands in `success.md`)
    - `next: send one-pager before Thursday 9am`
    - unprefixed lines stay context color only
-4. Show the **proposed** routing in plain language (what would become decisions, risks, contacts, next).
+4. Show the **REVIEW** block first (decided / asked / open / next / signer). That is the one screen to confirm. File routing stays underneath.
 5. On FDE confirm → run `fde debrief --apply`.
 6. On reject → stop; ask what to change; do not apply.
 

--- a/test/fde-cli.test.js
+++ b/test/fde-cli.test.js
@@ -1053,6 +1053,11 @@ test('debrief --smart proposes then --apply writes after confirm', () => {
   const propose = runFde(sandbox, ['debrief', '--smart', notes])
   assert.equal(propose.status, 0, propose.stderr)
   assert.match(propose.stdout, /SMART PROPOSE/)
+  assert.match(propose.stdout, /REVIEW \(one screen/)
+  const reviewAt = propose.stdout.indexOf('REVIEW (one screen')
+  const vocabAt = propose.stdout.indexOf('Prefix vocabulary')
+  assert.ok(reviewAt >= 0 && reviewAt < vocabAt, 'REVIEW must print before the file-routing dump')
+  assert.match(propose.stdout, /decided:[\s\S]*unconfirmed/)
   assert.match(propose.stdout, /\[signal:amber\].*Denise|Denise.*\[signal:amber\]/)
   assert.match(propose.stdout, /\[signal:green\].*Randy|Randy.*\[signal:green\]/)
   assert.match(propose.stdout, /Next action/)
@@ -3190,13 +3195,17 @@ test('dashboard does not render a schema-less reality.md as what is actually tru
   assert.doesNotMatch(html, /fb-why-reality">/)
 })
 
-test('debrief --smart prints the prefix vocabulary before the preview', () => {
+test('debrief --smart prints REVIEW before the prefix vocabulary', () => {
   const sandbox = makeSandbox('smart-vocab')
   assert.equal(runFde(sandbox, ['resume', '--init', 'vocabco']).status, 0)
   const notes = path.join(sandbox.dir, 'notes.md')
   fs.writeFileSync(notes, 'talked about the audit date\n')
   const smart = runFde(sandbox, ['debrief', '--smart', notes])
   assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /REVIEW \(one screen/)
+  const reviewAt = smart.stdout.indexOf('REVIEW (one screen')
+  const vocabAt = smart.stdout.indexOf('Prefix vocabulary')
+  assert.ok(reviewAt >= 0 && reviewAt < vocabAt)
   assert.match(smart.stdout, /decision:/)
   assert.match(smart.stdout, /risk:/)
   assert.match(smart.stdout, /delivery:/)
@@ -3619,6 +3628,7 @@ test('resume carries the record: who signs, what was promised, what was decided'
   assert.match(resume.stdout, /RECORD/)
   assert.match(resume.stdout, /signer: Ines Brandt/)
   assert.match(resume.stdout, /Hamburg desk only/)
+  assert.match(resume.stdout, /unconfirmed/, 'a decision without [approved:] stays visibly unconfirmed')
 
   // the session-start hook path (fde triage) carries the same record
   const triage = runFde(sandbox, ['triage'])
@@ -3765,3 +3775,65 @@ test('creating an engagement says it is not yet bound to a workspace', () => {
   assert.match(init.stdout, /fde resume --init meridian-health/, 'the one door that binds must be named')
   assert.doesNotMatch(init.stdout, /node bin\/install\.js/, 'an npm user has no clone to run that path from')
 })
+
+test('debrief REVIEW keeps [approved:] and does not infer a yes from prose', () => {
+  const sandbox = makeSandbox('review-approved')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'apprco']).status, 0)
+  const notes = path.join(sandbox.dir, 'notes.md')
+  fs.writeFileSync(notes, [
+    'decision: freeze the API [approved: Helena 2026-09-08]',
+    'decision: Helena agreed to keep Excel as fallback',
+    'delivery: retry live on staging',
+    'risk: legal may reopen scope',
+    'next: send the recap before Thursday',
+    'signer: Helena',
+  ].join('\n') + '\n')
+  const smart = runFde(sandbox, ['debrief', '--smart', notes])
+  assert.equal(smart.status, 0, smart.stderr)
+  assert.match(smart.stdout, /REVIEW \(one screen/)
+  assert.match(smart.stdout, /freeze the API\s+\(approved Helena 2026-09-08\)/)
+  assert.match(smart.stdout, /Helena agreed to keep Excel as fallback\s+\(unconfirmed\)/)
+  assert.doesNotMatch(smart.stdout, /Helena agreed to keep Excel as fallback\s+\(approved/)
+  assert.match(smart.stdout, /asked:[\s\S]*retry live on staging/)
+  assert.match(smart.stdout, /open:[\s\S]*legal may reopen/)
+  assert.match(smart.stdout, /next:[\s\S]*send the recap/)
+  assert.match(smart.stdout, /signer:[\s\S]*Helena/)
+  const applied = runFde(sandbox, ['debrief', '--apply'])
+  assert.equal(applied.status, 0, applied.stderr)
+  const resume = runFde(sandbox, ['resume'])
+  assert.match(resume.stdout, /approved Helena 2026-09-08/)
+  assert.match(resume.stdout, /unconfirmed/)
+})
+
+test('doctor asks for a review when a later decision lands after a committed delivery', () => {
+  const sandbox = makeSandbox('review-decision')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'revdec']).status, 0)
+  assert.equal(runFde(sandbox, ['log', 'delivery', 'retry live on staging']).status, 0)
+  const sameDay = runFde(sandbox, ['doctor'])
+  assert.doesNotMatch(sameDay.stdout, /decision landed after the last delivery/)
+  assert.equal(runFde(sandbox, ['log', 'decision', 'keep the flag off']).status, 0)
+  const stillSameDay = runFde(sandbox, ['doctor'])
+  assert.doesNotMatch(stillSameDay.stdout, /decision landed after the last delivery/, 'same-day debrief after a ship is not a doctor fail')
+  const eng = engagementPath(sandbox, 'revdec')
+  fs.appendFileSync(path.join(eng, 'decisions.md'), '\n- [2099-01-01] descope the reporting slice until the audit\n')
+  const later = runFde(sandbox, ['doctor'])
+  assert.match(later.stdout, /decision landed after the last delivery line/)
+})
+
+test('doctor asks for a review when the signer changes on an unaccepted number', () => {
+  const sandbox = makeSandbox('review-signer')
+  assert.equal(runFde(sandbox, ['resume', '--init', 'revsig']).status, 0)
+  const before = runFde(sandbox, ['debrief'], { input: 'signer: Priya\n' })
+  assert.equal(before.status, 0, before.stderr)
+  assert.equal(runFde(sandbox, [
+    'log', 'delivery',
+    'retry | cost-save | 2h/week | 1.8h/week | | sheet | flag off',
+  ]).status, 0)
+  const claimedFirst = runFde(sandbox, ['doctor'])
+  assert.doesNotMatch(claimedFirst.stdout, /signer line changed/, 'signer named before the number is not a change')
+  const after = runFde(sandbox, ['debrief'], { input: 'signer: Helena\n' })
+  assert.equal(after.status, 0, after.stderr)
+  const changed = runFde(sandbox, ['doctor'])
+  assert.match(changed.stdout, /signer line changed while a measured number is still unaccepted/)
+})
+


### PR DESCRIPTION
## Summary
- After a meeting, `fde debrief --smart` prints a one-screen REVIEW (decided / asked / open / next / signer) before the file-routing dump. Confirm once, then `--apply`.
- Optional `[approved: Name YYYY-MM-DD]` on a decision. RECORD marks missing approval as `(unconfirmed)`. Prose is not treated as a yes.
- Doctor asks for a look when a dated decision lands after the last committed delivery line, or when the signer changes while a measured number is still unaccepted. No state machine, no dependency graph.

## Test plan
- [x] `node bin/check.js`
- [x] CLI tests 160/160 (`npm test`)
- [ ] After merge: tag `v3.23.0` so release.yml publishes to npm


Made with [Cursor](https://cursor.com)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/91" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->