### PR TITLE
Fix daily debrief retries, review preservation, and handoff gaps

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "fdeops",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "category": "productivity",
   "tags": [
     "community-managed"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 3.27.1 - 2026-09-10
+
+- Preserve pending debrief reviews until applied or explicitly replaced with `--replace-proposal`, including their private notes after caught replacement failures.
+- Acquire record locks before applying a debrief and restore prior records after caught write errors, so ordinary contention retries do not duplicate partial updates. Serialize concurrent applies of one proposal.
+- Cap long debrief and ingest previews while keeping the complete proposal on disk. Say “not detected” when phrase recognition misses details rather than claiming the notes never stated them.
+- Include missing success criteria and acceptance owners in early handoff/readout gaps. Clarify that ledger summaries do not include every prose delivery note.
+- Refuse dashboard exports into record directories and clarify how to refresh a portfolio or custom report.
+- Document independent daily-use simulations, browser checks, effort counts, and remaining recovery/model limits.
+
 ## 3.27.0 - 2026-09-10
 
 - Keep unsourced decisions and delivery numbers as CLAIM. A log date is not a source; pending evidence cannot produce accepted value, including legacy ledger rows. Existing files are not rewritten.

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ The CLI does the file work without calling a model. Commands that change records
 
 [All commands and examples](docs/USAGE.md).
 
+For free-form notes, start with `@fde` so your agent can help interpret them. The CLI's `--smart` option recognizes common phrases; review its proposal because it can miss requests or next actions in ordinary prose.
+
 ## Your records, your control
 
 Each client has its own `.fde/` folder of Markdown files. The brief, success criteria, decisions, risks, and delivery ledger stay readable outside FDEOps. The CLI uses local files and Git, with no network calls or telemetry. Optional [MCP sources](mcp/recipes/) are connected through your agent host, then pulled and reviewed on request.

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -1994,7 +1994,7 @@ function readSealedProposal(eng) {
 // before the first append, and restore snapshots if an ordinary write fails.
 // This is not a power-loss transaction; no history is deleted or reset.
 function withDebriefRecords(eng, apply, files = ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md',
-  'success.md', 'context.md', SIGNAL_LEDGER, LAST_WRITE]) {
+  'success.md', 'context.md', SIGNAL_LEDGER, LAST_WRITE, DEBRIEF_PROPOSE, DEBRIEF_PRIVATE, DEBRIEF_SEAL]) {
   files = files.slice().sort()
   const snapshots = new Map()
   function lockAt(index) {
@@ -2021,7 +2021,7 @@ function withDebriefRecords(eng, apply, files = ['decisions.md', 'risks.md', 'de
           else if (fs.existsSync(target)) fs.unlinkSync(target)
         } catch (_) { failed.push(path.basename(target)) }
       }
-      if (failed.length) throw new Error(`${error.message}; recovery could not restore ${failed.join(', ')}. Inspect these records before retrying; the proposal is retained.`)
+      if (failed.length) throw new Error(`${error.message}; recovery could not restore ${failed.join(', ')}. Inspect these records and the pending proposal before retrying.`)
       throw new Error(`${error.message}; no record changes kept. The proposal is retained; retry after resolving the cause.`)
     } finally { debriefTransactionActive = false }
   }
@@ -2051,7 +2051,17 @@ function boundedDebriefPreview(eng, render, { proposal = true, maxBytes = 12000 
 function routeDebriefInput(eng, input, { dry, force, sealed = [] }) {
   if (!dry && !debriefTransactionActive) {
     ensureMemoryGit(eng)
-    return withDebriefRecords(eng, () => routeDebriefInput(eng, input, { dry, force, sealed }))
+    return withDebriefRecords(eng, () => {
+      const result = routeDebriefInput(eng, input, { dry, force, sealed })
+      // Consuming the review is part of the write. If cleanup fails, restoring
+      // both the records and proposal makes the next explicit apply safe.
+      for (const file of [DEBRIEF_PROPOSE, DEBRIEF_PRIVATE, DEBRIEF_SEAL]) {
+        try { fs.unlinkSync(path.join(eng, file)) } catch (error) {
+          if (error.code !== 'ENOENT') throw new Error(formatFsError(error, 'remove', file))
+        }
+      }
+      return result
+    })
   }
   const d = new Date()
   const date = d.toISOString().slice(0, 10)
@@ -2205,9 +2215,6 @@ function runDebrief(args, eng) {
     const hash = commitMemory(eng, 'debrief', {
       files: ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md', 'success.md', 'context.md', SIGNAL_LEDGER],
     })
-    try { fs.unlinkSync(path.join(eng, DEBRIEF_PROPOSE)) } catch (_) {}
-    try { fs.unlinkSync(path.join(eng, DEBRIEF_PRIVATE)) } catch (_) {}
-  try { fs.unlinkSync(path.join(eng, DEBRIEF_SEAL)) } catch (_) {}
     if (hash) console.log(`memory @${hash}`)
   }
   const plural = {

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -487,7 +487,11 @@ function formatFsError(err, action, target) {
   return `cannot ${action} ${where}${code ? ` (${code})` : ''}${err && err.message && !code ? ': ' + err.message : ''}`
 }
 
+let debriefTransactionActive = false
+const ownedDebriefLocks = new Set()
+
 function failFs(err, action, target) {
+  if (debriefTransactionActive || ownedDebriefLocks.size) throw new Error(formatFsError(err, action, target))
   console.error(formatFsError(err, action, target))
   process.exit(1)
 }
@@ -503,6 +507,7 @@ function refuseSymlinkWrite(p, opts = {}) {
       const msg = st.isSymbolicLink()
         ? `refused: ${path.basename(p)} is a symlink - write would leave the engagement tree. Replace it with a real file.`
         : `refused: ${path.basename(p)} is not a regular file - remove it and re-run; every write is refused while it is there.`
+      if ((debriefTransactionActive || ownedDebriefLocks.size) && !opts.soft) throw new Error(msg)
       if (opts.soft) return msg
       console.error(msg)
       process.exit(1)
@@ -518,6 +523,8 @@ function refuseSymlinkWrite(p, opts = {}) {
 // Exclusive create lock + retry. Two parallel agent sessions (or hook + CLI)
 // appending the same .fde file otherwise interleave/corrupt under load.
 function withFileLock(targetPath, fn, opts = {}) {
+  if (ownedDebriefLocks.has(targetPath)) return fn()
+  if (debriefTransactionActive || ownedDebriefLocks.size) opts = { ...opts, soft: true }
   const lockPath = targetPath + '.lock'
   const deadline = Date.now() + 5000
   while (true) {
@@ -1789,28 +1796,24 @@ function readDebriefInput(args) {
   if (args[0]) {
     const notesPath = args[0].replace(/^~/, HOME)
     let st
-    try { st = fs.statSync(notesPath) } catch (_) { console.error(`cannot read ${args[0]}`); process.exit(1) }
+    try { st = fs.statSync(notesPath) } catch (_) { throw new Error(`cannot read ${args[0]}`) }
     if (st.size > DEBRIEF_MAX_BYTES) {
-      console.error(`debrief refused: ${args[0]} is ${st.size} bytes (max ${DEBRIEF_MAX_BYTES}). Split the notes or paste the relevant section.`)
-      process.exit(1)
+      throw new Error(`debrief refused: ${args[0]} is ${st.size} bytes (max ${DEBRIEF_MAX_BYTES}). Split the notes or paste the relevant section.`)
     }
     let buf
-    try { buf = fs.readFileSync(notesPath) } catch (_) { console.error(`cannot read ${args[0]}`); process.exit(1) }
+    try { buf = fs.readFileSync(notesPath) } catch (_) { throw new Error(`cannot read ${args[0]}`) }
     if (buf.includes(0) || looksLikeBinaryNoise(buf.toString('utf8'))) {
-      console.error(`debrief refused: ${args[0]} looks binary or mostly non-printable. Paste text notes only.`)
-      process.exit(1)
+      throw new Error(`debrief refused: ${args[0]} looks binary or mostly non-printable. Paste text notes only.`)
     }
     input = buf.toString('utf8')
   } else {
     let buf
     try { buf = fs.readFileSync(0) } catch (_) { buf = Buffer.alloc(0) }
     if (Buffer.byteLength(buf) > DEBRIEF_MAX_BYTES) {
-      console.error(`debrief refused: stdin is over ${DEBRIEF_MAX_BYTES} bytes. Split the notes.`)
-      process.exit(1)
+      throw new Error(`debrief refused: stdin is over ${DEBRIEF_MAX_BYTES} bytes. Split the notes.`)
     }
     if (buf.includes(0) || looksLikeBinaryNoise(buf.toString('utf8'))) {
-      console.error('debrief refused: stdin looks binary or mostly non-printable. Paste text notes only.')
-      process.exit(1)
+      throw new Error('debrief refused: stdin looks binary or mostly non-printable. Paste text notes only.')
     }
     input = buf.toString('utf8')
   }
@@ -1823,15 +1826,29 @@ function previewLine(text, max = 240) {
   return `${t.slice(0, max)}… (${t.length} chars)`
 }
 
-function writeProposal(eng, text) {
+function writeProposal(eng, text, { replace = false, locked = false } = {}) {
+  if (!locked && ownedDebriefLocks.has(path.join(eng, DEBRIEF_PROPOSE))) return writeProposal(eng, text, { replace, locked: true })
+  if (!locked) return withFileLock(path.join(eng, DEBRIEF_PROPOSE), () => {
+    ownedDebriefLocks.add(path.join(eng, DEBRIEF_PROPOSE))
+    try { return writeProposal(eng, text, { replace, locked: true }) }
+    finally { ownedDebriefLocks.delete(path.join(eng, DEBRIEF_PROPOSE)) }
+  }, { soft: true })
+  if (!debriefTransactionActive) return withDebriefRecords(eng, () => writeProposal(eng, text, { replace, locked: true }), [DEBRIEF_PROPOSE, DEBRIEF_PRIVATE, DEBRIEF_SEAL])
   const { clean, blocks } = splitPrivate(text, { sealDangling: true })
   const proposePath = path.join(eng, DEBRIEF_PROPOSE)
   const privatePath = path.join(eng, DEBRIEF_PRIVATE)
+  if (fs.existsSync(proposePath) && !replace) {
+    const existing = fs.readFileSync(proposePath, 'utf8')
+    const existingPrivate = readSealedProposal(eng)
+    if (existing !== clean || JSON.stringify(existingPrivate) !== JSON.stringify(blocks)) {
+      throw new Error('pending proposal already exists. Review and apply it first, or explicitly replace it with fde debrief --smart <notes> --replace-proposal.')
+    }
+  }
   // Seal first. A refused or failed sidecar write must not leave behind a
   // proposal whose (private - redacted) marker has nothing left behind it.
   if (blocks.length) {
     const blocked = refuseSymlinkWrite(privatePath, { soft: true })
-    if (blocked) { console.error(blocked); process.exit(1) }
+    if (blocked) throw new Error(blocked)
     withFileLock(privatePath, () => { atomicWriteFile(privatePath, sealedText(blocks), { mode: 0o600 }) })
     try { fs.chmodSync(privatePath, 0o600) } catch (_) {}
   } else {
@@ -1898,12 +1915,13 @@ function printDebriefReview(text, eng) {
   let any = false
   for (const [label, items] of order) {
     if (!items.length) {
-      if (['stated asks', 'proposed scope', 'next action', 'named signer (authority, not approval)'].includes(label)) console.log(`  ${label}: not stated`)
+      if (['stated asks', 'proposed scope', 'next action', 'named signer (authority, not approval)'].includes(label)) console.log(`  ${label}: not detected - review the notes`)
       continue
     }
     any = true
     console.log(`  ${label}:`)
-    for (const item of items) console.log(`    - ${item}`)
+    for (const item of items.slice(0, 5)) console.log(`    - ${item}`)
+    if (items.length > 5) console.log(`    - ${items.length - 5} more omitted here; review the full proposal before applying.`)
   }
   if (!any) console.log('  (nothing prefixed yet - edit .debrief-propose, then apply)')
   const recorded = eng ? parseValueLedger(eng).rows : []
@@ -1972,7 +1990,69 @@ function readSealedProposal(eng) {
   } catch (_) { return [] }
 }
 
+// A debrief touches several records. Acquire every cooperating writer's lock
+// before the first append, and restore snapshots if an ordinary write fails.
+// This is not a power-loss transaction; no history is deleted or reset.
+function withDebriefRecords(eng, apply, files = ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md',
+  'success.md', 'context.md', SIGNAL_LEDGER, LAST_WRITE]) {
+  files = files.slice().sort()
+  const snapshots = new Map()
+  function lockAt(index) {
+    if (index < files.length) {
+      const target = path.join(eng, files[index])
+      if (ownedDebriefLocks.has(target)) return lockAt(index + 1)
+      return withFileLock(target, () => {
+        ownedDebriefLocks.add(target)
+        try { return lockAt(index + 1) } finally { ownedDebriefLocks.delete(target) }
+      }, { soft: true })
+    }
+    for (const file of files) {
+      const target = path.join(eng, file)
+      const blocked = refuseSymlinkWrite(target, { soft: true })
+      if (blocked) throw new Error(blocked)
+      snapshots.set(target, fs.existsSync(target) ? { bytes: fs.readFileSync(target), mode: fs.statSync(target).mode & 0o777 } : null)
+    }
+    debriefTransactionActive = true
+    try { return apply() } catch (error) {
+      const failed = []
+      for (const [target, previous] of snapshots) {
+        try {
+          if (previous) atomicWriteFile(target, previous.bytes, { mode: previous.mode, soft: true })
+          else if (fs.existsSync(target)) fs.unlinkSync(target)
+        } catch (_) { failed.push(path.basename(target)) }
+      }
+      if (failed.length) throw new Error(`${error.message}; recovery could not restore ${failed.join(', ')}. Inspect these records before retrying; the proposal is retained.`)
+      throw new Error(`${error.message}; no record changes kept. The proposal is retained; retry after resolving the cause.`)
+    } finally { debriefTransactionActive = false }
+  }
+  return lockAt(0)
+}
+
+// Limit model-facing review output while preserving the full editable proposal.
+function boundedDebriefPreview(eng, render, { proposal = true, maxBytes = 12000 } = {}) {
+  const original = console.log, originalError = console.error
+  let bytes = 0, omitted = 0
+  const bounded = output => (...args) => {
+    const line = args.join(' ') + '\n'
+    const size = Buffer.byteLength(line)
+    if (bytes + size > maxBytes) { omitted++; return }
+    bytes += size; output(...args)
+  }
+  console.log = bounded(original)
+  console.error = bounded(originalError)
+  let result
+  try { result = render() } finally { console.log = original; console.error = originalError }
+  if (omitted) console.log(proposal
+    ? `\n${omitted} preview lines omitted. Review the complete proposal at ${path.join(eng, DEBRIEF_PROPOSE)} before applying.`
+    : `\n${omitted} preview lines omitted. Review the full input notes before applying.`)
+  return result
+}
+
 function routeDebriefInput(eng, input, { dry, force, sealed = [] }) {
+  if (!dry && !debriefTransactionActive) {
+    ensureMemoryGit(eng)
+    return withDebriefRecords(eng, () => routeDebriefInput(eng, input, { dry, force, sealed }))
+  }
   const d = new Date()
   const date = d.toISOString().slice(0, 10)
   const counts = { decision: 0, risk: 0, delivery: 0, contact: 0, next: 0, signer: 0 }
@@ -2044,6 +2124,18 @@ function routeDebriefInput(eng, input, { dry, force, sealed = [] }) {
 }
 
 function cmdDebrief(args) {
+  const eng = resolveEngagement({ forWrite: true })
+  if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exitCode = 2; return }
+  const target = path.join(eng, DEBRIEF_PROPOSE)
+  try {
+    withFileLock(target, () => {
+      ownedDebriefLocks.add(target)
+      try { return runDebrief(args, eng) } finally { ownedDebriefLocks.delete(target) }
+    }, { soft: true })
+  } catch (error) { console.error(error.message); process.exitCode = 1 }
+}
+
+function runDebrief(args, eng) {
   args = args.slice()
   const dryIdx = args.indexOf('--dry-run')
   const dry = dryIdx !== -1
@@ -2058,35 +2150,45 @@ function cmdDebrief(args) {
   const forceIdx = args.indexOf('--force')
   if (forceIdx !== -1) { force = true; args.splice(forceIdx, 1) }
 
-  const eng = resolveEngagement({ forWrite: true })
-  if (!eng) { console.error('no engagement - run: fde resume --init <name>'); process.exit(2) }
+  const replaceIdx = args.indexOf('--replace-proposal')
+  const replace = replaceIdx !== -1
+  if (replace) args.splice(replaceIdx, 1)
+  if (replace && !smart) throw new Error('--replace-proposal requires --smart <notes>')
 
+  if (!smart && !apply && !dry && fs.existsSync(path.join(eng, DEBRIEF_PROPOSE))) {
+    throw new Error('pending proposal already exists. Review and apply it before writing another debrief.')
+  }
+  if (apply && !smart && args[0] && fs.existsSync(path.join(eng, DEBRIEF_PROPOSE))) {
+    throw new Error('pending proposal already exists. Use debrief --apply without a notes file to apply that review.')
+  }
   let input = ''
   let sealed = []
   if (apply && !smart && !args[0]) {
     try { input = stripControlChars(fs.readFileSync(path.join(eng, DEBRIEF_PROPOSE), 'utf8')) } catch (_) {
       console.error('nothing to apply - run: fde debrief --smart <notes.md>   then   fde debrief --apply')
-      process.exit(1)
+      return void (process.exitCode = 1)
     }
     sealed = readSealedProposal(eng)
     const expected = readSealCount(eng)
     if (expected === null ? (!sealed.length && input.includes(PRIVATE_MARKER)) : sealed.length < expected) {
       console.error(`refused: the proposal seals a private note but ${DEBRIEF_PRIVATE} is missing or unreadable - applying now would drop it silently.`)
       console.error('re-run the propose step (fde debrief --smart <notes> | fde ingest propose <id>).')
-      process.exit(1)
+      return void (process.exitCode = 1)
     }
   } else {
     input = readDebriefInput(args)
   }
 
     if (smart) {
-    const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
+    const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input), { replace })
+    boundedDebriefPreview(eng, () => {
     console.log('SMART PROPOSE (heuristic - review before apply; no new facts invented beyond line rewrites)\n')
     printDebriefReview(clean, eng)
     console.log('Prefix vocabulary (lines that route): decision:  risk:  delivery:  contact:  next:  signer:')
     console.log('Optional on a decision: [approved: Name YYYY-MM-DD]. Missing means unconfirmed.')
     console.log('Everything else → context.md. Keep the prefixes; the preview gate stays.\n')
     routeDebriefInput(eng, clean, { dry: true, force, sealed: blocks })
+    }, { maxBytes: 8000 })
     if (!apply) {
       console.log(`\nproposal saved → ${proposePath}`)
       console.log('confirm:  fde debrief --apply')
@@ -2097,7 +2199,8 @@ function cmdDebrief(args) {
     sealed = blocks
   }
 
-  const { counts, ctxLines, privateBlocks } = routeDebriefInput(eng, input, { dry, force, sealed })
+  const route = () => routeDebriefInput(eng, input, { dry, force, sealed })
+  const { counts, ctxLines, privateBlocks } = boundedDebriefPreview(eng, route, { proposal: false, maxBytes: smart ? 4000 : 12000 })
   if (!dry) {
     const hash = commitMemory(eng, 'debrief', {
       files: ['decisions.md', 'risks.md', 'delivery.md', 'stakeholders.md', 'success.md', 'context.md', SIGNAL_LEDGER],
@@ -2224,10 +2327,14 @@ function cmdIngest(args) {
       console.error(`ingest propose refused: staged item is over ${DEBRIEF_MAX_BYTES} bytes after provenance. Split it.`)
       process.exit(1)
     }
-    const { proposePath, clean, blocks } = writeProposal(eng, smartProposeText(input))
+    let proposal
+    try { proposal = writeProposal(eng, smartProposeText(input)) } catch (error) { console.error(error.message); process.exitCode = 1; return }
+    const { proposePath, clean, blocks } = proposal
+    boundedDebriefPreview(eng, () => {
     console.log(`INGEST PROPOSE from ${path.basename(item)} (via:${source})\n`)
     printDebriefReview(clean, eng)
     routeDebriefInput(eng, clean, { dry: true, force: false, sealed: blocks })
+    })
     console.log(`\nproposal saved → ${proposePath}`)
     console.log('confirm:  fde ingest apply')
     console.log('(agent: rewrite lines with decision:/risk:/contact:/next: prefixes before apply)')
@@ -3889,6 +3996,7 @@ function printUsage() {
   fde log --undo           remove the last CLI log/debrief entry from memory
   fde debrief [file]       meeting notes → memory (prefixed lines; --dry-run; --force)
   fde debrief --smart      heuristic propose; REVIEW first (decided/asked/open/next/signer); --apply after one confirm
+    --replace-proposal    explicitly discard a pending review when proposing different notes
   fde ingest stage …       stage raw pull into <engagement>/.inbox/ (not .fde/)
   fde ingest list          list staged inbox items
   fde ingest propose <id>  smart-propose a staged item → .debrief-propose (confirm before apply)

--- a/bin/fde.js
+++ b/bin/fde.js
@@ -2353,13 +2353,13 @@ function cmdHandoff(args, label = 'Handoff') {
   const claims = selected.filter(d => !hasSource(d.text))
   const decisionText = d => `${d.text} (decisions.md:${d.line}, redacted view)`
   const next = stripTemplateNoise(sectionBody(readClean(eng, 'context.md'), 'Next action', { lastNonEmpty: true }))
-  const gaps = collectDoctorIssues(eng)
+  const gaps = collectDoctorIssues(eng, { readiness: true })
   const report = context.boundedSections([
     `# ${label}: ${engagementSlugFromPath(eng)}\nSnapshot: ${new Date().toISOString()} · memory ${memoryHead(eng) || 'unversioned'}\nRead-only record, not proof of approval. Confirm sources with the named customer before relying on a claim. Private blocks are excluded; review remaining client information before sharing.`,
     `## Constraints - trust-profile.md\n${stripTemplateNoise(readClean(eng, 'trust-profile.md')) || '(missing)'}`,
     `## Signer and success - success.md\nSigner: ${signer || '(missing; do not infer)'}\n${success || '(missing)'}`,
     `## Next action - context.md\n${next || '(missing)'}\n\n## Open risks - risks.md\n${extractRisks(eng).map(r => '- ' + r.text).join('\n') || '(none recorded; not proof of no risk)'}`,
-    `## Accepted value - recorded assertion with source\n${ledger.filter(r => r.state === 'accepted').map(rowText).join('\n') || '(none)'}\n\n## CLAIMS and unmeasured promises\n${ledger.filter(r => r.state !== 'accepted').map(r => rowText(r) + ' [' + r.state + ']').join('\n') || '(none)'}`,
+    `## Accepted value - recorded assertion with source\nOnly structured value-ledger rows are summarized here; review other notes in delivery.md before presenting or handing over this record.\n${ledger.filter(r => r.state === 'accepted').map(rowText).join('\n') || '(none)'}\n\n## CLAIMS and unmeasured promises\n${ledger.filter(r => r.state !== 'accepted').map(r => rowText(r) + ' [' + r.state + ']').join('\n') || '(none)'}`,
     `## ON RECORD decisions - source supplied, not automatic approval\n${records.map(decisionText).join('\n') || '(none)'}\n\n## CLAIM decisions - source missing\n${claims.map(decisionText).join('\n') || '(none)'}\nSelected ${selected.length} of ${decisions.length} dated decisions. Retrieve older or conflicting decisions with fde recall.`,
     `## Gaps before relying on this packet\n${gaps.map(g => '- ' + g).join('\n') || '(no deterministic lint gaps; human review still required)'}`,
   ], parsed.maxBytes)
@@ -3522,7 +3522,13 @@ function cmdDashboard(args) {
   const html = render.buildFieldbookHtml({ engagements, today, generatedAt: new Date().toISOString() })
 
   try {
+    const isRecordPath = p => p.split(path.sep).some(part => ['.fde', '.git'].includes(part.toLowerCase()))
+    if (isRecordPath(outPath)) throw new Error('save the dashboard outside .fde/ and .git/; these folders hold records, not reports')
+    let existingParent = path.dirname(outPath)
+    while (!fs.existsSync(existingParent)) existingParent = path.dirname(existingParent)
+    if (isRecordPath(fs.realpathSync(existingParent))) throw new Error('save the dashboard outside .fde/ and .git/; this path points into a record folder')
     fs.mkdirSync(path.dirname(outPath), { recursive: true })
+    if (isRecordPath(fs.realpathSync(path.dirname(outPath)))) throw new Error('save the dashboard outside .fde/ and .git/; this path points into a record folder')
     atomicWriteFile(outPath, html)
   } catch (e) {
     failFs(e, 'write fieldbook', outPath)

--- a/bin/lib/render.js
+++ b/bin/lib/render.js
@@ -573,7 +573,7 @@ ${railItems}
 </aside>
 <main id="fb-main" tabindex="-1" class="fb-main fb-scroll">
 <div class="fb-main-inner">
-<div class="fb-snapshot"><strong>Read-only snapshot</strong> &middot; Snapshot generated <time datetime="${escapeHtml(generatedAt)}">${escapeHtml(generatedAt ? generatedAt.replace('T', ' ').replace(/\.\d+Z$/, ' UTC') : today)}</time>. Re-run <code>fde dashboard</code> after updating your records. Reloading this page alone does not refresh the record.</div>
+<div class="fb-snapshot"><strong>Read-only snapshot</strong> &middot; Snapshot generated <time datetime="${escapeHtml(generatedAt)}">${escapeHtml(generatedAt ? generatedAt.replace('T', ' ').replace(/\.\d+Z$/, ' UTC') : today)}</time>. After updating your records, run the dashboard command that created this file again, keeping the same <code>--all</code> and <code>--out</code> options if used. Then reload. Reloading this page alone does not refresh the record.</div>
 ${todayView}
 ${clientViews}
 <p id="fb-status" class="fb-copy-status" role="status" aria-live="polite"></p>

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -71,6 +71,10 @@ You do not pick a skill. **`@fde` routes the AI and loads the relevant reference
 
 ## A daily routine
 
+For free-form notes, ask `@fde` to help interpret them and review the proposed changes. The CLI's `debrief --smart` recognizes common phrases; “not detected” means it may have missed something, not that your notes contain no request or next action.
+
+An unfinished proposal stays available for review. Apply it before starting another, or use `fde debrief --smart --replace-proposal notes.md` to explicitly discard it and review different notes. Repeating an already-applied note is a new update, so check for duplicates before saving it again.
+
 | Moment | What to ask | What to check |
 |---|---|---|
 | Start of day | `@fde Where did we leave off with this client?` | Correct customer, current state, next action |
@@ -94,7 +98,7 @@ If your browser does not open automatically, open the HTML path printed by the c
 - Open an engagement to review its context, decisions, risks, and value ledger. A measured result and an accepted result are different states.
 - Use search to find an engagement or recorded detail.
 - Copy a meeting-prep, debrief, or readout prompt into your agent to do the follow-up work. Copying a prompt does not execute it or change records.
-- After applying notes or editing memory, run the dashboard command again and reload the page. It is a **read-only snapshot**, not a live editor. Check the generation date before relying on it.
+- After applying notes or editing memory, repeat the dashboard command with the same `--all` and `--out` options, if used, and reload the page. It is a **read-only snapshot**, not a live editor. Check the generation date before relying on it.
 
 The HTML contains redacted engagement information, which can still be customer-confidential. Review it before sharing or presenting your screen. `.fde/` remains the source of truth.
 

--- a/docs/verification.md
+++ b/docs/verification.md
@@ -46,3 +46,7 @@ Automated `toolCheckPassed` means an expected tool was called and a response arr
 GitHub identity and Context7 library lookup both responded in the maintainer's environment. These are connector checks, not source-ingestion end-to-end tests or evidence about every user's credentials. The disabled legacy computer-use entry was left unchanged. Other configured host tools were not globally reconfigured or certified.
 
 For model judgment, use the broader [delivery evaluation](../evals/delivery/README.md) with repeated, blinded comparisons. No universal performance or best-in-class claim follows from passing software tests.
+
+## Daily-use simulations
+
+[Daily-use results](../evals/daily-use.md) cover independent agent simulations of onboarding, updates, client switching, handoff, and a real browser journey. They record reproduced failures, repairs, command counts, and remaining limits. These checks do not establish human time savings or repeat adoption.

--- a/evals/daily-use.md
+++ b/evals/daily-use.md
@@ -1,0 +1,56 @@
+# Daily-use simulations
+
+Date: 2026-09-10. Baseline: Main `680f320` (3.27.0).
+
+Two independent agent sessions exercised the real CLI using fictional clients and isolated homes/workspaces. A lead session exercised the generated dashboard in Chromium. These are software and workflow simulations, not five independent human users or a live trial across every supported agent host.
+
+The quality bar is less work reconstructing context, clearer customer acceptance, and less administration. Repeat use and time saved still require independent users. No claim of best-in-class superiority follows from these results.
+
+## Reproduced failures and repairs
+
+| Situation | Baseline behavior | Repair |
+|---|---|---|
+| A decision and risk are applied while the risk record is locked | Decision is appended before failure; retry duplicates it | Acquire record locks before writing; restore records after caught write failures |
+| New notes arrive while a review is pending | Pending review is silently replaced | Preserve the review; require explicit replacement |
+| Large notes contain 5,000 decisions | REVIEW and routing output exceed 750 KB | Bound preview output and identify omitted content; keep the full proposal on disk |
+| Ordinary prose contains requests the simple phrase recognizer misses | REVIEW says they were “not stated” | Say “not detected” and ask for review; explain the agent/CLI distinction |
+| Sponsor readout or handoff during discovery lacks a signer and usable success test | Those gaps are omitted because phase-specific doctor checks have not started | Include readiness checks regardless of phase |
+| A delivery result is prose rather than a structured value-ledger row | An empty summary can look like no claim exists | State that the summary covers structured rows and direct the reader to other delivery notes |
+| Dashboard output is accidentally aimed at `success.md` | HTML replaces the client record | Refuse exports into `.fde/` or `.git/`, including aliases through symlinked directories |
+| A portfolio uses a custom output path | Refresh instruction creates a different report | Tell the user to repeat the original command with its original options, then reload |
+
+## Passing journeys
+
+- Create and bind Alpha and Beta independently; rebinding explicitly selects a client.
+- Stage Alpha's proposal, switch to Beta, and attempt apply: Alpha's notes do not enter Beta's records. Switching back exposes Alpha's own proposal.
+- Applying again after a completed apply refuses because no proposal remains.
+- Unknown signer and vague success fail the readiness check.
+- Handoff creates a portable Markdown file; exporting to the same destination again refuses to overwrite it.
+- Portfolio generation includes both clients without a model.
+- At 390px, opening Clients and switching to Beta selects Beta and collapses the client rail; copied prompts explicitly name Beta.
+- Denied clipboard access opens a selectable prompt dialog rather than losing the action.
+- At 1440px, reload preserves the selected client and saved theme. Both viewport checks had no page-width overflow.
+- Browser network inspection showed only local report reads; no external requests or console errors in the exercised journey.
+
+Search filters the client list and overview; it does not silently switch the open client. The current heading and copied prompt retain that client's identity.
+
+## Maintenance effort observed
+
+Using the CLI directly required one setup call, two calls plus review for a daily update, one dashboard regeneration, and one handoff export. Switching one shared workspace to another client requires a bind call; separate bound workspaces avoid that repeated step.
+
+These are observed command counts, not human time measurements. The agent may run those commands for the user. Free-form notes still need interpretation and review; the CLI does not understand arbitrary prose as a model would.
+
+## Deliberate limits
+
+- Re-submitting already-applied notes is a new update and may duplicate records. Identical wording can describe a new event, so the CLI does not silently discard it. Review before saving again.
+- Caught write errors and cooperating writer contention are tested. Power loss or killing the process between multi-file writes is not claimed to be atomic. Uncoordinated manual file edits are not transactional writes.
+- Large previews are excerpts. Review the saved proposal locally or split notes into smaller reviews before applying; do not interpret a truncated preview as full review.
+- A source string is not authenticated customer approval. Prose outside the structured ledger is not automatically classified.
+- The dashboard remains a read-only snapshot; it cannot observe later filesystem changes by itself.
+- These sessions used the repository CLI directly. They did not install every third-party host, call customer services, or re-certify local-model reasoning. Existing host and local-model limits remain in [verification](../docs/verification.md).
+
+## Reproduce
+
+Run `npm run check` for the full gate. Focused regressions live in `test/provenance.test.js`, `test/fieldbook-daily.test.js`, and `test/debrief-reliability.test.js`. Existing privacy, MCP, installer, concurrency, and context-budget regressions remain part of the full suite.
+
+For a manual browser check, generate two fictional clients in an isolated `FDEOPS_ENGAGEMENTS_ROOT`, run `dashboard --all --out <temporary-path>`, and exercise client selection, search/reset, denied clipboard access, theme persistence, and regeneration at desktop and mobile sizes.

--- a/evals/daily-use.md
+++ b/evals/daily-use.md
@@ -34,6 +34,12 @@ The quality bar is less work reconstructing context, clearer customer acceptance
 
 Search filters the client list and overview; it does not silently switch the open client. The current heading and copied prompt retain that client's identity.
 
+## Agent-assisted method check
+
+A separate session followed the actual `@fde` router and debrief reference, using the local CLI on a fictional engagement. The agent reviewed notes requesting CSV upload, an unapproved ERP request, a five-minute staging result with PR #42, and unknown production measurement and acceptance authority. It edited the proposed record, re-previewed it, simulated approval of accurate recording only, applied it, and exported/retrieved the result.
+
+The update kept requests separate from agreed scope, left authority unknown, and did not invent a production result or customer acceptance. Seven CLI calls covered setup, staging, re-preview, apply, export, and retrieval; one proposal edit and one simulated confirmation were needed. This is the current assistant following the method, not an end-to-end test of a different agent host or a real participant study.
+
 ## Maintenance effort observed
 
 Using the CLI directly required one setup call, two calls plus review for a daily update, one dashboard regeneration, and one handoff export. Switching one shared workspace to another client requires a bind call; separate bound workspaces avoid that repeated step.

--- a/mcp/fdeops-ingest/package.json
+++ b/mcp/fdeops-ingest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops-ingest-mcp",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "private": true,
   "description": "Thin stdio MCP sink for FDEOps ingest (stage → propose → apply). Zero runtime dependencies.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fdeops",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "description": "Client delivery tools for Forward Deployed Engineers. One @fde skill, local Markdown engagement records, and an offline dashboard for decisions, evidence, approvals, and next actions.",
   "bin": {
     "fdeops": "bin/install.js",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "fdeops",
-  "version": "3.27.0",
+  "version": "3.27.1",
   "description": "Forward deployed engineering skills for AI coding agents. One @fde skill for the client work around the code. You confirm; then it lands in .fde/ on your laptop.",
   "author": {
     "name": "Subash Natarajan",

--- a/test/debrief-reliability.test.js
+++ b/test/debrief-reliability.test.js
@@ -137,3 +137,28 @@ test('combined smart apply, dry-run and ingest previews remain bounded', t => {
   assert.match(result.stdout, /omitted/)
   assert.match(result.stdout, /ingest apply/)
 })
+
+for (const blocked of ['.debrief-propose', '.debrief-private', '.debrief-seal']) {
+  test(`failed ${blocked} cleanup rolls back records and leaves a retryable review`, t => {
+    const f = fixture(t)
+    fs.writeFileSync(f.notes, 'decision: CLEANUP_ONCE\n<private>KEEP_SEALED</private>\n')
+    assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+    const files = ['decisions.md', 'context.md', '.debrief-propose', '.debrief-private', '.debrief-seal']
+    const before = files.map(file => fs.readFileSync(path.join(f.eng, file), 'utf8'))
+    const head = () => spawnSync('git', ['rev-parse', 'HEAD'], { cwd: f.eng, encoding: 'utf8' }).stdout.trim()
+    const beforeHead = head()
+    const shim = path.join(f.dir, 'fail-cleanup.cjs')
+    fs.writeFileSync(shim, `const fs = require('fs'); const unlink = fs.unlinkSync; let failed = false;
+fs.unlinkSync = function(file) {
+  if (!failed && String(file).endsWith(${JSON.stringify('/' + blocked)})) { failed = true; throw Object.assign(new Error('simulated cleanup denial'), { code: 'EACCES' }); }
+  return unlink.call(fs, file);
+};`)
+    const result = spawnSync(process.execPath, ['--require', shim, path.resolve(__dirname, '../bin/fde.js'), 'debrief', '--apply'], { cwd: f.cwd, env: f.env, encoding: 'utf8' })
+    assert.equal(result.status, 1)
+    assert.deepEqual(files.map(file => fs.readFileSync(path.join(f.eng, file), 'utf8')), before)
+    assert.equal(head(), beforeHead, 'failed apply must not commit records')
+    assert.equal(f.run(['debrief', '--apply']).status, 0)
+    assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8').split('CLEANUP_ONCE').length - 1, 1)
+    for (const file of ['.debrief-propose', '.debrief-private', '.debrief-seal']) assert.equal(fs.existsSync(path.join(f.eng, file)), false)
+  })
+}

--- a/test/debrief-reliability.test.js
+++ b/test/debrief-reliability.test.js
@@ -1,0 +1,139 @@
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const os = require('node:os')
+const { spawn, spawnSync } = require('node:child_process')
+function fixture(t) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fde-debrief-retry-'))
+  t.after(() => fs.rmSync(dir, { recursive: true, force: true }))
+  const home = path.join(dir, 'home'), cwd = path.join(dir, 'workspace'); fs.mkdirSync(home); fs.mkdirSync(cwd)
+  const env = { ...process.env, HOME: home, USERPROFILE: home, FDEOPS_ENGAGEMENT: '', FDEOS_ENGAGEMENT: '', FDEOPS_ENGAGEMENTS_ROOT: path.join(dir, 'clients') }
+  const run = args => spawnSync(process.execPath, [path.resolve(__dirname, '../bin/fde.js'), ...args], { cwd, env, encoding: 'utf8' })
+  assert.equal(run(['resume', '--init', 'acme']).status, 0)
+  const eng = path.join(dir, 'clients/acme/.fde'), notes = path.join(cwd, 'notes.md')
+  return { dir, eng, notes, run, cwd, env }
+}
+test('a blocked debrief leaves every record unchanged and retry writes once', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, 'decision: KEEP_ONCE\nrisk: DELAYED_ACCESS\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+  const before = fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8')
+  fs.writeFileSync(path.join(f.eng, 'risks.md.lock'), 'other writer')
+  const failed = f.run(['debrief', '--apply'])
+  assert.equal(failed.status, 1)
+  assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8'), before)
+  assert.ok(fs.existsSync(path.join(f.eng, '.debrief-propose')))
+  fs.unlinkSync(path.join(f.eng, 'risks.md.lock'))
+  assert.equal(f.run(['debrief', '--apply']).status, 0)
+  assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8').split('KEEP_ONCE').length - 1, 1)
+})
+test('a different pending proposal requires explicit replacement and preserves private sidecars', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, 'decision: FIRST\n<private>KEEP_PRIVATE</private>\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+  const proposal = fs.readFileSync(path.join(f.eng, '.debrief-propose'), 'utf8')
+  fs.writeFileSync(f.notes, 'decision: SECOND\n')
+  const blocked = f.run(['debrief', '--smart', f.notes])
+  assert.equal(blocked.status, 1); assert.match(blocked.stderr, /pending proposal/)
+  assert.equal(fs.readFileSync(path.join(f.eng, '.debrief-propose'), 'utf8'), proposal)
+  assert.match(fs.readFileSync(path.join(f.eng, '.debrief-private'), 'utf8'), /KEEP_PRIVATE/)
+  assert.equal(f.run(['debrief', '--smart', f.notes, '--replace-proposal']).status, 0)
+  assert.equal(f.run(['debrief', '--apply']).status, 0)
+  assert.match(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8'), /SECOND/)
+})
+test('large smart proposals retain all notes on disk but cap terminal output', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, Array.from({length: 4000}, (_, i) => `decision: Weekly item ${i}`).join('\n'))
+  const result = f.run(['debrief', '--smart', f.notes])
+  assert.equal(result.status, 0)
+  assert.ok(Buffer.byteLength(result.stdout) <= 16384, Buffer.byteLength(result.stdout))
+  assert.match(result.stdout, /omitted|truncated/)
+  assert.match(result.stdout, /proposal saved/)
+  assert.match(result.stdout, /debrief --apply/)
+  assert.match(fs.readFileSync(path.join(f.eng, '.debrief-propose'), 'utf8'), /Weekly item 3999/)
+})
+
+test('a failed input read releases the proposal lock for the next attempt', t => {
+  const f = fixture(t)
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 1)
+  assert.equal(fs.existsSync(path.join(f.eng, '.debrief-propose.lock')), false)
+  fs.writeFileSync(f.notes, 'decision: RECOVERED_INPUT\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+})
+
+test('an ordinary mid-write error restores prior records and retry is safe', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, 'decision: ROLLBACK_ME\nrisk: WRITE_FAILS\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+  const before = fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8')
+  const shim = path.join(f.dir, 'fail-write.cjs')
+  fs.writeFileSync(shim, `const fs = require('fs'); const append = fs.appendFileSync; let failed = false;
+fs.appendFileSync = function(file, ...args) {
+  if (!failed && String(file).endsWith('/risks.md')) { failed = true; throw Object.assign(new Error('simulated disk full'), { code: 'ENOSPC' }); }
+  return append.call(fs, file, ...args);
+};`)
+  const result = spawnSync(process.execPath, ['--require', shim, path.resolve(__dirname, '../bin/fde.js'), 'debrief', '--apply'], {
+    cwd: f.dir, env: { ...process.env, HOME: path.join(f.dir, 'home'), FDEOPS_ENGAGEMENT: f.eng, FDEOPS_ENGAGEMENTS_ROOT: path.join(f.dir, 'clients') }, encoding: 'utf8',
+  })
+  assert.equal(result.status, 1); assert.match(result.stderr, /no record changes kept/)
+  assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8'), before)
+  assert.ok(fs.existsSync(path.join(f.eng, '.debrief-propose')))
+  assert.equal(f.run(['debrief', '--apply']).status, 0)
+  assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8').split('ROLLBACK_ME').length - 1, 1)
+})
+
+test('two agents applying the same proposal write it only once', async t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, 'decision: CONCURRENT_ONCE\nrisk: SHARED_RISK\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+  const apply = () => new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [path.resolve(__dirname, '../bin/fde.js'), 'debrief', '--apply'], { cwd: f.cwd, env: f.env })
+    let stderr = ''; child.stderr.on('data', b => { stderr += b }); child.stdout.resume()
+    child.on('error', reject); child.on('close', status => resolve({ status, stderr }))
+  })
+  const results = await Promise.all([apply(), apply()])
+  assert.deepEqual(results.map(r => r.status).sort(), [0, 1])
+  assert.match(results.find(r => r.status === 1).stderr, /nothing to apply/)
+  assert.equal(fs.readFileSync(path.join(f.eng, 'decisions.md'), 'utf8').split('CONCURRENT_ONCE').length - 1, 1)
+})
+
+test('failed explicit replacement preserves the old proposal and its sealed private note', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, 'decision: FIRST_REVIEW\n<private>FIRST_SECRET</private>\n')
+  assert.equal(f.run(['debrief', '--smart', f.notes]).status, 0)
+  const files = ['.debrief-propose', '.debrief-private', '.debrief-seal']
+  const before = files.map(file => fs.readFileSync(path.join(f.eng, file), 'utf8'))
+  fs.writeFileSync(f.notes, 'decision: NEW_REVIEW\n<private>DIFFERENT_SECRET</private>\n')
+  const shim = path.join(f.dir, 'fail-proposal.cjs')
+  fs.writeFileSync(shim, `const fs = require('fs'); const rename = fs.renameSync; let failed = false;
+fs.renameSync = function(from, to) {
+  if (!failed && String(to).endsWith('/.debrief-seal')) { failed = true; throw Object.assign(new Error('simulated disk full'), { code: 'ENOSPC' }); }
+  return rename.call(fs, from, to);
+};`)
+  const result = spawnSync(process.execPath, ['--require', shim, path.resolve(__dirname, '../bin/fde.js'), 'debrief', '--smart', f.notes, '--replace-proposal'], { cwd: f.cwd, env: f.env, encoding: 'utf8' })
+  assert.equal(result.status, 1)
+  assert.deepEqual(files.map(file => fs.readFileSync(path.join(f.eng, file), 'utf8')), before)
+  assert.equal(f.run(['debrief', '--apply']).status, 0)
+  assert.match(fs.readFileSync(path.join(f.eng, 'context.md'), 'utf8'), /FIRST_SECRET/)
+  assert.doesNotMatch(fs.readFileSync(path.join(f.eng, 'context.md'), 'utf8'), /DIFFERENT_SECRET/)
+})
+
+test('combined smart apply, dry-run and ingest previews remain bounded', t => {
+  const f = fixture(t)
+  fs.writeFileSync(f.notes, Array.from({ length: 2500 }, (_, i) => `Background note ${i}: someone discussed the system.`).join('\n'))
+  for (const args of [['debrief', '--smart', f.notes, '--apply'], ['debrief', '--dry-run', f.notes]]) {
+    const result = f.run(args)
+    assert.equal(result.status, 0, result.stderr)
+    assert.ok(Buffer.byteLength(result.stdout + result.stderr) <= 16384)
+    assert.match(result.stdout, /omitted/)
+  }
+  assert.equal(f.run(['ingest', 'stage', f.notes, '--source', 'manual', '--title', 'large-notes']).status, 0)
+  const inbox = path.join(path.dirname(f.eng), '.inbox')
+  const id = fs.readdirSync(inbox).find(file => file.endsWith('.md'))
+  const result = f.run(['ingest', 'propose', id])
+  assert.equal(result.status, 0, result.stderr)
+  assert.ok(Buffer.byteLength(result.stdout + result.stderr) <= 16384)
+  assert.match(result.stdout, /omitted/)
+  assert.match(result.stdout, /ingest apply/)
+})

--- a/test/fieldbook-daily.test.js
+++ b/test/fieldbook-daily.test.js
@@ -30,6 +30,25 @@ function engagementPath(sandbox, slug) {
   return path.join(sandbox.home, 'fde-engagements', slug, '.fde')
 }
 
+test('dashboard exports cannot replace client records or write through a record directory alias', t => {
+  const sandbox = makeSandbox('dashboard-record-destination')
+  t.after(() => fs.rmSync(sandbox.dir, { recursive: true, force: true }))
+  assert.equal(runFde(sandbox, ['resume', '--init', 'acme']).status, 0)
+  const eng = engagementPath(sandbox, 'acme')
+  const record = path.join(eng, 'success.md')
+  const before = fs.readFileSync(record, 'utf8')
+  const direct = runFde(sandbox, ['dashboard', '--out', record])
+  assert.notEqual(direct.status, 0)
+  assert.equal(fs.readFileSync(record, 'utf8'), before)
+  const alias = path.join(sandbox.dir, 'records-alias')
+  fs.symlinkSync(eng, alias, 'dir')
+  assert.notEqual(runFde(sandbox, ['dashboard', '--out', path.join(alias, 'report.html')]).status, 0)
+  assert.equal(fs.existsSync(path.join(eng, 'report.html')), false)
+  const report = path.join(sandbox.dir, 'portfolio.html')
+  assert.equal(runFde(sandbox, ['dashboard', '--all', '--out', report]).status, 0)
+  assert.equal(runFde(sandbox, ['dashboard', '--all', '--out', report]).status, 0, 'refreshing an ordinary report remains supported')
+})
+
 test('fieldbook people rows use table names, not the/Friday from signal prose', () => {
   const sandbox = makeSandbox('people-garvey')
   assert.equal(runFde(sandbox, ['resume', '--init', 'Garvey Payments']).status, 0)

--- a/test/provenance.test.js
+++ b/test/provenance.test.js
@@ -84,6 +84,20 @@ test('doctor --ready checks success before phase transition without writing', t 
   assert.match(r.stdout, /binary acceptance check/); assert.match(r.stdout, /named customer-side signer/)
   assert.equal(fs.readFileSync(path.join(f.eng, 'context.md'), 'utf8'), before)
 })
+test('early handoff exposes missing acceptance criteria and names the limits of its ledger summary', t => {
+  const f = fixture(t)
+  fs.writeFileSync(path.join(f.eng, 'context.md'), '# Context\n**Phase:** discover\n')
+  fs.writeFileSync(path.join(f.eng, 'success.md'), '# Success\n**Done when:** improve things\n**Stakeholder who signs off:** unconfirmed\n')
+  fs.writeFileSync(path.join(f.eng, 'delivery.md'), '# Delivery\n## Running value\nStaging replay took five minutes; production has not been measured.\n')
+  for (const command of ['defend', 'handoff']) {
+    const result = f.run([command])
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /binary acceptance check/)
+    assert.match(result.stdout, /named customer-side signer/)
+    assert.match(result.stdout, /Only structured value-ledger rows are summarized/)
+    assert.match(result.stdout, /review other notes in delivery\.md/)
+  }
+})
 test('handoff retains long-form decision sources and orders recent decisions by date', t => {
   const f = fixture(t)
   fs.writeFileSync(path.join(f.eng, 'decisions.md'), '# Decisions\n### [2026-09-10] Keep the connector\n- Rationale: preserve the tested path\n- Source: [source: meeting 2026-09-09]\n<private>PRIVATE_LONGFORM</private>\n## 2026-09-08 - Reject the rewrite\n- Source: PR #42\n- [2026-01-01] Earlier unsupported idea\n')

--- a/test/review-path.test.js
+++ b/test/review-path.test.js
@@ -45,7 +45,7 @@ test('tentative signer question stays a question and creates no authority', t =>
   const f = fixture(t)
   const proposed = f.run(['debrief', '--smart'], 'Maybe Priya signs off? We need to ask her.\n')
   assert.equal(proposed.status, 0)
-  assert.match(proposed.stdout, /named signer \(authority, not approval\): not stated/)
+  assert.match(proposed.stdout, /named signer \(authority, not approval\): not detected - review the notes/)
   assert.doesNotMatch(fs.readFileSync(path.join(f.eng, '.debrief-propose'), 'utf8'), /^signer:/m)
 })
 


### PR DESCRIPTION
Daily-use simulations found that a debrief could write one record before hitting a locked file, and an ignored proposal-cleanup error could make a retry apply the same update twice. A second meeting could also silently replace a pending review, while large notes produced more than 750 KB of review output.

This patch preserves pending reviews, requires explicit replacement, locks the affected records before applying, and restores records plus the proposal after caught write or cleanup failures. It bounds debrief/ingest previews while retaining the complete proposal, and describes missed phrase matches as “not detected.”

It also refuses dashboard exports into record folders, corrects portfolio refresh guidance, and surfaces missing acceptance criteria and signer in early handoffs. The README explains the difference between agent interpretation and the CLI's phrase recognition. No new dependencies or hosted components.

Validation: full `npm run check`; regression coverage for lock contention, concurrent apply, write/cleanup failure, private proposal replacement, large previews, handoff gaps, and record-directory exports. Independent review replayed the cleanup failure successfully. Real Chromium checks covered desktop/mobile client switching, denied clipboard access, themes, and report regeneration. Long-history fixture: 1,120,010 bytes to 16,384-byte resume; all three targeted records retrieved.

See `evals/daily-use.md` for the two independent simulations and agent-assisted fictional workflow. These do not establish human time savings, repeat adoption, or all-host/local-model reliability. Power-loss atomicity and automatic deduplication of separate reviewed imports are not claimed. Patch version: 3.27.1.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/suboss87/fdeops/pull/97" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-devin-review-dark.svg?v=3">
    <img src="https://static.devin.ai/assets/gh-devin-review-light.svg?v=3" alt="Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->